### PR TITLE
Fix Venoshock 4x effect on poison

### DIFF
--- a/js/damage.js
+++ b/js/damage.js
@@ -244,10 +244,6 @@ function getDamageResult(attacker, defender, move, field) {
         case "Nature Power":
             basePower = (field.terrain === "Electric" || field.terrain === "Grassy") ? 90 : (field.terrain === "Misty") ? 95 : 80;
             break;
-        case "Venoshock":
-            basePower = move.bp * (defender.status == "Poisoned" ? 2 : 1);
-            description.moveBP = basePower;
-            break;
         default:
             basePower = move.bp;
     }


### PR DESCRIPTION
Currently Venoshock calculates 4x on "Poisoned" status due to the bonus damage calculation ocurring twice, once in the lines removed from the commit and the second time in [this check](https://github.com/Zarel/honko-damagecalc/blob/master/js/damage.js#L308).

Also the removed lines had the issue of ignoring "Badly Poisoned" status.