### PR TITLE
Ensure that all event listeners are run before calculations

### DIFF
--- a/js/calc_ab.js
+++ b/js/calc_ab.js
@@ -154,6 +154,8 @@ $(".notation").change(function () {
 
 $(document).ready(function() {
     $(".terrain-trigger").bind("change keyup", getTerrainEffects);
-    $(".calc-trigger").bind("change keyup", calculate);
+    $(".calc-trigger").bind("change keyup", function() {
+        setTimeout(calculate, 0);
+    });
     calculate();
 });


### PR DESCRIPTION
By scheduling calculations to the next turn of the event loop,
this fixes the issue by which switching Gen caused some
damage ranges to display as NaN - NaN%