### PR TITLE
Fix priority check

### DIFF
--- a/js/data/ability_data.js
+++ b/js/data/ability_data.js
@@ -97,6 +97,7 @@ var ABILITIES_XY = ABILITIES_BW.concat([
     'Desolate Land',
     'Fairy Aura',
     'Fur Coat',
+    'Gale Wings',
     'Mega Launcher',
     'Parental Bond',
     'Pixilate',


### PR DESCRIPTION
The previous priority check
`
PriorityDamageCheck = move.hasPriority && (defAbility === "Queenly Majesty" || defAbility === "Dazzling") && (["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) !== -1) || (move.givesHealth && attacker.ability === "triage")
`
 has many errors:

1. It should check if the attacker's ability IS NOT Mold Breaker, instead of checking attacker's ability IS Molder Breaker; in fact this is unnecessary, because if attacker's ability is Mold Breaker, the defender's ability is already set to empty there;
2. It checks Triage last with `||` operator, means if Triage is in effect then previous condition is ignored

So I rewrite the priority check, also add check for Gale Wings and Psychic Terrain (tested). The Gale Wings check has the same "full HP issue" with Multiscale, everyone can improve it if you find a proper solution.
For Psychic Terrain I added `isGroundedForCalc` function, hope it can simply terrain check in the future