### PR TITLE
Add Endeavor

### DIFF
--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -899,6 +899,12 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
         category: 'Physical',
         makesContact: true
     },
+    'Endeavor': {
+        bp: 1,
+        type: "Normal",
+        category: "Physical",
+        makesContact: true
+    },
     'Eruption': {
         bp: 150,
         type: 'Fire',


### PR DESCRIPTION
Endeavor is added by accident when we add z-power, but its basic data (such as power) is not added yet, it seems this causes honkalculate to crash so I added it
Do we need to implement its effect? I tried to implement it but the KO chance message is really ridiculous. Or should we remove it?