### PR TITLE
Clear terrain when gen changed

### DIFF
--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -614,6 +614,7 @@ function clearField() {
     $("#helpingHandR").prop("checked", false);
     $("#friendGuardL").prop("checked", false);
     $("#friendGuardR").prop("checked", false);
+    $("input:checkbox[name='terrain']").prop("checked", false);
 }
 
 function getSetOptions() {


### PR DESCRIPTION
Now if I check Grassy Terrain in SM/XY and switch to a previous gen like DPP, Grassy Terrain recovery is still calculated.
I think the best way to prevent such a situation is to clear terrain when gen was changed, just like what we do with weather.