### PR TITLE
Improve z-move input

### DIFF
--- a/ap_calc.css
+++ b/ap_calc.css
@@ -324,20 +324,29 @@ select.toxic-counter {
     font-size: 0.9em;
 }
 .move-selector {
-    width: 9.5em;
+    width: 8.5em;
 }
 .poke-info input.move-bp {
     width: 2em;
+}
+.move-type {
+    width: 5.5em;
 }
 .move-cat {
     width: 5.7em;
 }
 .move-hits {
-    width: 5em;
+    width: 4.5em;
 }
 .poke-info .crit-btn {
     font-size: 0.8em;
     width: 2.5em;
+    height: 1em;
+    padding: 3px 3px;
+}
+.poke-info .z-btn {
+    font-size: 0.8em;
+    width: 1.5em;
     height: 1em;
     padding: 3px 3px;
 }

--- a/calc_bc.html
+++ b/calc_bc.html
@@ -413,6 +413,8 @@
                         </select>
                         <input class="move-crit btn-input" type="checkbox" id="critL1" />
                         <label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
+                        <input class="move-z btn-input" type="checkbox" id="zL1"/>
+                        <label class="btn z-btn gen-specific g7" for="zL1" title="Make this attack a Z-move?">Z</label>
                         <select class="move-hits hide">
                             <option value="2">2 hits</option>
                             <option value="3">3 hits</option>
@@ -430,6 +432,8 @@
                         </select>
                         <input class="move-crit btn-input" type="checkbox" id="critL2" />
                         <label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
+                        <input class="move-z btn-input" type="checkbox" id="zL2"/>
+                        <label class="btn z-btn gen-specific g7" for="zL2" title="Make this attack a Z-move?">Z</label>
                         <select class="move-hits hide">
                             <option value="2">2 hits</option>
                             <option value="3">3 hits</option>
@@ -447,6 +451,8 @@
                         </select>
                         <input class="move-crit btn-input" type="checkbox" id="critL3" />
                         <label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
+                        <input class="move-z btn-input" type="checkbox" id="zL3"/>
+                        <label class="btn z-btn gen-specific g7" for="zL3" title="Make this attack a Z-move?">Z</label>
                         <select class="move-hits hide">
                             <option value="2">2 hits</option>
                             <option value="3">3 hits</option>
@@ -464,6 +470,8 @@
                         </select>
                         <input class="move-crit btn-input" type="checkbox" id="critL4" />
                         <label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
+                        <input class="move-z btn-input" type="checkbox" id="zL4"/>
+                        <label class="btn z-btn gen-specific g7" for="zL4" title="Make this attack a Z-move?">Z</label>
                         <select class="move-hits hide">
                             <option value="2">2 hits</option>
                             <option value="3">3 hits</option>

--- a/index.html
+++ b/index.html
@@ -451,6 +451,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL1" />
                 <label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zL1"/>
+                <label class="btn z-btn gen-specific g7" for="zL1" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -468,6 +470,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL2" />
                 <label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zL2"/>
+                <label class="btn z-btn gen-specific g7" for="zL2" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -485,6 +489,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL3" />
                 <label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zL3"/>
+                <label class="btn z-btn gen-specific g7" for="zL3" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -502,6 +508,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL4" />
                 <label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zL4"/>
+                <label class="btn z-btn gen-specific g7" for="zL4" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -1012,6 +1020,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR1" />
                 <label class="btn crit-btn" for="critR1" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zR1"/>
+                <label class="btn z-btn gen-specific g7" for="zR1" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -1029,6 +1039,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR2" />
                 <label class="btn crit-btn" for="critR2" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zR2"/>
+                <label class="btn z-btn gen-specific g7" for="zR2" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -1046,6 +1058,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR3" />
                 <label class="btn crit-btn" for="critR3" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zR3"/>
+                <label class="btn z-btn gen-specific g7" for="zR3" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>
@@ -1063,6 +1077,8 @@
                 </select>
                 <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR4" />
                 <label class="btn crit-btn" for="critR4" title="Force this attack to be a critical hit?">Crit</label>
+                <input class="move-z calc-trigger btn-input" type="checkbox" id="zR4"/>
+                <label class="btn z-btn gen-specific g7" for="zR4" title="Make this attack a Z-move?">Z</label>
                 <select class="move-hits calc-trigger hide">
                     <option value="2">2 hits</option>
                     <option value="3">3 hits</option>

--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -445,6 +445,7 @@ function getMoveDetails(moveInfo, item) {
             bp: moves[zMoveName].bp === 1 ? defaultDetails.zp : moves[zMoveName].bp,
             category: defaultDetails.category,
             isCrit: moveInfo.find(".move-crit").prop("checked"),
+            isZ: true,
             hits: 1
         });
     } else {

--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -260,6 +260,7 @@ $(".move-selector").change(function() {
     } else {
         moveGroupObj.children(".move-hits").hide();
     }
+    moveGroupObj.children(".move-z").prop("checked", false);
 });
 
 // auto-update set details on select
@@ -422,26 +423,54 @@ function Pokemon(pokeInfo) {
         this.status = pokeInfo.find(".status").val();
         this.toxicCounter = this.status === 'Badly Poisoned' ? ~~pokeInfo.find(".toxic-counter").val() : 0;
         this.moves = [
-            getMoveDetails(pokeInfo.find(".move1")),
-            getMoveDetails(pokeInfo.find(".move2")),
-            getMoveDetails(pokeInfo.find(".move3")),
-            getMoveDetails(pokeInfo.find(".move4"))
+            getMoveDetails(pokeInfo.find(".move1"), this.item),
+            getMoveDetails(pokeInfo.find(".move2"), this.item),
+            getMoveDetails(pokeInfo.find(".move3"), this.item),
+            getMoveDetails(pokeInfo.find(".move4"), this.item)
         ];
         this.weight = +pokeInfo.find(".weight").val();
     }
 }
 
-function getMoveDetails(moveInfo) {
+function getMoveDetails(moveInfo, item) {
     var moveName = moveInfo.find("select.move-selector").val();
     var defaultDetails = moves[moveName];
-    return $.extend({}, defaultDetails, {
-        name: moveName,
-        bp: ~~moveInfo.find(".move-bp").val(),
-        type: moveInfo.find(".move-type").val(),
-        category: moveInfo.find(".move-cat").val(),
-        isCrit: moveInfo.find(".move-crit").prop("checked"),
-        hits: defaultDetails.isMultiHit ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isTwoHit ? 2 : 1
-    });
+    var isZMove = gen >= 7 && moveInfo.find("input.move-z").prop("checked");
+
+    // If z-move is checked but there isn't a corresponding z-move, use the original move
+    if (isZMove && defaultDetails.hasOwnProperty("zp")) {
+        var zMoveName = getZMoveName(moveName, defaultDetails.type, item);
+        return $.extend({}, moves[zMoveName], {
+            name: zMoveName,
+            bp: moves[zMoveName].bp === 1 ? defaultDetails.zp : moves[zMoveName].bp,
+            category: defaultDetails.category,
+            isCrit: moveInfo.find(".move-crit").prop("checked"),
+            hits: 1
+        });
+    } else {
+        return $.extend({}, defaultDetails, {
+            name: moveName,
+            bp: ~~moveInfo.find(".move-bp").val(),
+            type: moveInfo.find(".move-type").val(),
+            category: moveInfo.find(".move-cat").val(),
+            isCrit: moveInfo.find(".move-crit").prop("checked"),
+            hits: defaultDetails.isMultiHit ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isTwoHit ? 2 : 1
+        });
+    }
+}
+
+function getZMoveName(moveName, moveType, item) {
+    return moveName.indexOf("Hidden Power") !== -1 ? "Breakneck Blitz" // Hidden Power will become Breakneck Blitz
+            : moveName === "Giga Impact" && item === "Snorlium Z" ? "Pulverizing Pancake"
+            : moveName === "Thunderbolt" && item === "Aloraichium Z" ? "Stoked Sparksurfer"
+            : moveName === "Volt Tackle" && item === "Pikanium Z" ? "Catastropika"
+            : moveName === "Thunderbolt" && item === "Pikashunium Z" ? "10,000,000 Volt Thunderbolt"
+            : moveName === "Psychic" && item === "Mewnium Z" ? "Genesis Supernova"
+            : moveName === "Spirit Shackle" && item === "Decidium Z" ? "Sinister Arrow Raid"
+            : moveName === "Darkest Lariat" && item === "Incinium Z" ? "Malicious Moonsault"
+            : moveName === "Sparkling Aria" && item === "Primarium Z" ? "Oceanic Operetta"
+            : moveName === "Spectral Thief" && item === "Marshadium Z" ? "Soul-Stealing 7-Star Strike"
+            : ZMOVES_TYPING[moveType];
 }
 
 function Field() {

--- a/js/damage.js
+++ b/js/damage.js
@@ -335,6 +335,11 @@ function getDamageResult(attacker, defender, move, field) {
             (defender.name.indexOf("Genesect") !== -1 && defender.item.indexOf("Drive") !== -1))) {
         bpMods.push(0x1800);
         description.moveBP = move.bp * 1.5;
+    } else if (["Breakneck Blitz","Bloom Doom","Inferno Overdrive","Hydro Vortex","Gigavolt Havoc","Subzero Slammer","Supersonic Skystrike",
+            "Savage Spin-Out","Acid Downpour","Tectonic Rage","Continental Crush","All-Out Pummeling","Shattered Psyche","Never-Ending Nightmare",
+            "Devastating Drake","Black Hole Eclipse","Corkscrew Crash","Twinkle Tackle"].indexOf(move.name) !== -1) {
+        // show z-move power in description
+        description.moveBP = move.bp;
     }
     
     if (field.isHelpingHand) {

--- a/js/damage.js
+++ b/js/damage.js
@@ -98,27 +98,35 @@ function getDamageResult(attacker, defender, move, field) {
     } else if (move.name === "Nature Power") {
         move.type = field.terrain === "Electric" ? "Electric" : field.terrain === "Grassy" ? "Grass" : field.terrain === "Misty" ? "Fairy" : field.terrain === "Psychic" ? "Psychic" : "Normal";
     }
-    
-    var isAerilate = attacker.ability === "Aerilate" && move.type === "Normal";
-    var isPixilate = attacker.ability === "Pixilate" && move.type === "Normal";
-    var isRefrigerate = attacker.ability === "Refrigerate" && move.type === "Normal";
-    var isGalvanize = attacker.ability === "Galvanize" && move.type === "Normal";
-    var isLiquidVoice = attacker.ability === "Liquid Voice" && move.isSound;
-    if (isAerilate) {
-        move.type = "Flying";
-    } else if (isGalvanize) {
-        move.type = "Electric";
-    } else if (isLiquidVoice) {
-        move.type = "Water";
-    } else if (isPixilate) {
-        move.type = "Fairy";
-    } else if (isRefrigerate) {
-        move.type = "Ice";
-    } else if (attacker.ability === "Normalize") {
-        move.type = "Normal";
-        description.attackerAbility = attacker.ability;
+
+    var isAerilate = false;
+    var isPixilate = false;
+    var isRefrigerate = false;
+    var isGalvanize = false;
+    var isLiquidVoice = false;
+
+    if (!move.isZ) {
+        isAerilate = attacker.ability === "Aerilate" && move.type === "Normal";
+        isPixilate = attacker.ability === "Pixilate" && move.type === "Normal";
+        isRefrigerate = attacker.ability === "Refrigerate" && move.type === "Normal";
+        isGalvanize = attacker.ability === "Galvanize" && move.type === "Normal";
+        isLiquidVoice = attacker.ability === "Liquid Voice" && move.isSound;
+        if (isAerilate) {
+            move.type = "Flying";
+        } else if (isGalvanize) {
+            move.type = "Electric";
+        } else if (isLiquidVoice) {
+            move.type = "Water";
+        } else if (isPixilate) {
+            move.type = "Fairy";
+        } else if (isRefrigerate) {
+            move.type = "Ice";
+        } else if (attacker.ability === "Normalize") {
+            move.type = "Normal";
+            description.attackerAbility = attacker.ability;
+        }
     }
-    
+
     var typeEffect1 = getMoveEffectiveness(move, defender.type1, attacker.ability === "Scrappy" || field.isForesight, field.isGravity);
     var typeEffect2 = defender.type2 ? getMoveEffectiveness(move, defender.type2, attacker.ability === "Scrappy" || field.isForesight, field.isGravity) : 1;
     var typeEffectiveness = typeEffect1 * typeEffect2;

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -2487,6 +2487,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Rock',
         category: 'Physical'
     },
+    'Acid Spray': { zp: 100 },
     'Accelerock': {
         bp: 40,
         type: 'Rock',
@@ -2495,9 +2496,11 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         hasPriority: true,
         zp: 100
     },
+    'Acrobatics': { zp: 100 },
     'Aerial Ace': { zp: 120 },
     'Aeroblast': { zp: 180 },
     'Air Cutter': { zp: 120 },
+    'Air Slash': { zp: 140 },
     'All-Out Pummeling': {
         bp: 1,
         type: 'Fighting',
@@ -2511,8 +2514,15 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         zp: 160
     },
     'Ancient Power': { zp: 120 },
+    'Aqua Jet': { zp: 100 },
+    'Aqua Tail': { zp: 175 },
     'Arm Thrust': { zp: 100 },
+    'Assurance': { zp: 120 },
+    'Astonish': { zp: 100 },
+    'Attack Order': { zp: 175 },
+    'Aura Sphere': { zp: 160 },
     'Aurora Beam': { zp: 120 },
+    'Avalanche': { zp: 120 },
     'Beak Blast': {
         bp: 100,
         type: 'Flying',
@@ -2525,6 +2535,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Dark',
         category: 'Physical'
     },
+    'Blast Burn': { zp: 200 },
     'Blaze Kick': { zp: 160 },
     'Blizzard': { zp: 185 },
     'Bloom Doom': {
@@ -2532,13 +2543,21 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Grass',
         category: 'Physical'
     },
+    'Blue Flare': { zp: 195 },
+    'Brave Bird': { zp: 190 },
     'Breakneck Blitz': {
         bp: 1,
         type: 'Normal',
         category: 'Physical'
     },
+    'Brine': { zp: 120 },
     'Body Slam': { zp: 160 },
+    'Bolt Strike': { zp: 195 },
+    'Bone Club': { zp: 120 },
+    'Bone Rush': { zp: 140 },
     'Bonemerang': { zp: 100 },
+    'Boomburst': { zp: 200 },
+    'Bounce': { zp: 160 },
     'Brick Break': { zp: 140 },
     'Brutal Swing': {
         bp: 60,
@@ -2548,6 +2567,10 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         isSpread: true,
         zp: 120
     },
+    'Bug Bite': { zp: 120 },
+    'Bug Buzz': { zp: 175 },
+    'Bulldoze': { zp: 120 },
+    'Bullet Punch': { zp: 100 },
     'Bullet Seed': { zp: 140 },
     'Burn Up': {
         bp: 130,
@@ -2560,6 +2583,10 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Electric',
         category: 'Physical'
     },
+    'Charge Beam': { zp: 100 },
+    'Chatter': { zp: 120 },
+    'Chip Away': { zp: 140 },
+    'Circle Throw': { zp: 120 },
     'Clanging Scales': {
         bp: 110,
         type: 'Dragon',
@@ -2568,6 +2595,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         isSpread: true,
         zp: 185
     },
+    'Clear Smog': { zp: 100 },
+    'Close Combat': { zp: 190 },
     'Continental Crush': {
         bp: 1,
         type: 'Rock',
@@ -2585,9 +2614,13 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Steel',
         category: 'Physical'
     },
+    'Covet': { zp: 120 },
     'Crabhammer': { zp: 180 },
     'Cross Chop': { zp: 180 },
+    'Cross Poison': { zp: 140 },
     'Crunch': { zp: 160 },
+    'Crush Claw': { zp: 140 },
+    'Dark Pulse': { zp: 160 },
     'Darkest Lariat': {
         bp: 85,
         type: 'Dark',
@@ -2595,6 +2628,10 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         makesContact: true,
         zp: 160
     },
+    'Dazzling Gleam': { zp: 160 },
+    'Diamond Storm': { zp: 180 },
+    'Discharge': { zp: 160 },
+    'Dive': { zp: 160 },
     'Dragon Hammer': {
         bp: 90,
         type: 'Dragon',
@@ -2608,19 +2645,38 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Ghost',
         category: 'Physical'
     },
+    'Doom Desire': { zp: 200 },
     'Double-Edge': { zp: 190 },
+    'Double Hit': { zp: 140 },
     'Double Kick': { zp: 100 },
+    'Draco Meteor': { zp: 195 },
+    'Dragon Ascent': { zp: 190 },
+    'Dragon Claw': { zp: 160 },
+    'Dragon Pulse': { zp: 160 },
+    'Dragon Rush': { zp: 180 },
+    'Dragon Tail': { zp: 120 },
+    'Drain Punch': { zp: 140 },
+    'Drill Run': { zp: 160 },
+    'Dual Chop': { zp: 100 },
     'Dynamic Punch': { zp: 180 },
+    'Earth Power': { zp: 175 },
     'Earthquake': { zp: 180 },
+    'Electro Ball': { zp: 160 },
+    'Electroweb': { zp: 100 },
     'Endeavor': { zp: 160 },
+    'Energy Ball': { zp: 175 },
     'Eruption': { zp: 200 },
     'Explosion': { zp: 200 },
     'Extrasensory': { zp: 160 },
     'Extreme Speed': { zp: 160 },
     'Fake Out': { zp: 100 },
     'Facade': { zp: 140 },
+    'Feint': { zp: 100 },
     'Feint Attack': { zp: 120 },
+    'Fiery Dance': { zp: 160 },
+    'Final Gambit': { zp: 180 },
     'Fire Blast': { zp: 185 },
+    'Fire Fang': { zp: 120 },
     'Fire Lash': {
         bp: 80,
         type: 'Fire',
@@ -2640,7 +2696,11 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Flail': { zp: 160 },
     'Flamethrower': { zp: 175 },
+    'Flame Burst': { zp: 140 },
+    'Flame Charge': { zp: 100 },
     'Flame Wheel': { zp: 120 },
+    'Flare Blitz': { zp: 190 },
+    'Flash Cannon': { zp: 160 },
     'Fleur Cannon': {
         bp: 130,
         type: 'Fairy',
@@ -2648,22 +2708,62 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         hasSecondaryEffect: true,
         zp: 195
     },
-    'Flying Press': { bp: 100 },
+    'Fling': { zp: 100 },
+    'Fly': { zp: 175 },
+    'Flying Press': { bp: 100, zp: 170 },
+    'Focus Blast': { zp: 190 },
     'Focus Punch': { zp: 200 },
+    'Force Palm': { zp: 120 },
+    'Foul Play': { zp: 175 },
+    'Freeze Shock': { zp: 200 },
+    'Freeze-Dry': { zp: 140 },
+    'Frenzy Plant': { zp: 200 },
+    'Frost Breath': { zp: 120 },
     'Frustration': { zp: 160 },
+    'Fury Swipes': { zp: 100 },
+    'Fusion Bolt': { zp: 180 },
+    'Fusion Flare': { zp: 180 },
+    'Future Sight': { zp: 190 },
+    'Gear Grind': { zp: 180 },
     'Genesis Supernova': {
         bp: 185,
         type: 'Psychic',
         category: 'Special'
     },
     'Giga Drain': { zp: 140 },
+    'Giga Impact': { zp: 200 },
     'Gigavolt Havoc': {
         bp: 1,
         type: 'Electric',
         category: 'Physical'
     },
+    'Glaciate': { zp: 120 },
+    'Grass Knot': { zp: 160 },
+    'Gunk Shot': { zp: 190 },
+    'Gyro Ball': { zp: 160 },
+    'Hammer Arm': { zp: 180 },
     'Headbutt': { zp: 140 },
+    'Head Charge': { zp: 190 },
+    'Head Smash': { zp: 200 },
     'Heat Wave': { zp: 175 },
+    'Heavy Slam': { zp: 160 },
+    'Hex': { zp: 160 },
+    'Hidden Power Bug': { zp: 120 },
+    'Hidden Power Dark': { zp: 120 },
+    'Hidden Power Dragon': { zp: 120 },
+    'Hidden Power Electric': { zp: 120 },
+    'Hidden Power Fighting': { zp: 120 },
+    'Hidden Power Fire': { zp: 120 },
+    'Hidden Power Flying': { zp: 120 },
+    'Hidden Power Ghost': { zp: 120 },
+    'Hidden Power Grass': { zp: 120 },
+    'Hidden Power Ground': { zp: 120 },
+    'Hidden Power Ice': { zp: 120 },
+    'Hidden Power Poison': { zp: 120 },
+    'Hidden Power Psychic': { zp: 120 },
+    'Hidden Power Rock': { zp: 120 },
+    'Hidden Power Steel': { zp: 120 },
+    'Hidden Power Water': { zp: 120 },
     'High Horsepower': {
         bp: 95,
         type: 'Ground',
@@ -2672,6 +2772,9 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         zp: 175
     },
     'High Jump Kick': { zp: 195 },
+    'Horn Leech': { zp: 140 },
+    'Hurricane': { zp: 185 },
+    'Hydro Cannon': { zp: 200 },
     'Hydro Pump': { zp: 185 },
     'Hydro Vortex': {
         bp: 1,
@@ -2680,7 +2783,11 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Hyper Beam': { zp: 200 },
     'Hyper Voice': { zp: 175 },
+    'Hyperspace Fury': { zp: 180 },
+    'Hyperspace Hole': { zp: 160 },
     'Ice Beam': { zp: 175 },
+    'Ice Burn': { zp: 200 },
+    'Ice Fang': { zp: 120 },
     'Ice Hammer': {
         bp: 100,
         type: 'Ice',
@@ -2690,21 +2797,36 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         zp: 180
     },
     'Ice Punch': { zp: 140 },
+    'Ice Shard': { zp: 100 },
+    'Icicle Crash': { zp: 160 },
+    'Icicle Spear': { zp: 140 },
     'Icy Wind': { zp: 100 },
+    'Incinerate': { zp: 120 },
+    'Inferno': { zp: 180 },
     'Inferno Overdrive': {
         bp: 1,
         type: 'Fire',
         category: 'Physical'
     },
+    'Iron Head': { zp: 160 },
     'Iron Tail': { zp: 180 },
+    'Judgment': { zp: 180 },
     'Jump Kick': { zp: 180 },
     'Knock Off': { zp: 120 },
+    'Land\'s Wrath': { zp: 185 },
+    'Last Resort': { zp: 200 },
+    'Lava Plume': { zp: 160 },
     'Leafage': {
         bp: 40,
         type: 'Grass',
-        category: 'Physical'
+        category: 'Physical',
+        zp: 100
     },
+    'Leaf Blade': { zp: 175 },
+    'Leaf Storm': { zp: 195 },
+    'Leaf Tornado': { zp: 120 },
     'Leech Life': { bp: 80, zp: 160 },
+    'Light of Ruin': { zp: 200 },
     'Liquidation': {
         bp: 85,
         type: 'Water',
@@ -2714,6 +2836,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         zp: 160
     },
     'Low Kick': { zp: 160 },
+    'Low Sweep': { zp: 120 },
     'Lunge': {
         bp: 80,
         type: 'Bug',
@@ -2724,6 +2847,9 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Luster Purge': { zp: 140 },
     'Mach Punch': { zp: 100 },
+    'Magical Leaf': { zp: 120 },
+    'Magma Storm': { zp: 180 },
+    'Magnet Bomb': { zp: 120 },
     'Malicious Moonsault': {
         bp: 180,
         type: 'Dark',
@@ -2732,6 +2858,9 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Megahorn': { zp: 190 },
     'Meteor Mash': { zp: 175 },
+    'Mirror Shot': { zp: 120 },
+    'Mist Ball': { zp: 140 },
+    'Moonblast': { zp: 175 },
     'Moongeist Beam': {
         bp: 100,
         type: 'Ghost',
@@ -2739,6 +2868,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         zp: 180
     },
     'Muddy Water': { zp: 175 },
+    'Mud Bomb': { zp: 120 },
+    'Mud Shot': { zp: 100 },
     'Multi-Attack': {
         bp: 90,
         type: 'Normal',
@@ -2746,22 +2877,36 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         makesContact: true,
         zp: 185
     },
+    'Natural Gift': { zp: 160 },
+    'Needle Arm': { zp: 120 },
     'Never-Ending Nightmare': {
         bp: 1,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Night Daze': { zp: 160 },
     'Night Shade': { zp: 100 },
+    'Night Slash': { zp: 140 },
+    'Nuzzle': { zp: 100 },
+    'Oblivion Wing': { zp: 160 },
     'Oceanic Operetta': {
         bp: 195,
         type: 'Water',
         category: 'Special'
     },
+    'Ominous Wind': { zp: 120 },
+    'Origin Pulse': { zp: 185 },
     'Outrage': { zp: 190 },
     'Overheat': { zp: 195 },
+    'Payback': { zp: 100 },
     'Petal Dance': { zp: 190 },
+    'Phantom Force': { zp: 175 },
     'Pin Missile': { zp: 140 },
+    'Play Rough': { zp: 175 },
+    'Pluck': { zp: 120 },
     'Poison Fang': { zp: 100 },
+    'Poison Jab': { zp: 160 },
+    'Poison Tail': { zp: 100 },
     'Pollen Puff': {
         bp: 90,
         type: 'Bug',
@@ -2769,6 +2914,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         isBullet: true,
         zp: 175
     },
+    'Power Gem': { zp: 160 },
     'Power Trip': {
         bp: 20,
         type: 'Dark',
@@ -2776,12 +2922,15 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         makesContact: true,
         zp: 160
     },
+    'Power Whip': { zp: 190 },
+    'Power-Up Punch': { zp: 100 },
     'Prismatic Laser': {
         bp: 160,
         type: 'Psychic',
         category: 'Special',
         zp: 200
     },
+    'Precipice Blades': { zp: 190 },
     'Psychic': { zp: 175 },
     'Psychic Fangs': {
         bp: 85,
@@ -2791,14 +2940,23 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         isBite: true,
         zp: 160
     },
+    'Psycho Boost': { zp: 200 },
+    'Psycho Cut': { zp: 140 },
+    'Psyshock': { zp: 160 },
+    'Psystrike': { zp: 180 },
     'Pulverizing Pancake': {
         bp: 210,
         type: 'Normal',
         category: 'Physical'
     },
+    'Punishment': { zp: 160 },
     'Pursuit': { zp: 100 },
     'Quick Attack': { zp: 100 },
     'Rapid Spin': { zp: 100 },
+    'Razor Leaf': { zp: 120 },
+    'Razor Shell': { zp: 140 },
+    'Relic Song': { zp: 140 },
+    'Retaliate': { zp: 140 },
     'Return': { zp: 160 },
     'Revelation Dancer': {
         bp: 90,
@@ -2808,17 +2966,32 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Revenge': { zp: 120 },
     'Reversal': { zp: 160 },
+    'Roar of Time': { zp: 200 },
+    'Rock Blast': { zp: 140 },
+    'Rock Climb': { zp: 175 },
     'Rock Slide': { zp: 140 },
     'Rock Smash': { zp: 100 },
     'Rock Tomb': { zp: 140 },
+    'Rock Wrecker': { zp: 200 },
+    'Round': { zp: 120 },
     'Sacred Fire': { zp: 180 },
+    'Sacred Sword': { zp: 175 },
     'Savage Spin-Out': {
         bp: 1,
         type: 'Bug',
         category: 'Physical'
     },
+    'Scald': { zp: 160 },
+    'Searing Shot': { zp: 180 },
+    'Secret Power': { zp: 140 },
+    'Secret Sword': { zp: 160 },
+    'Seed Bomb': { zp: 160 },
+    'Seed Flare': { zp: 190 },
     'Seismic Toss': { zp: 100 },
     'Self-Destruct': { zp: 200 },
+    'Shadow Claw': { zp: 140 },
+    'Shadow Force': { zp: 190 },
+    'Shadow Sneak': { zp: 100 },
     'Shattered Psyche': {
         bp: 1,
         type: 'Psychic',
@@ -2841,15 +3014,21 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         isSpread: true,
         zp: 200
     },
+    'Shock Wave': { zp: 120 },
     'Signal Beam': { zp: 140 },
+    "Silver Wind": { zp: 120 },
     'Sinister Arrow Raid': {
         bp: 180,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Skull Bash': { zp: 195 },
     'Sky Attack': { zp: 200 },
+    'Sky Drop': { zp: 120 },
     'Sky Uppercut': { zp: 160 },
     'Sludge Bomb': { zp: 175 },
+    'Sludge Wave': { zp: 175 },
+    'Smack Down': { zp: 100 },
     'Smart Strike': {
         bp: 70,
         type: 'Steel',
@@ -2857,6 +3036,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         makesContact: true,
         zp: 140
     },
+    'Snarl': { zp: 100 },
     'Solar Beam': { zp: 190 },
     'Solar Blade': {
         bp: 125,
@@ -2870,6 +3050,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Ghost',
         category: 'Physical'
     },
+    'Spacial Rend': { zp: 180 },
     'Spark': { zp: 120 },
     'Sparkling Aria': {
         bp: 90,
@@ -2892,6 +3073,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         category: 'Physical',
         zp: 160
     },
+    'Steam Eruption': { zp: 185 },
+    'Steamroller': { zp: 120 },
     'Steel Wing': { zp: 140 },
     'Stoked Sparksurfer': {
         bp: 175,
@@ -2905,12 +3088,16 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         makesContact: true,
         zp: 140
     },
+    'Stone Edge': { zp: 180 },
+    'Stored Power': { zp: 160 },
+    'Storm Throw': { zp: 120 },
+    'Struggle Bug': { zp: 100 },
     'Subzero Slammer': {
         bp: 1,
         type: 'Ice',
         category: 'Physical'
     },
-    'Sucker Punch': { bp: 70 },
+    'Sucker Punch': { bp: 70, zp: 140 },
     'Sunsteel Strike': {
         bp: 100,
         type: 'Steel',
@@ -2927,13 +3114,18 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Surf': { zp: 175 },
     'Swift': { zp: 120 },
+    'Synchronoise': { zp: 190 },
     'Tackle': { bp: 40, zp: 100 },
+    'Tail Slap': { zp: 140 },
+    'Techno Blast': { zp: 190 },
     'Tectonic Rage': {
         bp: 1,
         type: 'Ground',
         category: 'Physical'
     },
     'Thief': { zp: 120 },
+    'Thousand Arrows': { zp: 180 },
+    'Thousand Waves': { zp: 175 },
     'Thrash': { zp: 190 },
     'Throat Chop': {
         bp: 80,
@@ -2944,6 +3136,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Thunder': { zp: 185 },
     'Thunderbolt': { zp: 175 },
+    'Thunder Fang': { zp: 120 },
     'Thunder Punch': { zp: 140 },
     'Tri Attack': { zp: 160 },
     'Trop Kick': {
@@ -2959,10 +3152,24 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Fairy',
         category: 'Physical'
     },
+    "U-turn": { zp: 140 },
+    'Uproar': { zp: 175 },
+    'V-create': { zp: 220 },
+    'Vacuum Wave': { zp: 100 },
+    'Venoshock': { zp: 120 },
+    'Volt Switch': { zp: 140 },
+    'Volt Tackle': { zp: 190 },
+    'Wake-Up Slap': { zp: 140 },
     'Waterfall': { zp: 160 },
+    'Water Pulse': { zp: 120 },
     'Water Shuriken': { category: 'Special', zp: 100 },
     'Water Spout': { zp: 200 },
     'Weather Ball': { zp: 160 },
+    'Wild Charge': { zp: 175 },
+    'Wood Hammer': { zp: 190 },
+    'X-Scissor': { zp: 160 },
+    'Zap Cannon': { zp: 190 },
+    'Zen Headbutt': { zp: 160 },
     'Zing Zap': {
         bp: 80,
         type: 'Electric',

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -16,6 +16,11 @@ var MOVES_RBY = {
         bp: 0,
         type: 'Psychic'
     },
+    'Aurora Beam': {
+        bp: 65,
+        type: 'Ice',
+        hasSecondaryEffect: true
+    },
     'Barrier': {
         bp: 0,
         type: 'Psychic'
@@ -192,6 +197,13 @@ var MOVES_RBY = {
         category: 'Physical',
         makesContact: true,
         hasRecoil: true
+    },
+    'Leech Life': {
+        bp: 20,
+        type: 'Bug',
+        category: 'Physical',
+        makesContact: true,
+        givesHealth: true
     },
     'Leech Seed': {
         bp: 0,
@@ -2443,6 +2455,27 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
     }
 });
 
+var ZMOVES_TYPING = {
+    'Bug':'Savage Spin-Out',
+    'Dark':'Black Hole Eclipse',
+    'Dragon':'Devastating Drake',
+    'Electric':'Gigavolt Havoc',
+    'Fairy':'Twinkle Tackle',
+    'Fighting':'All-Out Pummeling',
+    'Fire':'Inferno Overdrive',
+    'Flying':'Supersonic Skystrike',
+    'Ghost':'Never-Ending Nightmare',
+    'Grass':'Bloom Doom',
+    'Ground':'Tectonic Rage',
+    'Ice':'Subzero Slammer',
+    'Normal':'Breakneck Blitz',
+    'Poison':'Acid Downpour',
+    'Psychic':'Shattered Psyche',
+    'Rock':'Continental Crush',
+    'Steel':'Corkscrew Crash',
+    'Water':'Hydro Vortex'
+};
+
 var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     '10,000,000 Volt Thunderbolt': {
         bp: 195,
@@ -2459,8 +2492,12 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Rock',
         category: 'Physical',
         makesContact: true,
-        hasPriority: true
+        hasPriority: true,
+        zp: 100
     },
+    'Aerial Ace': { zp: 120 },
+    'Aeroblast': { zp: 180 },
+    'Air Cutter': { zp: 120 },
     'All-Out Pummeling': {
         bp: 1,
         type: 'Fighting',
@@ -2470,21 +2507,29 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         bp: 80,
         type: 'Steel',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
+    'Ancient Power': { zp: 120 },
+    'Arm Thrust': { zp: 100 },
+    'Aurora Beam': { zp: 120 },
+    'Beak Blast': {
+        bp: 100,
+        type: 'Flying',
+        category: 'Physical',
+        zp: 180
+    },
+    'Bite': { zp: 120 },
     'Black Hole Eclipse': {
         bp: 1,
         type: 'Dark',
         category: 'Physical'
     },
+    'Blaze Kick': { zp: 160 },
+    'Blizzard': { zp: 185 },
     'Bloom Doom': {
         bp: 1,
         type: 'Grass',
-        category: 'Physical'
-    },
-    'Beak Blast': {
-        bp: 100,
-        type: 'Flying',
         category: 'Physical'
     },
     'Breakneck Blitz': {
@@ -2492,16 +2537,23 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         type: 'Normal',
         category: 'Physical'
     },
+    'Body Slam': { zp: 160 },
+    'Bonemerang': { zp: 100 },
+    'Brick Break': { zp: 140 },
     'Brutal Swing': {
         bp: 60,
         type: 'Dark',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        isSpread: true,
+        zp: 120
     },
+    'Bullet Seed': { zp: 140 },
     'Burn Up': {
         bp: 130,
         type: 'Fire',
-        category: 'Special'
+        category: 'Special',
+        zp: 195
     },
     'Catastropika': {
         bp: 210,
@@ -2512,7 +2564,9 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         bp: 110,
         type: 'Dragon',
         category: 'Special',
-        isSound: true
+        isSound: true,
+        isSpread: true,
+        zp: 185
     },
     'Continental Crush': {
         bp: 1,
@@ -2522,216 +2576,323 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Core Enforcer': {
         bp: 100,
         type: 'Dragon',
-        category: 'Special'
+        category: 'Special',
+        isSpread: true,
+        zp: 140
     },
     'Corkscrew Crash': {
         bp: 1,
         type: 'Steel',
         category: 'Physical'
     },
+    'Crabhammer': { zp: 180 },
+    'Cross Chop': { zp: 180 },
+    'Crunch': { zp: 160 },
     'Darkest Lariat': {
         bp: 85,
         type: 'Dark',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
     'Dragon Hammer': {
         bp: 90,
         type: 'Dragon',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 175
     },
+    'Drill Peck': { zp: 160 },
     'Devastating Drake': {
         bp: 1,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Double-Edge': { zp: 190 },
+    'Double Kick': { zp: 100 },
+    'Dynamic Punch': { zp: 180 },
+    'Earthquake': { zp: 180 },
+    'Endeavor': { zp: 160 },
+    'Eruption': { zp: 200 },
+    'Explosion': { zp: 200 },
+    'Extrasensory': { zp: 160 },
+    'Extreme Speed': { zp: 160 },
+    'Fake Out': { zp: 100 },
+    'Facade': { zp: 140 },
+    'Feint Attack': { zp: 120 },
+    'Fire Blast': { zp: 185 },
     'Fire Lash': {
         bp: 80,
         type: 'Fire',
         category: 'Physical',
         hasSecondaryEffect: true,
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
+    'Fire Punch': { zp: 140 },
+    'First Impression': {
+        bp: 90,
+        type: 'Bug',
+        category: 'Physical',
+        makesContact: true,
+        hasPriority: true,
+        zp: 175
+    },
+    'Flail': { zp: 160 },
+    'Flamethrower': { zp: 175 },
+    'Flame Wheel': { zp: 120 },
     'Fleur Cannon': {
         bp: 130,
         type: 'Fairy',
         category: 'Special',
-        hasSecondaryEffect: true
+        hasSecondaryEffect: true,
+        zp: 195
     },
     'Flying Press': { bp: 100 },
+    'Focus Punch': { zp: 200 },
+    'Frustration': { zp: 160 },
     'Genesis Supernova': {
         bp: 185,
         type: 'Psychic',
         category: 'Special'
     },
+    'Giga Drain': { zp: 140 },
     'Gigavolt Havoc': {
         bp: 1,
         type: 'Electric',
         category: 'Physical'
     },
-    'Highhorse Power': {
+    'Headbutt': { zp: 140 },
+    'Heat Wave': { zp: 175 },
+    'High Horsepower': {
         bp: 95,
         type: 'Ground',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 175
     },
+    'High Jump Kick': { zp: 195 },
+    'Hydro Pump': { zp: 185 },
     'Hydro Vortex': {
         bp: 1,
         type: 'Water',
         category: 'Physical'
     },
+    'Hyper Beam': { zp: 200 },
+    'Hyper Voice': { zp: 175 },
+    'Ice Beam': { zp: 175 },
     'Ice Hammer': {
         bp: 100,
         type: 'Ice',
         category: 'Physical',
         makesContact: true,
-        isPunch: true
+        isPunch: true,
+        zp: 180
     },
+    'Ice Punch': { zp: 140 },
+    'Icy Wind': { zp: 100 },
     'Inferno Overdrive': {
         bp: 1,
         type: 'Fire',
         category: 'Physical'
     },
+    'Iron Tail': { zp: 180 },
+    'Jump Kick': { zp: 180 },
+    'Knock Off': { zp: 120 },
     'Leafage': {
         bp: 40,
         type: 'Grass',
         category: 'Physical'
     },
+    'Leech Life': { bp: 80, zp: 160 },
     'Liquidation': {
         bp: 85,
         type: 'Water',
         category: 'Physical',
         hasSecondaryEffect: true,
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
+    'Low Kick': { zp: 160 },
     'Lunge': {
         bp: 80,
         type: 'Bug',
         category: 'Physical',
         hasSecondaryEffect: true,
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
+    'Luster Purge': { zp: 140 },
+    'Mach Punch': { zp: 100 },
     'Malicious Moonsault': {
         bp: 180,
         type: 'Dark',
         category: 'Physical',
         makesContact: true
     },
+    'Megahorn': { zp: 190 },
+    'Meteor Mash': { zp: 175 },
     'Moongeist Beam': {
         bp: 100,
         type: 'Ghost',
-        category: 'Special'
+        category: 'Special',
+        zp: 180
     },
+    'Muddy Water': { zp: 175 },
     'Multi-Attack': {
         bp: 90,
         type: 'Normal',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 185
     },
     'Never-Ending Nightmare': {
         bp: 1,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Night Shade': { zp: 100 },
     'Oceanic Operetta': {
         bp: 195,
         type: 'Water',
         category: 'Special'
     },
+    'Outrage': { zp: 190 },
+    'Overheat': { zp: 195 },
+    'Petal Dance': { zp: 190 },
+    'Pin Missile': { zp: 140 },
+    'Poison Fang': { zp: 100 },
     'Pollen Puff': {
         bp: 90,
         type: 'Bug',
-        category: 'Special'
+        category: 'Special',
+        isBullet: true,
+        zp: 175
     },
     'Power Trip': {
         bp: 20,
         type: 'Dark',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
     'Prismatic Laser': {
         bp: 160,
         type: 'Psychic',
-        category: 'Special'
+        category: 'Special',
+        zp: 200
     },
+    'Psychic': { zp: 175 },
     'Psychic Fangs': {
         bp: 85,
         type: 'Psychic',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        isBite: true,
+        zp: 160
     },
     'Pulverizing Pancake': {
         bp: 210,
         type: 'Normal',
         category: 'Physical'
     },
+    'Pursuit': { zp: 100 },
+    'Quick Attack': { zp: 100 },
+    'Rapid Spin': { zp: 100 },
+    'Return': { zp: 160 },
     'Revelation Dancer': {
         bp: 90,
         type: 'Normal',
-        category: 'Special'
+        category: 'Special',
+        zp: 175
     },
+    'Revenge': { zp: 120 },
+    'Reversal': { zp: 160 },
+    'Rock Slide': { zp: 140 },
+    'Rock Smash': { zp: 100 },
+    'Rock Tomb': { zp: 140 },
+    'Sacred Fire': { zp: 180 },
     'Savage Spin-Out': {
         bp: 1,
         type: 'Bug',
         category: 'Physical'
     },
+    'Seismic Toss': { zp: 100 },
+    'Self-Destruct': { zp: 200 },
     'Shattered Psyche': {
         bp: 1,
         type: 'Psychic',
         category: 'Physical'
     },
+    'Shadow Ball': { zp: 160 },
     'Shadow Bone': {
         bp: 85,
         type: 'Ghost',
         category: 'Physical',
-        hasSecondaryEffect: true
+        hasSecondaryEffect: true,
+        zp: 160
     },
+    'Shadow Punch': { zp: 120 },
+    'Sheer Cold': { zp: 180 },
     'Shell Trap': {
         bp: 150,
         type: 'Fire',
         category: 'Special',
-        isSpread: true
+        isSpread: true,
+        zp: 200
     },
+    'Signal Beam': { zp: 140 },
     'Sinister Arrow Raid': {
         bp: 180,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Sky Attack': { zp: 200 },
+    'Sky Uppercut': { zp: 160 },
+    'Sludge Bomb': { zp: 175 },
     'Smart Strike': {
         bp: 70,
         type: 'Steel',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 140
     },
+    'Solar Beam': { zp: 190 },
     'Solar Blade': {
         bp: 125,
         type: 'Grass',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 190
     },
     'Soul-Stealing 7-Star Strike': {
         bp: 195,
         type: 'Ghost',
         category: 'Physical'
     },
+    'Spark': { zp: 120 },
     'Sparkling Aria': {
         bp: 90,
         type: 'Water',
         category: 'Special',
-        isSound: true
+        isSound: true,
+        isSpread: true,
+        zp: 175
     },
     'Spectral Thief': {
         bp: 90,
         type: 'Ghost',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 175
     },
     'Spirit Shackle': {
         bp: 80,
         type: 'Ghost',
-        category: 'Physical'
+        category: 'Physical',
+        zp: 160
     },
+    'Steel Wing': { zp: 140 },
     'Stoked Sparksurfer': {
         bp: 175,
         type: 'Electric',
@@ -2741,7 +2902,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         bp: 75,
         type: 'Ground',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 140
     },
     'Subzero Slammer': {
         bp: 1,
@@ -2753,43 +2915,60 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         bp: 100,
         type: 'Steel',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 180
     },
+    'Super Fang': { zp: 100 },
+    'Superpower': { zp: 190 },
     'Supersonic Skystrike': {
         bp: 1,
         type: 'Flying',
         category: 'Physical'
     },
-    'Tackle': { bp: 40 },
+    'Surf': { zp: 175 },
+    'Swift': { zp: 120 },
+    'Tackle': { bp: 40, zp: 100 },
     'Tectonic Rage': {
         bp: 1,
         type: 'Ground',
         category: 'Physical'
     },
+    'Thief': { zp: 120 },
+    'Thrash': { zp: 190 },
     'Throat Chop': {
         bp: 80,
         type: 'Dark',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        zp: 160
     },
+    'Thunder': { zp: 185 },
+    'Thunderbolt': { zp: 175 },
+    'Thunder Punch': { zp: 140 },
+    'Tri Attack': { zp: 160 },
     'Trop Kick': {
         bp: 70,
         type: 'Grass',
         category: 'Physical',
         hasSecondaryEffect: true,
-        makesContact: true
+        makesContact: true,
+        zp: 140
     },
     'Twinkle Tackle': {
         bp: 1,
         type: 'Fairy',
         category: 'Physical'
     },
-    'Water Shuriken': { category: 'Special' },
+    'Waterfall': { zp: 160 },
+    'Water Shuriken': { category: 'Special', zp: 100 },
+    'Water Spout': { zp: 200 },
+    'Weather Ball': { zp: 160 },
     'Zing Zap': {
         bp: 80,
         type: 'Electric',
         category: 'Physical',
         hasSecondaryEffect: true,
-        makesContact: true
+        makesContact: true,
+        zp: 160
     }
 });


### PR DESCRIPTION
Add a "z" checkbox beside move selector. If it is checked, the corresponding z-move will be used for calc, which should simplify z-move input.

This requires work of @AustinXII (in progress), which adds a z-power property to each move, and a z-move map.

Changes in detail:

1. Add a "z" checkbox beside each move (`index.html`, `calc_bc.html`), and update layout to make all views in the same line. (`ap_calc.css`)
2. Add `getZMoveName` function, which finds the proper z-move to use. Hidden Power becomes Breakneck Blitz. Special move with special z-crystal becomes special z-move (e.g. Volt Tackle with Pikanium Z becomes Catastropika). Otherwise a generic z-move is used. Generic z-moves do not force require a z-crystal or it would be too difficult to use. (`ap_calc.js`)
3. Add z-move check to `getMoveDetails`. In gen 7, when z checkbox is checked and the original has a `zp` property, we use z-move instead of original move. (`ap_calc.js`).
4. Uncheck z checkbox if move was changed. (`ap_calc.js`)
5. Show power of generic z-moves in damage description. (`damage.js`)