### PR TITLE
Update move_data.js

### DIFF
--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -1575,6 +1575,11 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         category: 'Physical',
         makesContact: true,
         hasRecoil: true
+    },
+    'Venoshock': {
+        bp: 65,
+        type: 'Poison',
+        category: 'Special'
     }
 });
 


### PR DESCRIPTION
Venoshock does not appear as a move on the calculator. Besides this change it has to hit double when foe is poisoned