### PR TITLE
Add usage-based sets in place of absent analyses.

### DIFF
--- a/js/data/setdex_dpp.js
+++ b/js/data/setdex_dpp.js
@@ -59,6 +59,7 @@ var SETDEX_DPP = {
 		"UU Offensive Baton Pass": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Technician","item":"Life Orb","moves":["Nasty Plot","Baton Pass","Swift","Taunt"]},
 	},
 	"Ampharos": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":24,"hp":232,"sa":252},"nature":"Quiet","ability":"Static","item":"Life Orb","moves":["Thunderbolt","Focus Blast","Hidden Power Ice","Discharge"]},
 		"UU Why Ampharos Don&#39;t Have Wool (Life Orb)": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Static","item":"Life Orb","moves":["Thunderbolt","Hidden Power Ice","Focus Blast","Substitute"]},
 		"UU Specially Defensive": {"level":100,"evs":{"sd":176,"hp":252,"sa":80},"nature":"Modest","ability":"Static","item":"Leftovers","moves":["Discharge","Hidden Power Ice","Heal Bell","Reflect"]},
 		"UU Choice Specs": {"level":100,"evs":{"hp":208,"sp":48,"sa":252},"nature":"Modest","ability":"Static","item":"Choice Specs","moves":["Thunderbolt","Focus Blast","Hidden Power Ice","Signal Beam"]},
@@ -71,6 +72,7 @@ var SETDEX_DPP = {
 		"LC Swords Dance": {"level":5,"evs":{"df":36,"at":236,"sp":236},"nature":"Adamant","ability":"Battle Armor","item":"Life Orb","moves":["Swords Dance","Rock Slide","X-Scissor","Brick Break"]},
 	},
 	"Arbok": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Black Sludge","moves":["Earthquake","Crunch","Gunk Shot","Aqua Tail"]},
 		"UU Glare": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Intimidate","item":"Leftovers","moves":["Glare","Gunk Shot","Earthquake","Seed Bomb"]},
 		"UU Switcheroo": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Switcheroo","Gunk Shot","Earthquake","Seed Bomb"]},
 	},
@@ -154,6 +156,7 @@ var SETDEX_DPP = {
 		"UU Toxic Spikes Lead": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Insomnia","item":"Focus Sash","moves":["Toxic Spikes","Sucker Punch","Poison Jab","Protect"]},
 	},
 	"Armaldo": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Battle Armor","item":"Leftovers","moves":["Rapid Spin","Stealth Rock","Earthquake","X-Scissor"]},
 		"UU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Battle Armor","item":"Life Orb","moves":["Swords Dance","X-Scissor","Stone Edge","Earthquake"]},
 		"UU Rock Polish": {"level":100,"evs":{"at":252,"hp":12,"sp":244},"nature":"Adamant","ability":"Battle Armor","item":"Life Orb","moves":["Rock Polish","X-Scissor","Stone Edge","Earthquake"]},
 		"UU Support": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Battle Armor","item":"Leftovers","moves":["Rock Slide","Stealth Rock","Rapid Spin","Knock Off"]},
@@ -164,6 +167,7 @@ var SETDEX_DPP = {
 		"LC Choice Band": {"level":5,"evs":{"sd":36,"df":36,"at":196,"hp":36,"sp":196},"nature":"Adamant","ability":"Rock Head","item":"Choice Band","moves":["Head Smash","Earthquake","Iron Head","Superpower"]},
 	},
 	"Articuno": {
+		"NU Showdown Usage": {"level":100,"evs":{},"nature":"Hardy","ability":"Pressure","item":"Leftovers","moves":["Ice Beam","Blizzard","Avalanche","Roost"]},
 		"UU SubRoost": {"level":100,"evs":{"sd":32,"hp":252,"sp":224},"nature":"Timid","ability":"Pressure","item":"Leftovers","moves":["Substitute","Roost","Ice Beam","Toxic"]},
 		"UU Support": {"level":100,"evs":{"sd":252,"hp":252,"sp":4},"nature":"Calm","ability":"Pressure","item":"Leftovers","moves":["Ice Beam","Roost","Roar","Heal Bell"]},
 	},
@@ -196,6 +200,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":36,"hp":36,"sp":236,"sa":196},"nature":"Mild","ability":"Levitate","item":"Choice Scarf","moves":["Earth Power","Psychic","Ice Beam","Explosion"]},
 	},
 	"Banette": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":160,"hp":252,"sp":24,"sa":68},"nature":"Bold","ability":"Insomnia","item":"Leftovers","moves":["Will-O-Wisp","Shadow Ball","Shadow Claw","Calm Mind"]},
 		"UU Trick Room": {"level":100,"evs":{"at":252},"ivs":{"sd":0,"df":0,"hp":0,"sp":0},"nature":"Brave","ability":"Insomnia","item":"Focus Sash","moves":["Trick Room","Destiny Bond","Taunt","Shadow Claw"]},
 	},
 	"Barboach": {
@@ -204,6 +209,7 @@ var SETDEX_DPP = {
 		"LC Special Choice": {"level":5,"evs":{"sd":28,"df":12,"hp":36,"sp":200,"sa":232},"nature":"Modest","ability":"Anticipation","item":"Choice Scarf","moves":["Earth Power","Hydro Pump","Ice Beam","Hidden Power Fire"]},
 	},
 	"Bastiodon": {
+		"NU Showdown Usage": {"level":100,"evs":{},"nature":"Hardy","ability":"Sturdy","item":"Leftovers","moves":["Stealth Rock","Earthquake","Flash Cannon","Ancient Power"]},
 		"UU Support": {"level":100,"evs":{"sd":248,"at":8,"hp":252},"nature":"Impish","ability":"Sturdy","item":"Leftovers","moves":["Stealth Rock","Toxic","Roar","Iron Head"]},
 		"UU Torment": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Impish","ability":"Sturdy","item":"Leftovers","moves":["Torment","Substitute","Protect","Roar"]},
 		"UU Metal Burst": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Sturdy","item":"Leftovers","moves":["Metal Burst","Taunt","Stealth Rock","Earthquake"]},
@@ -212,6 +218,7 @@ var SETDEX_DPP = {
 		"UU Special Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swarm","item":"Life Orb","moves":["Bug Buzz","Hidden Power Ground","Shadow Ball","Stun Spore"]},
 	},
 	"Beedrill": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Swarm","item":"Focus Sash","moves":["Toxic Spikes","Endeavor","U-turn","Knock Off"]},
 		"UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swarm","item":"Life Orb","moves":["Swords Dance","X-Scissor","Brick Break","Baton Pass"]},
 		"UU Choice Scarf": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swarm","item":"Choice Scarf","moves":["U-turn","X-Scissor","Brick Break","Poison Jab"]},
 		"UU Baton Pass": {"level":100,"evs":{"sd":12,"hp":244,"sp":252},"nature":"Jolly","ability":"Swarm","item":"Liechi Berry","moves":["Baton Pass","Agility","Substitute","X-Scissor"]},
@@ -229,6 +236,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"sd":36,"hp":36,"sp":200,"sa":200},"nature":"Timid","ability":"Chlorophyll","item":"Choice Scarf","moves":["Sludge Bomb","Energy Ball","Hidden Power Fire","Sleep Powder"]},
 	},
 	"Bibarel": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Simple","item":"Leftovers","moves":["Waterfall","Quick Attack","Curse","Stealth Rock"]},
 		"UU Baton Pass Receiver": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Simple","item":"Life Orb","moves":["Waterfall","Return","Quick Attack","Taunt"]},
 	},
 	"Bidoof": {
@@ -313,11 +321,13 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":156,"hp":36,"sp":236,"sa":76},"nature":"Hasty","ability":"Sand Veil","item":"Choice Scarf","moves":["Dark Pulse","Brick Break","Needle Arm","Hidden Power Ice"]},
 	},
 	"Cacturne": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Veil","item":"Focus Sash","moves":["Sucker Punch","Seed Bomb","Spikes","Swords Dance"]},
 		"UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Veil","item":"Life Orb","moves":["Swords Dance","Sucker Punch","Seed Bomb","Low Kick"]},
 		"UU Spikes Lead": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Veil","item":"Focus Sash","moves":["Spikes","Encore","Sucker Punch","Seed Bomb"]},
 		"UU Spikes": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Sand Veil","item":"Leftovers","moves":["Spikes","Synthesis","Dark Pulse","Energy Ball"]},
 	},
 	"Camerupt": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Solid Rock","item":"Leftovers","moves":["Earth Power","Stealth Rock","Lava Plume","Toxic"]},
 		"UU Special Rock Polish": {"level":100,"evs":{"at":40,"sp":216,"sa":252},"nature":"Rash","ability":"Solid Rock","item":"Life Orb","moves":["Rock Polish","Fire Blast","Earth Power","Explosion"]},
 		"UU Trick Room Attacker": {"level":100,"evs":{"at":252,"hp":4,"sa":252},"ivs":{"sp":2},"nature":"Quiet","ability":"Solid Rock","item":"Life Orb","moves":["Fire Blast","Earth Power","Stone Edge","Explosion"]},
 		"UU Physical Rock Polish": {"level":100,"evs":{"at":252,"sp":216,"sa":40},"nature":"Naughty","ability":"Solid Rock","item":"Life Orb","moves":["Rock Polish","Earthquake","Fire Blast","Explosion"]},
@@ -349,6 +359,7 @@ var SETDEX_DPP = {
 		"UU Cleric": {"level":100,"evs":{"sd":252,"df":252,"hp":4},"nature":"Calm","ability":"Natural Cure","item":"Leftovers","moves":["Aromatherapy","Soft-Boiled","Seismic Toss","Stealth Rock"]},
 	},
 	"Charizard": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Life Orb","moves":["Air Slash","Fire Blast","Hidden Power Grass","Roost"]},
 		"UU Special Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Life Orb","moves":["Fire Blast","Air Slash","Hidden Power Grass","Roost"]},
 		"UU Sunny Day": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Life Orb","moves":["Sunny Day","Fire Blast","Solar Beam","Roost"]},
 		"UU Dragon Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Blaze","item":"Life Orb","moves":["Dragon Dance","Flare Blitz","Earthquake","Thunder Punch"]},
@@ -359,6 +370,7 @@ var SETDEX_DPP = {
 		"LC Dragon Dance": {"level":5,"evs":{"sd":36,"df":12,"at":180,"hp":44,"sp":236},"nature":"Adamant","ability":"Blaze","item":"Oran Berry","moves":["Dragon Dance","Flare Blitz","Brick Break","Thunder Punch"]},
 	},
 	"Chatot": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Keen Eye","item":"Choice Scarf","moves":["Hyper Voice","Chatter","Heat Wave","Hidden Power Grass"]},
 		"UU Nasty Plot": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Tangled Feet","item":"Life Orb","moves":["Nasty Plot","Hyper Voice","Heat Wave","Encore"]},
 		"UU Choice": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Tangled Feet","item":"Choice Specs","moves":["Hyper Voice","Heat Wave","Hidden Power Grass","U-turn"]},
 	},
@@ -424,6 +436,7 @@ var SETDEX_DPP = {
 		"UU I Can Tank Too!": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Natural Cure","item":"Leftovers","moves":["Recover","Toxic","Surf","Stealth Rock"]},
 	},
 	"Cradily": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Careful","ability":"Suction Cups","item":"Leftovers","moves":["Recover","Rock Slide","Seed Bomb","Stealth Rock"]},
 		"UU Mono-Attacker": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Suction Cups","item":"Leftovers","moves":["Rock Slide","Curse","Rest","Sleep Talk"]},
 		"UU ChestoRest": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Suction Cups","item":"Chesto Berry","moves":["Curse","Rock Slide","Seed Bomb","Rest"]},
 		"UU Support": {"level":100,"evs":{"sd":160,"df":96,"hp":252},"nature":"Careful","ability":"Suction Cups","item":"Leftovers","moves":["Rock Slide","Toxic","Recover","Seed Bomb"]},
@@ -439,6 +452,7 @@ var SETDEX_DPP = {
 		"LC Trick Room Attacker": {"level":5,"evs":{"sd":36,"at":236,"hp":210},"ivs":{"sp":0},"nature":"Brave","ability":"Mold Breaker","item":"Life Orb","moves":["Stone Edge","Earthquake","Zen Headbutt","Ice Beam"]},
 	},
 	"Crawdaunt": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Hyper Cutter","item":"Life Orb","moves":["Crunch","Superpower","X-Scissor","Waterfall"]},
 		"UU Dragon Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Life Orb","moves":["Dragon Dance","Waterfall","Crunch","X-Scissor"]},
 		"UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","item":"Choice Band","moves":["Crunch","Waterfall","Superpower","X-Scissor"]},
 	},
@@ -514,11 +528,13 @@ var SETDEX_DPP = {
 		"LC Lead": {"level":5,"evs":{"at":236,"hp":36,"sp":236},"nature":"Jolly","ability":"Arena Trap","item":"Focus Sash","moves":["Stealth Rock","Earthquake","Sucker Punch","Protect"]},
 		"LC Non-Choice Revenge Killer": {"level":5,"evs":{"at":240,"sp":236},"nature":"Hasty","ability":"Arena Trap","item":"Life Orb","moves":["Earthquake","Sucker Punch","Hidden Power Ice","Substitute"]},
 		"LC Choice Revenge Killer": {"level":5,"evs":{"at":240,"sp":236},"nature":"Hasty","ability":"Arena Trap","item":"Choice Band","moves":["Earthquake","Hidden Power Ice","Sucker Punch","Shadow Claw"]},
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Arena Trap","item":"Choice Band","moves":["Earthquake","Rock Slide","Shadow Claw","Aerial Ace"]},
 	},
 	"Ditto": {
 		"UU The Best Set Ever": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Limber","item":"Leftovers","moves":["Transform"]},
 	},
 	"Dodrio": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Early Bird","item":"Choice Band","moves":["Brave Bird","Return","Quick Attack","Pursuit"]},
 		"UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Early Bird","item":"Choice Band","moves":["Brave Bird","Return","Pursuit","Quick Attack"]},
 		"UU Utility Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Early Bird","item":"Sharp Beak","moves":["Brave Bird","Return","Roost","Taunt"]},
 	},
@@ -533,6 +549,7 @@ var SETDEX_DPP = {
 		"OU Choice Band": {"level":100,"evs":{"at":252,"hp":172,"sp":84},"nature":"Adamant","ability":"Sturdy","item":"Choice Band","moves":["Earthquake","Stone Edge","Assurance","Rapid Spin"]},
 	},
 	"Dragonair": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":52,"sp":204},"nature":"Adamant","ability":"Shed Skin","item":"Leftovers","moves":["Extreme Speed","Aqua Tail","Outrage","Dragon Dance"]},
 		"UU Dragon Dance": {"level":100,"evs":{"at":252,"hp":52,"sp":204},"nature":"Adamant","ability":"Shed Skin","item":"Life Orb","moves":["Dragon Dance","Extreme Speed","Outrage","Aqua Tail"]},
 	},
 	"Dragonite": {
@@ -559,6 +576,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":84,"hp":28,"sp":196,"sa":196},"nature":"Rash","ability":"Shed Skin","item":"Choice Scarf","moves":["Draco Meteor","Ice Beam","Fire Blast","Outrage"]},
 	},
 	"Drifblim": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":252,"sp":148,"sa":108},"nature":"Modest","ability":"Unburden","item":"Chesto Berry","moves":["Shadow Ball","Calm Mind","Hidden Power Fighting","Rest"]},
 		"UU ChestoRest": {"level":100,"evs":{"df":252,"sp":148,"sa":108},"nature":"Modest","ability":"Unburden","item":"Chesto Berry","moves":["Calm Mind","Rest","Shadow Ball","Hidden Power Fighting"]},
 		"UU Baton Pass": {"level":100,"evs":{"sd":252,"df":4,"sp":252},"nature":"Timid","ability":"Aftermath","item":"Leftovers","moves":["Baton Pass","Substitute","Calm Mind","Shadow Ball"]},
 		"UU Pinch Berry Baton Pass": {"level":100,"evs":{"sd":252,"df":196,"sp":60},"ivs":{"hp":30},"nature":"Timid","ability":"Unburden","item":"Petaya Berry","moves":["Baton Pass","Substitute","Shadow Ball","Hypnosis"]},
@@ -589,6 +607,7 @@ var SETDEX_DPP = {
 		"UU Substitute + Paralysis": {"level":100,"evs":{"at":212,"hp":252,"sp":44},"nature":"Adamant","ability":"Serene Grace","item":"Leftovers","moves":["Substitute","Thunder Wave","Headbutt","Earthquake"]},
 	},
 	"Dusclops": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Pressure","item":"Leftovers","moves":["Will-O-Wisp","Seismic Toss","Rest","Pain Split"]},
 		"UU Bulky Spinblocker": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Pressure","item":"Leftovers","moves":["Seismic Toss","Will-O-Wisp","Rest","Sleep Talk"]},
 		"UU Trick Room Support": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"ivs":{"sp":0},"nature":"Relaxed","ability":"Pressure","item":"Leftovers","moves":["Trick Room","Seismic Toss","Will-O-Wisp","Pain Split"]},
 	},
@@ -626,6 +645,7 @@ var SETDEX_DPP = {
 		"LC Choice": {"level":5,"evs":{"hp":36,"sp":236,"sa":236},"nature":"Modest","ability":"Static","item":"Choice Scarf","moves":["Thunderbolt","Flamethrower","Switcheroo","Hidden Power Ice"]},
 	},
 	"Electrode": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Hasty","ability":"Static","item":"Choice Specs","moves":["Thunderbolt","Signal Beam","Explosion","Hidden Power Grass"]},
 		"UU Rain Dance Support": {"level":100,"evs":{"at":252,"sp":156,"sa":100},"nature":"Naive","ability":"Static","item":"Damp Rock","moves":["Rain Dance","Taunt","Thunder","Explosion"]},
 		"UU Life Orb": {"level":100,"evs":{"at":88,"sp":168,"sa":252},"nature":"Naive","ability":"Static","item":"Life Orb","moves":["Thunderbolt","Hidden Power Ice","Taunt","Explosion"]},
 	},
@@ -692,10 +712,12 @@ var SETDEX_DPP = {
 		"LC Physical Attacker": {"level":5,"evs":{"at":204,"sp":232,"sa":44},"nature":"Jolly","ability":"Swift Swim","item":"Choice Scarf","moves":["U-turn","Waterfall","Return","Ice Beam"]},
 	},
 	"Flareon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":176,"df":80,"hp":252},"nature":"Calm","ability":"Flash Fire","item":"Leftovers","moves":["Wish","Toxic","Lava Plume","Heal Bell"]},
 		"UU Wish Support": {"level":100,"evs":{"sd":176,"df":80,"hp":252},"nature":"Calm","ability":"Flash Fire","item":"Leftovers","moves":["Wish","Protect","Flamethrower","Toxic"]},
 		"UU Choice Scarf": {"level":100,"evs":{"at":252,"sp":244,"sa":12},"nature":"Hasty","ability":"Flash Fire","item":"Choice Scarf","moves":["Fire Blast","Return","Superpower","Hidden Power Grass"]},
 	},
 	"Floatzel": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":252,"hp":80,"sp":176},"nature":"Jolly","ability":"Swift Swim","item":"Focus Sash","moves":["Waterfall","Ice Punch","Taunt","Crunch"]},
 		"UU Physical Attacker": {"level":100,"evs":{"df":8,"at":252,"hp":232,"sp":16},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Waterfall","Ice Punch","Return","Rain Dance"]},
 		"UU Bulk Up": {"level":100,"evs":{"df":48,"at":252,"hp":32,"sp":176},"nature":"Jolly","ability":"Swift Swim","item":"Life Orb","moves":["Bulk Up","Waterfall","Ice Punch","Return"]},
 		"UU Baton Pass": {"level":100,"evs":{"df":252,"hp":80,"sp":176},"nature":"Jolly","ability":"Swift Swim","item":"Leftovers","moves":["Waterfall","Bulk Up","Taunt","Baton Pass"]},
@@ -722,9 +744,11 @@ var SETDEX_DPP = {
 		"Uber Spikes Lead": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Snow Cloak","item":"Focus Sash","moves":["Spikes","Icy Wind","Shadow Ball","Destiny Bond"]},
 	},
 	"Furret": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":40,"hp":252,"sp":216},"nature":"Jolly","ability":"Keen Eye","item":"Flame Orb","moves":["Trick","Body Slam","Toxic","Super Fang"]},
 		"UU Choice": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Keen Eye","item":"Choice Band","moves":["Trick","Return","Brick Break","U-turn"]},
 	},
 	"Gabite": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Sand Veil","item":"Life Orb","moves":["Earthquake","Dragon Claw","Outrage","Stone Edge"]},
 		"UU Physical Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Sand Veil","item":"Choice Band","moves":["Outrage","Earthquake","Stone Edge","Dragon Claw"]},
 	},
 	"Gallade": {
@@ -739,6 +763,7 @@ var SETDEX_DPP = {
 		"Uber SubSalac": {"level":100,"evs":{"df":4,"at":252,"sp":252},"ivs":{"hp":30},"nature":"Jolly","ability":"Sand Veil","item":"Salac Berry","moves":["Swords Dance","Substitute","Dragon Claw","Earthquake"]},
 	},
 	"Gardevoir": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Leftovers","moves":["Psychic","Focus Blast","Will-O-Wisp","Thunderbolt"]},
 		"UU Support": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Trace","item":"Leftovers","moves":["Will-O-Wisp","Psychic","Wish","Protect"]},
 		"UU Choice": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Choice Specs","moves":["Psychic","Thunderbolt","Focus Blast","Trick"]},
 		"UU Calm Mind": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Leftovers","moves":["Calm Mind","Focus Blast","Shadow Ball","Psychic"]},
@@ -752,6 +777,7 @@ var SETDEX_DPP = {
 		"LC Trick Room Lead": {"level":5,"evs":{"sd":76,"df":166,"hp":116,"sa":196},"ivs":{"sp":0},"nature":"Quiet","ability":"Levitate","item":"Focus Sash","moves":["Trick Room","Explosion","Shadow Ball","Hypnosis"]},
 	},
 	"Gastrodon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Storm Drain","item":"Leftovers","moves":["Recover","Surf","Toxic","Earth Power"]},
 		"UU Tank": {"level":100,"evs":{"sd":44,"df":252,"hp":212},"nature":"Calm","ability":"Sticky Hold","item":"Leftovers","moves":["Surf","Ice Beam","Toxic","Recover"]},
 		"UU Curse": {"level":100,"evs":{"sd":200,"df":56,"hp":252},"nature":"Careful","ability":"Sticky Hold","item":"Leftovers","moves":["Curse","Waterfall","Earthquake","Recover"]},
 		"UU Trapper": {"level":100,"evs":{"sd":44,"df":212,"hp":252},"nature":"Careful","ability":"Sticky Hold","item":"Rindo Berry","moves":["Block","Yawn","Memento","Earthquake"]},
@@ -796,9 +822,11 @@ var SETDEX_DPP = {
 		"Uber RestTalk": {"level":100,"evs":{"sd":96,"at":216,"hp":84,"sp":112},"nature":"Adamant","ability":"Levitate","item":"Griseous Orb","moves":["Rest","Sleep Talk","Outrage","Shadow Force"]},
 	},
 	"Glaceon": {
+		"NU Showdown Usage": {"level":100,"evs":{},"nature":"Hardy","ability":"Snow Cloak","item":"Choice Scarf","moves":["Ice Beam","Shadow Ball","Wish","Baton Pass"]},
 		"UU Choice": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Snow Cloak","item":"Choice Scarf","moves":["Blizzard","Hidden Power Ground","Baton Pass","Ice Beam"]},
 	},
 	"Glalie": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Focus Sash","moves":["Spikes","Explosion","Ice Shard","Taunt"]},
 		"UU Spikes Lead": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Focus Sash","moves":["Spikes","Taunt","Explosion","Ice Shard"]},
 	},
 	"Glameow": {
@@ -812,6 +840,7 @@ var SETDEX_DPP = {
 		"LC Life Orb": {"level":5,"evs":{"at":236,"sp":236},"nature":"Jolly","ability":"Sand Veil","item":"Life Orb","moves":["Earthquake","Stone Edge","Aqua Tail","Night Slash"]},
 		"LC Substitute": {"level":5,"evs":{"sd":76,"df":236,"hp":156},"nature":"Impish","ability":"Sand Veil","item":"Bright Powder","moves":["Substitute","Roost","Earthquake","Toxic"]},
 		"LC Lead": {"level":5,"evs":{"at":236,"sp":236},"nature":"Jolly","ability":"Sand Veil","item":"Focus Sash","moves":["Stealth Rock","Earthquake","Quick Attack","Aqua Tail"]},
+		"NU Showdown Usage": {"level":100,"evs":{"df":252,"hp":240,"sp":16},"nature":"Impish","ability":"Hyper Cutter","item":"Leftovers","moves":["Earthquake","Roost","Stealth Rock","Toxic"]},
 		"UU SubRoost": {"level":100,"evs":{"df":84,"hp":200,"sp":224},"nature":"Jolly","ability":"Sand Veil","item":"Leftovers","moves":["Substitute","Roost","Taunt","Toxic"]},
 		"UU Wall": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Impish","ability":"Sand Veil","item":"Leftovers","moves":["Taunt","Roost","Earthquake","Aerial Ace"]},
 		"UU Baton Pass": {"level":100,"evs":{"df":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Hyper Cutter","item":"Yache Berry","moves":["Swords Dance","Agility","Baton Pass","Taunt"]},
@@ -836,11 +865,13 @@ var SETDEX_DPP = {
 		"UU All-Out Attacker": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cloud Nine","item":"Life Orb","moves":["Hydro Pump","Ice Beam","Hidden Power Grass","Psychic"]},
 	},
 	"Golem": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Rock Head","item":"Custap Berry","moves":["Earthquake","Stone Edge","Explosion","Stealth Rock"]},
 		"UU Attacking Lead": {"level":100,"evs":{"at":252,"hp":12,"sp":244},"nature":"Adamant","item":"Focus Sash","moves":["Stone Edge","Earthquake","Explosion","Sucker Punch"]},
 		"UU Substitute + 3 Attacks": {"level":100,"evs":{"at":252,"hp":212,"sp":44},"nature":"Adamant","item":"Life Orb","moves":["Substitute","Explosion","Earthquake","Stone Edge"]},
 		"UU All-Out Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Rock Head","item":"Choice Band","moves":["Earthquake","Stone Edge","Double-Edge","Explosion"]},
 	},
 	"Gorebyss": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Ice Beam","Surf","Hydro Pump","Hidden Power Grass"]},
 		"UU Swift Swim Special Attacker": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Ice Beam","Hidden Power Grass","Psychic"]},
 		"UU Baton Pass": {"level":100,"evs":{"hp":252,"sp":220,"sa":36},"nature":"Timid","ability":"Swift Swim","item":"Leftovers","moves":["Baton Pass","Agility","Substitute","Surf"]},
 	},
@@ -863,6 +894,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":196,"sp":196,"sa":116},"ivs":{"df":30,"at":30},"nature":"Naive","ability":"Intimidate","item":"Choice Scarf","moves":["Flare Blitz","Overheat","Hidden Power Ice","Reversal"]},
 	},
 	"Grumpig": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":72,"df":172,"hp":248,"sp":16},"nature":"Calm","ability":"Thick Fat","item":"Leftovers","moves":["Psychic","Heal Bell","Focus Blast","Thunder Wave"]},
 		"UU Support": {"level":100,"evs":{"sd":176,"df":80,"hp":252},"nature":"Calm","ability":"Thick Fat","item":"Leftovers","moves":["Heal Bell","Thunder Wave","Reflect","Psychic"]},
 		"UU Calm Mind": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Thick Fat","item":"Leftovers","moves":["Calm Mind","Substitute","Psychic","Signal Beam"]},
 		"UU Dual Screens": {"level":100,"evs":{"sd":252,"hp":252,"sp":4},"nature":"Calm","ability":"Thick Fat","item":"Light Clay","moves":["Reflect","Light Screen","Psychic","Heal Bell"]},
@@ -888,6 +920,7 @@ var SETDEX_DPP = {
 		"OU Attacking Lead": {"level":100,"evs":{"sd":164,"at":252,"sp":92},"nature":"Adamant","ability":"Guts","item":"Toxic Orb","moves":["Fake Out","Close Combat","Payback","Ice Punch"]},
 	},
 	"Haunter": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Shadow Ball","Substitute","Sludge Bomb","Hidden Power Ground"]},
 		"UU Substitute + 3 Attacks": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Substitute","Shadow Ball","Sludge Bomb","Hidden Power Ground"]},
 		"UU SubSplit": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Substitute","Pain Split","Shadow Ball","Hidden Power Ground"]},
 	},
@@ -988,6 +1021,7 @@ var SETDEX_DPP = {
 		"UU Rain Dance Physical Attacker": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Naughty","ability":"Swift Swim","item":"Life Orb","moves":["Aqua Tail","Double-Edge","Ice Beam","Crunch"]},
 	},
 	"Hypno": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":96,"df":160,"hp":252},"nature":"Calm","ability":"Insomnia","item":"Leftovers","moves":["Wish","Protect","Thunder Wave","Seismic Toss"]},
 		"UU Support": {"level":100,"evs":{"sd":56,"df":200,"hp":252},"nature":"Calm","ability":"Insomnia","item":"Leftovers","moves":["Wish","Seismic Toss","Thunder Wave","Protect"]},
 		"UU Baton Pass": {"level":100,"evs":{"sd":176,"df":80,"hp":252},"nature":"Calm","ability":"Insomnia","item":"Leftovers","moves":["Nasty Plot","Psychic","Baton Pass","Substitute"]},
 		"UU Nasty Plot": {"level":100,"evs":{"hp":168,"sp":120,"sa":220},"nature":"Modest","ability":"Insomnia","item":"Leftovers","moves":["Nasty Plot","Psychic","Grass Knot","Baton Pass"]},
@@ -1032,12 +1066,14 @@ var SETDEX_DPP = {
 		"OU Yawn": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Volt Absorb","item":"Life Orb","moves":["Yawn","Protect","Thunderbolt","Hidden Power Grass"]},
 	},
 	"Jumpluff": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Chlorophyll","item":"Life Orb","moves":["Sleep Powder","Seed Bomb","Aerial Ace","Swords Dance"]},
 		"UU SubSeed": {"level":100,"evs":{"sd":68,"df":188,"sp":252},"nature":"Timid","ability":"Chlorophyll","item":"Leftovers","moves":["Leech Seed","Substitute","Sleep Powder","Encore"]},
 		"UU Double Status": {"level":100,"evs":{"at":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Chlorophyll","item":"Leftovers","moves":["Sleep Powder","Stun Spore","Encore","U-turn"]},
 		"UU Support": {"level":100,"evs":{"df":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Chlorophyll","item":"Leftovers","moves":["Sleep Powder","Memento","Encore","Reflect"]},
 		"UU Sunny Day": {"level":100,"evs":{"at":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Chlorophyll","item":"Heat Rock","moves":["Sleep Powder","Sunny Day","U-turn","Encore"]},
 	},
 	"Jynx": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Oblivious","item":"Focus Sash","moves":["Lovely Kiss","Ice Beam","Nasty Plot","Psychic"]},
 		"UU Nasty Plot": {"level":100,"evs":{"hp":8,"sp":252,"sa":248},"nature":"Timid","ability":"Forewarn","item":"Leftovers","moves":["Ice Beam","Nasty Plot","Lovely Kiss","Substitute"]},
 		"UU Luna (SubCM)": {"level":100,"evs":{"hp":200,"sp":252,"sa":56},"nature":"Timid","ability":"Forewarn","item":"Leftovers","moves":["Ice Beam","Calm Mind","Substitute","Lovely Kiss"]},
 		"UU Attacking Lead": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Forewarn","item":"Focus Sash","moves":["Lovely Kiss","Ice Beam","Grass Knot","Nasty Plot"]},
@@ -1056,6 +1092,9 @@ var SETDEX_DPP = {
 		"Uber Swords Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Swords Dance","Waterfall","Low Kick","Stone Edge"]},
 		"Uber Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Choice Band","moves":["Waterfall","Low Kick","Stone Edge","X-Scissor"]},
 	},
+	"Kadabra": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Inner Focus","item":"Focus Sash","moves":["Psychic","Thunder Wave","Taunt","Counter"]},
+	},
 	"Kakuna": {
 		"OU Tank": {"level":100,"evs":{"df":176,"at":80,"hp":252},"nature":"Impish","ability":"Shed Skin","item":"Leftovers","moves":["Poison Sting","Iron Defense","String Shot","Bug Bite"]},
 		"OU Sweeper": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Shed Skin","item":"Metronome","moves":["Poison Sting","Iron Defense","String Shot","Bug Bite"]},
@@ -1068,6 +1107,7 @@ var SETDEX_DPP = {
 		"UU SubPunch": {"level":100,"evs":{"at":44,"hp":212,"sp":252},"nature":"Jolly","ability":"Scrappy","item":"Leftovers","moves":["Substitute","Focus Punch","Sucker Punch","Return"]},
 	},
 	"Kecleon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Color Change","item":"Leftovers","moves":["Recover","Shadow Claw","Fire Punch","Low Kick"]},
 		"UU Support": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Color Change","item":"Leftovers","moves":["Stealth Rock","Return","Aqua Tail","Recover"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":92,"sp":164},"nature":"Adamant","ability":"Color Change","item":"Choice Band","moves":["Return","Aqua Tail","Low Kick","Trick"]},
 		"UU Trick Room": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Color Change","item":"Leftovers","moves":["Trick Room","Stealth Rock","Return","Recover"]},
@@ -1085,6 +1125,7 @@ var SETDEX_DPP = {
 		"Uber Mixed Attacker": {"level":100,"evs":{"at":80,"sp":176,"sa":252},"nature":"Mild","ability":"Swift Swim","item":"Life Orb","moves":["Surf","Draco Meteor","Outrage","Waterfall"]},
 	},
 	"Kingler": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Hyper Cutter","item":"Choice Band","moves":["Crabhammer","Superpower","Rock Slide","Swords Dance"]},
 		"UU Agility + Swords Dance": {"level":100,"evs":{"at":252,"hp":68,"sp":188},"nature":"Adamant","ability":"Hyper Cutter","item":"Life Orb","moves":["Agility","Swords Dance","Crabhammer","Return"]},
 		"UU Choice": {"level":100,"evs":{"at":252,"hp":32,"sp":224},"nature":"Adamant","ability":"Hyper Cutter","item":"Choice Band","moves":["Crabhammer","Return","Rock Slide","Superpower"]},
 	},
@@ -1123,6 +1164,7 @@ var SETDEX_DPP = {
 		"OU Parafusion": {"level":100,"evs":{"sd":252,"df":220,"hp":36},"nature":"Calm","ability":"Volt Absorb","item":"Leftovers","moves":["Thunder Wave","Confuse Ray","Thunderbolt","Ice Beam"]},
 	},
 	"Lapras": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":32,"sp":224},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Dragon Dance","Waterfall","Return","Ice Beam"]},
 		"UU Special Attacker": {"level":100,"evs":{"sd":56,"hp":252,"sa":200},"nature":"Modest","ability":"Water Absorb","item":"Leftovers","moves":["Surf","Ice Beam","Thunderbolt","Toxic"]},
 		"UU LapDance (Dragon Dance)": {"level":100,"evs":{"at":252,"hp":32,"sp":224},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Dragon Dance","Waterfall","Return","Substitute"]},
 		"UU Mixed Dragon Dance": {"level":100,"evs":{"at":220,"sp":224,"sa":64},"nature":"Naughty","ability":"Water Absorb","item":"Life Orb","moves":["Dragon Dance","Waterfall","Hydro Pump","Ice Beam"]},
@@ -1156,6 +1198,7 @@ var SETDEX_DPP = {
 		"LC Agility": {"level":5,"evs":{"df":36,"hp":36,"sp":236,"sa":196},"nature":"Modest","ability":"Swarm","item":"Petaya Berry","moves":["Agility","Substitute","Bug Buzz","Hidden Power Flying"]},
 	},
 	"Lickilicky": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Own Tempo","item":"Leftovers","moves":["Earthquake","Explosion","Swords Dance","Power Whip"]},
 		"UU Support": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Own Tempo","item":"Leftovers","moves":["Return","Toxic","Wish","Protect"]},
 		"UU Swords Dance": {"level":100,"evs":{"at":252,"hp":88,"sp":168},"nature":"Careful","ability":"Own Tempo","item":"Leftovers","moves":["Swords Dance","Return","Power Whip","Explosion"]},
 		"UU Mixed Attacker": {"level":100,"evs":{"at":252,"hp":116,"sa":140},"nature":"Brave","ability":"Own Tempo","item":"Life Orb","moves":["Fire Blast","Power Whip","Earthquake","Return"]},
@@ -1172,10 +1215,12 @@ var SETDEX_DPP = {
 		"LC Lead": {"level":5,"evs":{"sd":220,"hp":228,"sa":36},"nature":"Calm","ability":"Suction Cups","item":"Oran Berry","moves":["Stealth Rock","Energy Ball","Earth Power","Ancient Power"]},
 	},
 	"Linoone": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Pickup","item":"Silk Scarf","moves":["Extreme Speed","Belly Drum","Seed Bomb","Substitute"]},
 		"UU Belly Drum": {"level":100,"evs":{"df":4,"at":252,"hp":132,"sp":120},"nature":"Adamant","ability":"Gluttony","item":"Salac Berry","moves":["Belly Drum","Extreme Speed","Seed Bomb","Return"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Gluttony","item":"Choice Band","moves":["Extreme Speed","Shadow Claw","Seed Bomb","Switcheroo"]},
 	},
 	"Lopunny": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Cute Charm","item":"Flame Orb","moves":["Encore","Return","Fake Out","Ice Punch"]},
 		"UU Baton Pass + Switcheroo": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Klutz","item":"Flame Orb","moves":["Baton Pass","Substitute","Encore","Switcheroo"]},
 		"UU Agility + Baton Pass": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Cute Charm","item":"Liechi Berry","moves":["Baton Pass","Agility","Substitute","Encore"]},
 		"UU Support": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Klutz","item":"Flame Orb","moves":["Switcheroo","Encore","Heal Bell","Baton Pass"]},
@@ -1222,6 +1267,7 @@ var SETDEX_DPP = {
 		"UU F(l)ail": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Liechi Berry","moves":["Substitute","Flail","Agility","Safeguard"]},
 	},
 	"Luxray": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":92,"hp":252,"sp":160},"nature":"Impish","ability":"Intimidate","item":"Leftovers","moves":["Superpower","Crunch","Thunder Fang","Toxic"]},
 		"UU Wallbreaker": {"level":100,"evs":{"at":204,"sp":148,"sa":156},"nature":"Naughty","ability":"Intimidate","item":"Life Orb","moves":["Thunderbolt","Superpower","Crunch","Hidden Power Grass"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Adamant","ability":"Intimidate","item":"Choice Band","moves":["Spark","Ice Fang","Superpower","Crunch"]},
 		"UU Defensive": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Intimidate","item":"Leftovers","moves":["Discharge","Hidden Power Grass","Toxic","Protect"]},
@@ -1249,9 +1295,11 @@ var SETDEX_DPP = {
 		"LC Choice": {"level":5,"evs":{"at":240,"sp":252},"nature":"Hasty","item":"Choice Scarf","moves":["Flare Blitz","Mach Punch","Thunder Punch","Hidden Power Ice"]},
 	},
 	"Magcargo": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":68,"df":28,"hp":248,"sp":164},"nature":"Timid","ability":"Flame Body","item":"Leftovers","moves":["Recover","Lava Plume","Hidden Power Rock","Stealth Rock"]},
 		"UU Defensive Snail": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Bold","ability":"Flame Body","item":"Leftovers","moves":["Lava Plume","Hidden Power Rock","Recover","Stealth Rock"]},
 	},
 	"Magmortar": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flame Body","item":"Choice Scarf","moves":["Thunderbolt","Fire Blast","Focus Blast","Hidden Power Grass"]},
 		"UU Mixed Attacker": {"level":100,"evs":{"at":16,"sp":240,"sa":252},"nature":"Naive","item":"Life Orb","moves":["Fire Blast","Thunderbolt","Hidden Power Grass","Cross Chop"]},
 		"UU Special Attacker": {"level":100,"evs":{"hp":16,"sp":240,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Fire Blast","Thunderbolt","Focus Blast","Hidden Power Ice"]},
 		"UU Choice": {"level":100,"evs":{"df":40,"sp":216,"sa":252},"nature":"Modest","item":"Choice Scarf","moves":["Fire Blast","Thunderbolt","Focus Blast","Hidden Power Ice"]},
@@ -1263,6 +1311,7 @@ var SETDEX_DPP = {
 		"LC Attacker": {"level":5,"evs":{"hp":236,"sa":240},"nature":"Quiet","ability":"Magnet Pull","item":"Life Orb","moves":["Thunderbolt","Flash Cannon","Hidden Power Fire","Explosion"]},
 	},
 	"Magneton": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Naive","ability":"Magnet Pull","item":"Choice Scarf","moves":["Thunderbolt","Flash Cannon","Explosion","Hidden Power Grass"]},
 		"UU Steel Killer (Substitute)": {"level":100,"evs":{"hp":108,"sp":148,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Substitute","Thunderbolt","Hidden Power Fire","Magnet Rise"]},
 		"UU Special Attacker": {"level":100,"evs":{"hp":96,"sp":160,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Charge Beam","Thunderbolt","Hidden Power Grass","Substitute"]},
 		"UU Choice Scarf": {"level":100,"evs":{"at":56,"sp":228,"sa":224},"nature":"Naive","ability":"Magnet Pull","item":"Choice Scarf","moves":["Thunderbolt","Hidden Power Ice","Flash Cannon","Explosion"]},
@@ -1298,6 +1347,7 @@ var SETDEX_DPP = {
 		"Uber Bulky Calm Mind": {"level":100,"evs":{"hp":252,"sp":252,"sa":4},"nature":"Timid","ability":"Hydration","item":"Leftovers","moves":["Calm Mind","Rest","Surf","Ice Beam"]},
 	},
 	"Manectric": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Static","item":"Choice Scarf","moves":["Thunderbolt","Hidden Power Grass","Switcheroo","Overheat"]},
 		"UU Life Orb": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Static","item":"Life Orb","moves":["Thunderbolt","Flamethrower","Hidden Power Grass","Charge Beam"]},
 		"UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Static","item":"Choice Specs","moves":["Thunderbolt","Overheat","Hidden Power Grass","Switcheroo"]},
 	},
@@ -1305,6 +1355,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":196,"hp":116,"sp":196},"nature":"Adamant","item":"Choice Scarf","moves":["Close Combat","U-turn","Payback","Ice Punch"]},
 	},
 	"Mantine": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Leftovers","moves":["Sleep Talk","Surf","Rest","Toxic"]},
 		"UU Specially Defensive RestTalk": {"level":100,"evs":{"sd":216,"hp":252,"sa":40},"nature":"Calm","ability":"Water Absorb","item":"Leftovers","moves":["Rest","Sleep Talk","Surf","Hidden Power Flying"]},
 		"UU Physically Defensive RestTalk": {"level":100,"evs":{"df":240,"hp":252,"sa":16},"nature":"Calm","ability":"Water Absorb","item":"Life Orb","moves":["Rest","Sleep Talk","Surf","Hidden Power Flying"]},
 	},
@@ -1318,20 +1369,24 @@ var SETDEX_DPP = {
 		"LC Choice Specs": {"level":5,"evs":{"sd":76,"df":40,"hp":156,"sa":236},"nature":"Modest","ability":"Static","item":"Choice Specs","moves":["Discharge","Hidden Power Ice","Power Gem","Signal Beam"]},
 	},
 	"Marowak": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Brave","ability":"Rock Head","item":"Thick Club","moves":["Double-Edge","Fire Punch","Earthquake","Thunder Punch"]},
 		"UU Substitute + 3 Attacks": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Rock Head","item":"Thick Club","moves":["Substitute","Earthquake","Double-Edge","Fire Punch"]},
 	},
 	"Masquerain": {
 		"UU Agility": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Intimidate","item":"Leftovers","moves":["Agility","Air Slash","Hydro Pump","Baton Pass"]},
 	},
 	"Mawile": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Intimidate","item":"Leftovers","moves":["Iron Head","Baton Pass","Pain Split","Iron Defense"]},
 		"UU Baton Pass": {"level":100,"evs":{"df":28,"hp":252,"sp":228},"nature":"Jolly","ability":"Intimidate","item":"Leftovers","moves":["Swords Dance","Baton Pass","Taunt","Substitute"]},
 	},
 	"Medicham": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Pure Power","item":"Choice Scarf","moves":["High Jump Kick","Psycho Cut","Ice Punch","Thunder Punch"]},
 		"UU Choice Scarf": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Pure Power","item":"Choice Scarf","moves":["High Jump Kick","Psycho Cut","Ice Punch","Trick"]},
 		"UU Life Orb": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Pure Power","item":"Life Orb","moves":["High Jump Kick","Zen Headbutt","Fake Out","Bullet Punch"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Pure Power","item":"Choice Band","moves":["High Jump Kick","Psycho Cut","Thunder Punch","Ice Punch"]},
 	},
 	"Meganium": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sp":4},"nature":"Calm","ability":"Overgrow","item":"Leftovers","moves":["Synthesis","Leech Seed","Seed Bomb","Swords Dance"]},
 		"UU Support": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Overgrow","item":"Leftovers","moves":["Energy Ball","Aromatherapy","Synthesis","Leech Seed"]},
 		"UU Dual Screens": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Overgrow","item":"Light Clay","moves":["Light Screen","Reflect","Energy Ball","Synthesis"]},
 		"UU Swords Dance": {"level":100,"evs":{"at":160,"hp":252,"sp":96},"nature":"Adamant","ability":"Overgrow","item":"Leftovers","moves":["Swords Dance","Synthesis","Seed Bomb","Earthquake"]},
@@ -1362,6 +1417,7 @@ var SETDEX_DPP = {
 		"OU Trick + Iron Ball": {"level":100,"evs":{"at":252,"hp":236,"sp":20},"nature":"Adamant","ability":"Clear Body","item":"Iron Ball","moves":["Trick","Earthquake","Meteor Mash","Explosion"]},
 	},
 	"Metang": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":20,"at":56,"hp":248,"sp":184},"nature":"Jolly","ability":"Clear Body","item":"Leftovers","moves":["Meteor Mash","Stealth Rock","Zen Headbutt","Earthquake"]},
 		"UU Dual Screens": {"level":100,"evs":{"sd":208,"df":48,"hp":252},"nature":"Careful","ability":"Clear Body","item":"Light Clay","moves":["Light Screen","Reflect","Stealth Rock","Explosion"]},
 	},
 	"Mew": {
@@ -1408,6 +1464,9 @@ var SETDEX_DPP = {
 		"UU Defensive Baton Pass": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","item":"Leftovers","moves":["Baton Pass","Nasty Plot","Encore","Thunderbolt"]},
 		"UU Nasty Plot Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Nasty Plot","Encore","Thunderbolt","Hidden Power Ice"]},
 	},
+	"Misdreavus": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":236,"hp":252,"sp":20},"nature":"Bold","ability":"Levitate","item":"Leftovers","moves":["Shadow Ball","Will-O-Wisp","Pain Split","Memento"]},
+	},
 	"Mismagius": {
 		"UU Nasty Plot": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Leftovers","moves":["Substitute","Nasty Plot","Shadow Ball","Thunderbolt"]},
 		"UU Lead": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Taunt","Will-O-Wisp","Shadow Ball","Thunderbolt"]},
@@ -1439,6 +1498,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":196,"hp":116,"sp":196},"nature":"Jolly","ability":"Torrent","item":"Choice Scarf","moves":["Waterfall","Rock Slide","Double-Edge","Superpower"]},
 	},
 	"Muk": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":188,"at":68,"hp":252},"nature":"Adamant","ability":"Sticky Hold","item":"Black Sludge","moves":["Poison Jab","Gunk Shot","Explosion","Brick Break"]},
 		"UU Curse": {"level":100,"evs":{"sd":176,"df":80,"hp":252},"nature":"Careful","ability":"Sticky Hold","item":"Black Sludge","moves":["Curse","Poison Jab","Brick Break","Explosion"]},
 		"UU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Sticky Hold","item":"Choice Band","moves":["Poison Jab","Brick Break","Ice Punch","Explosion"]},
 		"UU SubPunch": {"level":100,"evs":{"df":40,"at":252,"hp":212,"sp":4},"nature":"Adamant","ability":"Sticky Hold","item":"Black Sludge","moves":["Substitute","Focus Punch","Poison Jab","Ice Punch"]},
@@ -1465,6 +1525,7 @@ var SETDEX_DPP = {
 		"UU Physical Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Poison Point","item":"Life Orb","moves":["Earthquake","Stone Edge","Megahorn","Sucker Punch"]},
 	},
 	"Nidoqueen": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Poison Point","item":"Black Sludge","moves":["Stealth Rock","Toxic Spikes","Ice Beam","Earth Power"]},
 		"UU Support": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Poison Point","item":"Leftovers","moves":["Earth Power","Stealth Rock","Ice Beam","Toxic Spikes"]},
 		"OU Toxic Spikes": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Relaxed","ability":"Poison Point","item":"Leftovers","moves":["Toxic Spikes","Earthquake","Fire Blast","Stealth Rock"]},
 	},
@@ -1477,6 +1538,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"df":36,"at":236,"sp":196,"sa":36},"nature":"Naive","item":"Choice Scarf","moves":["Bug Bite","Night Slash","Aerial Ace","Hidden Power Ice"]},
 	},
 	"Ninetales": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Life Orb","moves":["Nasty Plot","Energy Ball","Fire Blast","Hypnosis"]},
 		"UU Lure": {"level":100,"evs":{"hp":72,"sp":220,"sa":216},"nature":"Timid","item":"Leftovers","moves":["Nasty Plot","Fire Blast","Energy Ball","Hidden Power Rock"]},
 		"UU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Nasty Plot","Fire Blast","Energy Ball","Hypnosis"]},
 		"UU Double Status": {"level":100,"evs":{"sd":104,"hp":184,"sp":220},"nature":"Timid","item":"Wide Lens","moves":["Hypnosis","Will-O-Wisp","Energy Ball","Fire Blast"]},
@@ -1549,6 +1611,7 @@ var SETDEX_DPP = {
 		"UU Physical Wall": {"level":100,"evs":{"df":204,"hp":248,"sp":56},"nature":"Bold","item":"Leftovers","moves":["Surf","Air Slash","Roost","Hidden Power Grass"]},
 	},
 	"Persian": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Technician","item":"Focus Sash","moves":["Taunt","Fake Out","U-turn","Sunny Day"]},
 		"UU Nasty Plot": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Technician","item":"Life Orb","moves":["Nasty Plot","Hypnosis","Swift","Water Pulse"]},
 		"UU Physical Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Technician","item":"Silk Scarf","moves":["Fake Out","U-turn","Hypnosis","Bite"]},
 		"UU Switcheroo": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Limber","item":"Choice Band","moves":["Switcheroo","Return","U-turn","Night Slash"]},
@@ -1575,6 +1638,7 @@ var SETDEX_DPP = {
 		"UU Nasty Plot": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","item":"Light Ball","moves":["Nasty Plot","Encore","Thunderbolt","Hidden Power Ice"]},
 	},
 	"Piloswine": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Oblivious","item":"Focus Sash","moves":["Ice Shard","Earthquake","Stealth Rock","Endeavor"]},
 		"UU Physical Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Snow Cloak","item":"Life Orb","moves":["Ice Shard","Earthquake","Substitute","Stone Edge"]},
 	},
 	"Pineco": {
@@ -1582,6 +1646,7 @@ var SETDEX_DPP = {
 		"LC Spikes": {"level":5,"evs":{"df":196,"at":76,"hp":196},"nature":"Impish","item":"Oran Berry","moves":["Spikes","Stealth Rock","Bug Bite","Explosion"]},
 	},
 	"Pinsir": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Hyper Cutter","item":"Focus Sash","moves":["X-Scissor","Stone Edge","Stealth Rock","Quick Attack"]},
 		"UU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","item":"Life Orb","moves":["Swords Dance","X-Scissor","Close Combat","Stone Edge"]},
 		"UU Attacking Lead": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","item":"Focus Sash","moves":["X-Scissor","Close Combat","Stone Edge","Stealth Rock"]},
 		"UU Choice": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Mold Breaker","item":"Choice Scarf","moves":["X-Scissor","Stone Edge","Earthquake","Close Combat"]},
@@ -1595,6 +1660,7 @@ var SETDEX_DPP = {
 		"UU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Nasty Plot","Encore","Thunderbolt","Hidden Power Ice"]},
 	},
 	"Politoed": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":248,"sp":8},"nature":"Calm","ability":"Water Absorb","item":"Leftovers","moves":["Surf","Toxic","Encore","Counter"]},
 		"UU Support": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Water Absorb","item":"Leftovers","moves":["Surf","Encore","Toxic","Ice Beam"]},
 		"UU Choice Specs": {"level":100,"evs":{"hp":84,"sp":172,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Choice Specs","moves":["Surf","Ice Beam","Hidden Power Grass","Focus Blast"]},
 	},
@@ -1604,6 +1670,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf Lead": {"level":5,"evs":{"at":196,"hp":116,"sp":196},"nature":"Jolly","ability":"Water Absorb","item":"Choice Scarf","moves":["Encore","Hypnosis","Waterfall","Return"]},
 	},
 	"Poliwrath": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Waterfall","Substitute","Toxic","Focus Punch"]},
 		"UU SubPunch": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Substitute","Focus Punch","Waterfall","Encore"]},
 		"UU Bulk Up": {"level":100,"evs":{"at":252,"hp":252,"sp":4},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Bulk Up","Waterfall","Ice Punch","Hypnosis"]},
 		"UU RestTalk": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Water Absorb","item":"Leftovers","moves":["Rest","Sleep Talk","Waterfall","Brick Break"]},
@@ -1631,6 +1698,7 @@ var SETDEX_DPP = {
 		"OU Nasty Plot": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Adaptability","item":"Life Orb","moves":["Nasty Plot","Tri Attack","Dark Pulse","Hidden Power Fighting"]},
 	},
 	"Porygon2": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Download","item":"Life Orb","moves":["Ice Beam","Thunderbolt","Recover","Tri Attack"]},
 		"UU Defensive Duck": {"level":100,"evs":{"sd":216,"hp":252,"sa":40},"nature":"Calm","item":"Leftovers","moves":["Discharge","Ice Beam","Recover","Toxic"]},
 		"UU Offensive Trick Room": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"ivs":{"sp":0},"nature":"Quiet","ability":"Download","item":"Life Orb","moves":["Trick Room","Ice Beam","Thunderbolt","Tri Attack"]},
 		"UU Life Orb Duck": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Download","item":"Life Orb","moves":["Tri Attack","Thunderbolt","Ice Beam","Recover"]},
@@ -1644,6 +1712,7 @@ var SETDEX_DPP = {
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Vital Spirit","item":"Choice Band","moves":["Close Combat","U-turn","Punishment","Ice Punch"]},
 	},
 	"Probopass": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Power Gem","Thunder Wave","Earth Power","Stealth Rock"]},
 		"UU Specially Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Magnet Pull","item":"Leftovers","moves":["Stealth Rock","Thunder Wave","Power Gem","Earth Power"]},
 		"UU Trapper": {"level":100,"evs":{"hp":172,"sp":84,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Magnet Rise","Taunt","Earth Power","Power Gem"]},
 	},
@@ -1655,6 +1724,7 @@ var SETDEX_DPP = {
 		"UU Weather Support": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Thick Fat","item":"Damp Rock","moves":["Fake Out","Sunny Day","U-turn","Taunt"]},
 	},
 	"Quagsire": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":216,"df":40,"hp":252},"nature":"Careful","ability":"Water Absorb","item":"Leftovers","moves":["Earthquake","Recover","Rock Slide","Yawn"]},
 		"UU Wall": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Water Absorb","item":"Leftovers","moves":["Recover","Earthquake","Waterfall","Toxic"]},
 		"UU Curse": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Water Absorb","item":"Leftovers","moves":["Curse","Recover","Earthquake","Waterfall"]},
 		"OU Specially Defensive": {"level":100,"evs":{"sd":200,"df":56,"hp":252},"nature":"Careful","ability":"Water Absorb","item":"Leftovers","moves":["Earthquake","Encore","Recover","Toxic"]},
@@ -1712,15 +1782,18 @@ var SETDEX_DPP = {
 		"Uber Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","item":"Choice Band","moves":["Dragon Claw","Extreme Speed","Earthquake","Outrage"]},
 	},
 	"Regice": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":8,"hp":248,"sa":252},"nature":"Quiet","ability":"Clear Body","item":"Leftovers","moves":["Ice Beam","Thunderbolt","Focus Blast","Explosion"]},
 		"UU Tank": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Calm","item":"Leftovers","moves":["Thunder Wave","Ice Beam","Thunderbolt","Seismic Toss"]},
 		"UU RestTalk": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Calm","item":"Leftovers","moves":["Rest","Sleep Talk","Ice Beam","Seismic Toss"]},
 		"UU Life Orb": {"level":100,"evs":{"at":48,"hp":32,"sp":176,"sa":252},"nature":"Modest","item":"Life Orb","moves":["Ice Beam","Thunderbolt","Focus Blast","Explosion"]},
 	},
 	"Regigigas": {
+		"NU Showdown Usage": {"level":100,"evs":{},"nature":"Hardy","ability":"Slow Start","item":"Leftovers","moves":["Earthquake","Drain Punch","Return","Brick Break"]},
 		"UU Stall": {"level":100,"evs":{"at":252,"hp":48,"sp":208},"nature":"Adamant","item":"Leftovers","moves":["Thunder Wave","Return","Substitute","Earthquake"]},
 		"UU Tank": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","item":"Leftovers","moves":["Return","Earthquake","Thunder Wave","Knock Off"]},
 	},
 	"Regirock": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":156,"at":148,"hp":204},"nature":"Adamant","ability":"Clear Body","item":"Leftovers","moves":["Stealth Rock","Earthquake","Explosion","Stone Edge"]},
 		"UU Tank": {"level":100,"evs":{"sd":156,"at":148,"hp":204},"nature":"Adamant","item":"Leftovers","moves":["Stone Edge","Earthquake","Stealth Rock","Explosion"]},
 		"UU Mono-Attacker": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","item":"Leftovers","moves":["Curse","Rock Slide","Rest","Sleep Talk"]},
 		"UU Physical Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","item":"Choice Band","moves":["Stone Edge","Earthquake","Ice Punch","Explosion"]},
@@ -1737,6 +1810,7 @@ var SETDEX_DPP = {
 		"Uber Ubers Support": {"level":100,"evs":{"sd":152,"df":80,"at":24,"hp":252},"nature":"Careful","item":"Leftovers","moves":["Stealth Rock","Thunder Wave","Ice Punch","Explosion"]},
 	},
 	"Relicanth": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":172,"sp":84},"nature":"Adamant","ability":"Rock Head","item":"Choice Band","moves":["Head Smash","Earthquake","Waterfall","Rock Polish"]},
 		"UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Rock Head","item":"Choice Band","moves":["Head Smash","Aqua Tail","Earthquake","Double-Edge"]},
 		"UU Rock Polish": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Rock Head","item":"Life Orb","moves":["Rock Polish","Head Smash","Waterfall","Earthquake"]},
 		"UU Rain Dance Physical Attacker": {"level":100,"evs":{"at":252,"hp":72,"sp":184},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Head Smash","Aqua Tail","Earthquake","Rain Dance"]},
@@ -1745,6 +1819,9 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"sp":236,"sa":240},"nature":"Timid","ability":"Sniper","item":"Choice Scarf","moves":["Water Spout","Surf","Ice Beam","Hidden Power Ground"]},
 		"LC Physical Choice": {"level":5,"evs":{"at":236,"sp":236},"nature":"Jolly","ability":"Hustle","item":"Choice Scarf","moves":["Waterfall","Seed Bomb","Return","Water Spout"]},
 		"LC Mixed Choice Scarf": {"level":5,"evs":{"sp":236,"sa":236},"nature":"Naughty","ability":"Hustle","item":"Choice Scarf","moves":["Waterfall","Water Spout","Seed Bomb","Fire Blast"]},
+	},
+	"Rhydon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":248,"at":16,"hp":244},"nature":"Adamant","ability":"Lightning Rod","item":"Leftovers","moves":["Earthquake","Stone Edge","Stealth Rock","Megahorn"]},
 	},
 	"Rhyhorn": {
 		"LC Rock Polish": {"level":5,"evs":{"sd":36,"at":236,"sp":236},"nature":"Jolly","ability":"Rock Head","item":"Life Orb","moves":["Rock Polish","Stone Edge","Earthquake","Megahorn"]},
@@ -1771,6 +1848,7 @@ var SETDEX_DPP = {
 		"LC Lead": {"level":5,"evs":{"sd":36,"at":196,"sp":196},"nature":"Adamant","ability":"Inner Focus","item":"Focus Sash","moves":["High Jump Kick","Bullet Punch","Crunch","Counter"]},
 	},
 	"Roselia": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":16,"df":96,"hp":248,"sa":148},"nature":"Modest","ability":"Natural Cure","item":"Black Sludge","moves":["Spikes","Giga Drain","Toxic Spikes","Sludge Bomb"]},
 		"UU Spikes": {"level":100,"evs":{"sd":208,"hp":240,"sp":60},"nature":"Calm","ability":"Natural Cure","item":"Leftovers","moves":["Spikes","Stun Spore","Synthesis","Energy Ball"]},
 		"UU Offensive Spikes": {"level":100,"evs":{"hp":252,"sp":136,"sa":120},"nature":"Modest","ability":"Natural Cure","item":"Leftovers","moves":["Toxic Spikes","Sleep Powder","Leaf Storm","Sludge Bomb"]},
 	},
@@ -1847,6 +1925,7 @@ var SETDEX_DPP = {
 		"LC Swords Dance": {"level":5,"evs":{"sd":36,"at":236,"hp":40,"sp":196},"nature":"Adamant","item":"Oran Berry","moves":["Swords Dance","Earthquake","Rock Slide","Night Slash"]},
 	},
 	"Sandslash": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Sand Veil","item":"Leftovers","moves":["Earthquake","Rapid Spin","Stealth Rock","Night Slash"]},
 		"UU Bulky Swords Dance": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","item":"Leftovers","moves":["Swords Dance","Rapid Spin","Earthquake","Night Slash"]},
 		"UU Offensive Swords Dance": {"level":100,"evs":{"at":252,"hp":44,"sp":212},"nature":"Adamant","item":"Bright Powder","moves":["Swords Dance","Earthquake","Stone Edge","Substitute"]},
 		"UU Support": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","item":"Leftovers","moves":["Stealth Rock","Rapid Spin","Earthquake","Night Slash"]},
@@ -1895,6 +1974,7 @@ var SETDEX_DPP = {
 		"UU Choice Scarf": {"level":100,"evs":{"at":252,"hp":12,"sp":244},"nature":"Jolly","item":"Choice Scarf","moves":["Poison Jab","Earthquake","Crunch","Switcheroo"]},
 	},
 	"Sharpedo": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Rough Skin","item":"Life Orb","moves":["Crunch","Waterfall","Aqua Jet","Substitute"]},
 		"UU Attacking Lead": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Focus Sash","moves":["Crunch","Waterfall","Aqua Jet","Taunt"]},
 		"UU Physical Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","item":"Life Orb","moves":["Waterfall","Crunch","Earthquake","Substitute"]},
 		"UU Special Attacker": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Surf","Ice Beam","Hidden Power Grass","Substitute"]},
@@ -1928,6 +2008,7 @@ var SETDEX_DPP = {
 		"LC Support": {"level":5,"evs":{"sd":212,"df":52,"at":20,"hp":196,"sa":20},"nature":"Sassy","item":"Oran Berry","moves":["Stealth Rock","Earthquake","Ice Beam","Thunderbolt"]},
 	},
 	"Shiftry": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":180,"sp":252,"sa":76},"nature":"Lonely","ability":"Chlorophyll","item":"Life Orb","moves":["Sucker Punch","Dark Pulse","Leaf Storm","Explosion"]},
 		"UU Swords Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Chlorophyll","item":"Life Orb","moves":["Swords Dance","Sucker Punch","Seed Bomb","Low Kick"]},
 		"UU Nasty Plot": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Life Orb","moves":["Nasty Plot","Solar Beam","Hidden Power Fire","Dark Pulse"]},
 		"UU Attacking Lead": {"level":100,"evs":{"at":116,"sp":140,"sa":252},"nature":"Rash","ability":"Early Bird","item":"Focus Sash","moves":["Low Kick","Leaf Storm","Dark Pulse","Explosion"]},
@@ -1966,6 +2047,7 @@ var SETDEX_DPP = {
 		"LC Swords Dance": {"level":5,"evs":{"sd":236,"df":36,"at":196,"hp":36},"nature":"Adamant","ability":"Battle Armor","item":"Oran Berry","moves":["Swords Dance","Crunch","Cross Poison","Aqua Tail"]},
 	},
 	"Skuntank": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Aftermath","item":"Life Orb","moves":["Sucker Punch","Explosion","Pursuit","Crunch"]},
 		"UU Trapper": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Aftermath","item":"Life Orb","moves":["Pursuit","Explosion","Taunt","Sucker Punch"]},
 		"UU Wallbreaker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Aftermath","item":"Life Orb","moves":["Sucker Punch","Explosion","Poison Jab","Crunch"]},
 	},
@@ -1985,6 +2067,7 @@ var SETDEX_DPP = {
 		"OU Choice Specs": {"level":100,"evs":{"df":4,"hp":252,"sa":252},"nature":"Modest","ability":"Own Tempo","item":"Choice Specs","moves":["Surf","Psychic","Trick","Fire Blast"]},
 	},
 	"Slowking": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":112,"df":144,"hp":252},"nature":"Calm","ability":"Own Tempo","item":"Leftovers","moves":["Surf","Psychic","Slack Off","Thunder Wave"]},
 		"UU Bulky Water": {"level":100,"evs":{"sd":112,"df":144,"hp":252},"nature":"Calm","ability":"Own Tempo","item":"Leftovers","moves":["Surf","Psychic","Slack Off","Toxic"]},
 		"UU Defensive Trick Room": {"level":100,"evs":{"sd":112,"df":144,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Own Tempo","item":"Leftovers","moves":["Trick Room","Surf","Psychic","Slack Off"]},
 		"UU Offensive Trick Room": {"level":100,"evs":{"df":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Own Tempo","item":"Life Orb","moves":["Trick Room","Nasty Plot","Psychic","Surf"]},
@@ -2009,6 +2092,7 @@ var SETDEX_DPP = {
 		"LC Choice Scarf": {"level":5,"evs":{"sp":236,"sa":240},"nature":"Modest","ability":"Forewarn","item":"Choice Scarf","moves":["Blizzard","Psychic","Hidden Power Ground","Ice Beam"]},
 	},
 	"Sneasel": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Choice Band","moves":["Pursuit","Ice Punch","Ice Shard","Punishment"]},
 		"UU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","item":"Choice Band","moves":["Ice Shard","Pursuit","Low Kick","Punishment"]},
 		"UU Attacking Lead": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Focus Sash","moves":["Fake Out","Counter","Taunt","Pursuit"]},
 		"UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","item":"Life Orb","moves":["Swords Dance","Ice Shard","Low Kick","Punishment"]},
@@ -2037,6 +2121,7 @@ var SETDEX_DPP = {
 		"LC Tank": {"level":5,"evs":{"sd":116,"df":196,"hp":196},"nature":"Impish","ability":"Intimidate","item":"Oran Berry","moves":["Thunder Wave","Return","Crunch","Fire Punch"]},
 	},
 	"Solrock": {
+		"NU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Brave","ability":"Levitate","item":"Focus Sash","moves":["Explosion","Stealth Rock","Reflect","Light Screen"]},
 		"UU Rock Polish + Baton Pass": {"level":100,"evs":{"df":28,"hp":252,"sp":228},"nature":"Impish","item":"Leftovers","moves":["Rock Polish","Baton Pass","Stone Edge","Explosion"]},
 		"UU Trick Room": {"level":100,"evs":{"df":4,"at":252,"hp":252},"ivs":{"sp":0},"nature":"Brave","item":"Leftovers","moves":["Trick Room","Explosion","Stealth Rock","Stone Edge"]},
 	},
@@ -2173,6 +2258,7 @@ var SETDEX_DPP = {
 		"OU Knock it Off, Mojonbo Rules Here! (Physical Tank)": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","item":"Leftovers","moves":["Sleep Powder","Knock Off","Power Whip","Earthquake"]},
 	},
 	"Tauros": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Earthquake","Stone Edge","Double-Edge","Pursuit"]},
 		"UU All-Out Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Double-Edge","Earthquake","Stone Edge","Payback"]},
 		"UU Anger Point": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Anger Point","item":"Salac Berry","moves":["Substitute","Return","Earthquake","Payback"]},
 	},
@@ -2202,12 +2288,14 @@ var SETDEX_DPP = {
 		"LC ParaFlinch": {"level":5,"evs":{"df":76,"at":196,"hp":236},"nature":"Adamant","ability":"Serene Grace","item":"Oran Berry","moves":["Body Slam","Headbutt","Fire Blast","Soft-Boiled"]},
 	},
 	"Togetic": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":138,"df":120,"hp":252},"nature":"Sassy","ability":"Serene Grace","item":"Damp Rock","moves":["Roost","Baton Pass","Rain Dance","Nasty Plot"]},
 		"UU Baton Pass": {"level":100,"evs":{"sd":172,"hp":252,"sp":84},"nature":"Calm","item":"Leftovers","moves":["Baton Pass","Nasty Plot","Roost","Hidden Power Flying"]},
 	},
 	"Torchic": {
 		"LC Mixed Attacker": {"level":5,"evs":{"sd":36,"at":36,"sp":236,"sa":200},"nature":"Hasty","item":"Life Orb","moves":["Fire Blast","Hidden Power Grass","Rock Slide","Quick Attack"]},
 	},
 	"Torkoal": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Relaxed","ability":"White Smoke","item":"Leftovers","moves":["Rapid Spin","Lava Plume","Stealth Rock","Explosion"]},
 		"UU Support": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","item":"Leftovers","moves":["Stealth Rock","Rapid Spin","Lava Plume","Yawn"]},
 	},
 	"Torterra": {
@@ -2251,6 +2339,7 @@ var SETDEX_DPP = {
 		"LC Mixed Attacker": {"level":5,"evs":{"df":4,"at":216,"sa":240},"ivs":{"at":30,"sp":2,"sa":30},"nature":"Quiet","item":"Life Orb","moves":["Seed Bomb","Earth Power","Hidden Power Fire","Crunch"]},
 	},
 	"Typhlosion": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Choice Scarf","moves":["Focus Blast","Eruption","Fire Blast","Hidden Power Grass"]},
 		"UU Sunny Day Special Attacker": {"level":100,"evs":{"sd":36,"sp":220,"sa":252},"nature":"Timid","item":"Life Orb","moves":["Sunny Day","Fire Blast","Solar Beam","Hidden Power Rock"]},
 		"UU Choice Scarf": {"level":100,"evs":{"hp":32,"sp":224,"sa":252},"nature":"Modest","item":"Choice Scarf","moves":["Eruption","Focus Blast","Hidden Power Rock","Fire Blast"]},
 		"UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","item":"Choice Specs","moves":["Overheat","Focus Blast","Hidden Power Grass","Fire Blast"]},
@@ -2302,6 +2391,7 @@ var SETDEX_DPP = {
 		"OU Baton Pass": {"level":100,"evs":{"df":128,"hp":252,"sp":128},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Baton Pass","Substitute","Acid Armor","Surf"]},
 	},
 	"Venomoth": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Tinted Lens","item":"Choice Specs","moves":["Bug Buzz","Sleep Powder","U-turn","Psychic"]},
 		"UU Life Orb": {"level":100,"evs":{"hp":8,"sp":252,"sa":248},"nature":"Timid","ability":"Tinted Lens","item":"Life Orb","moves":["Bug Buzz","Psychic","Sleep Powder","Roost"]},
 		"UU Choice": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Tinted Lens","item":"Choice Specs","moves":["Bug Buzz","Psychic","U-turn","Sleep Powder"]},
 		"UU Support": {"level":100,"evs":{"hp":156,"sp":232,"sa":120},"nature":"Timid","ability":"Tinted Lens","item":"Leftovers","moves":["Toxic Spikes","Sleep Powder","Bug Buzz","Psychic"]},
@@ -2327,6 +2417,7 @@ var SETDEX_DPP = {
 		"UU Bulky Bee": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Careful","item":"Leftovers","moves":["Attack Order","Toxic","Substitute","Roost"]},
 	},
 	"Victreebel": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Life Orb","moves":["Sleep Powder","Sludge Bomb","Sucker Punch","Solar Beam"]},
 		"UU Special Sweeper": {"level":100,"evs":{"hp":28,"sp":228,"sa":252},"nature":"Modest","item":"Life Orb","moves":["Solar Beam","Weather Ball","Sleep Powder","Hidden Power Rock"]},
 		"UU Swords Dance": {"level":100,"evs":{"at":252,"hp":104,"sp":152},"nature":"Adamant","item":"Life Orb","moves":["Swords Dance","Leaf Blade","Sucker Punch","Sleep Powder"]},
 	},
@@ -2377,6 +2468,7 @@ var SETDEX_DPP = {
 		"OU Tank": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Levitate","item":"Leftovers","moves":["Fire Blast","Thunderbolt","Pain Split","Will-O-Wisp"]},
 	},
 	"Whiscash": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Anticipation","item":"Life Orb","moves":["Earthquake","Dragon Dance","Stone Edge","Waterfall"]},
 		"UU Dragon Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Anticipation","item":"Life Orb","moves":["Dragon Dance","Waterfall","Earthquake","Bounce"]},
 	},
 	"Whismur": {

--- a/js/data/setdex_gsc.js
+++ b/js/data/setdex_gsc.js
@@ -11,6 +11,7 @@ var SETDEX_GSC = {
 		"OU Offensive": {"level":100,"item":"Leftovers","moves":["Recover","Thunder Wave","Fire Punch","Psychic"]},
 	},
 	"Ampharos": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Fire Punch","Thunder","Rest"]},
 		"OU Lead / Cleaner": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Fire Punch","Thunder Wave","Dynamic Punch"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Fire Punch","Rest","Sleep Talk"]},
 	},
@@ -18,6 +19,7 @@ var SETDEX_GSC = {
 		"OU Glare": {"level":100,"item":"Leftovers","moves":["Sludge Bomb","Glare","Earthquake","Giga Drain"]},
 	},
 	"Arcanine": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Fire Blast","Extreme Speed","Flamethrower","Crunch"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Fire Blast","Hidden Power Fighting","Rest","Sleep Talk"]},
 	},
 	"Ariados": {
@@ -41,6 +43,7 @@ var SETDEX_GSC = {
 		"OU Double Powder": {"level":100,"item":"Leftovers","moves":["Sleep Powder","Stun Spore","Moonlight","Razor Leaf"]},
 	},
 	"Blastoise": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Surf","Rest","Rapid Spin","Ice Beam"]},
 		"OU Bulky Water": {"level":100,"item":"Leftovers","moves":["Surf","Rest","Reflect","Rapid Spin"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Surf","Ice Beam"]},
 	},
@@ -52,6 +55,9 @@ var SETDEX_GSC = {
 	},
 	"Celebi": {
 		"Uber Standard": {"level":100,"item":"Leftovers","moves":["Heal Bell","Recover","Leech Seed","Psychic"]},
+	},
+	"Chansey": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Soft-Boiled","Heal Bell","Toxic","Thunder Wave"]},
 	},
 	"Charizard": {
 		"OU BellyZard (Belly Drum)": {"level":100,"item":"Leftovers","moves":["Belly Drum","Earthquake","Fire Blast","Rock Slide"]},
@@ -69,6 +75,7 @@ var SETDEX_GSC = {
 		"OU Support": {"level":100,"item":"Leftovers","moves":["Surf","Recover","Toxic","Mirror Coat"]},
 	},
 	"Crobat": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Toxic","Confuse Ray","Haze","Whirlwind"]},
 		"OU Offensive": {"level":100,"item":"Leftovers","moves":["Wing Attack","Hidden Power Ground","Toxic","Screech"]},
 		"OU Toxic Staller": {"level":100,"item":"Leftovers","moves":["Confuse Ray","Toxic","Wing Attack","Mean Look"]},
 	},
@@ -83,6 +90,7 @@ var SETDEX_GSC = {
 		"OU The Set": {"level":100,"item":"Metal Powder","moves":["Transform"]},
 	},
 	"Dodrio": {
+		"UU Showdown Usage": {"level":100,"item":"","moves":["Drill Peck","Flail","Endure","Double-Edge"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Double-Edge","Drill Peck","Rest","Sleep Talk"]},
 	},
 	"Donphan": {
@@ -97,14 +105,17 @@ var SETDEX_GSC = {
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Earthquake","Rock Slide","Sludge Bomb","Substitute"]},
 	},
 	"Dunsparce": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Curse","Return","Rest","Sleep Talk"]},
 		"OU Swagger + Psych Up": {"level":100,"item":"Leftovers","moves":["Glare","Swagger","Psych Up","Headbutt"]},
 		"OU SunnyBeam": {"level":100,"item":"Leftovers","moves":["Sunny Day","Solar Beam","Flamethrower","Return"]},
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Curse","Return","Rest","Sleep Talk"]},
 	},
 	"Electabuzz": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Cross Chop","Ice Punch","Thunderbolt","Fire Punch"]},
 		"OU All-Out Attacker": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Ice Punch","Cross Chop","Fire Punch"]},
 	},
 	"Electrode": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Explosion","Thunder Wave","Thunder","Thunderbolt"]},
 		"OU Exploder": {"level":100,"item":"Leftovers","moves":["Thunder Wave","Thunderbolt","Explosion","Hidden Power Grass"]},
 		"OU Support": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Light Screen","Rest","Thunder Wave"]},
 	},
@@ -127,10 +138,12 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Double-Edge","Drill Peck"]},
 	},
 	"Feraligatr": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Hydro Pump","Crunch","Surf"]},
 		"OU Mixed Sweeper": {"level":100,"item":"Leftovers","moves":["Hydro Pump","Earthquake","Rock Slide","Curse"]},
 		"OU Special Sweeper": {"level":100,"item":"Leftovers","moves":["Hydro Pump","Ice Beam","Crunch","Hidden Power Grass"]},
 	},
 	"Flareon": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Fire Blast","Shadow Ball","Baton Pass","Growth"]},
 		"OU All-Out Attacker": {"level":100,"item":"Leftovers","moves":["Fire Blast","Shadow Ball","Return","Hidden Power Rock"]},
 	},
 	"Forretress": {
@@ -144,23 +157,34 @@ var SETDEX_GSC = {
 		"OU Perish Trapper": {"level":100,"item":"Leftovers","moves":["Perish Song","Mean Look","Protect","Thunderbolt"]},
 	},
 	"Girafarig": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Baton Pass","Agility","Psychic","Amnesia"]},
 		"OU Baton Pass": {"level":100,"item":"Leftovers","moves":["Agility","Baton Pass","Thunder","Psychic"]},
 	},
 	"Gligar": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Wing Attack","Rest","Sludge Bomb"]},
 		"OU Screech": {"level":100,"item":"Leftovers","moves":["Screech","Earthquake","Wing Attack","Counter"]},
 		"OU Thief": {"level":100,"item":"Mint Berry","moves":["Earthquake","Wing Attack","Rest","Thief"]},
 	},
 	"Golduck": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Cross Chop","Surf","Hypnosis","Hidden Power Electric"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Cross Chop","Hypnosis","Surf","Ice Beam"]},
 	},
 	"Golem": {
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Rock Slide","Earthquake","Curse","Explosion"]},
 	},
 	"Granbull": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Return","Curse"]},
 		"OU Heal Bell": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Return","Heal Bell"]},
 	},
+	"Graveler": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Rapid Spin","Hidden Power Rock","Explosion"]},
+	},
 	"Gyarados": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Hydro Pump","Hidden Power Flying","Substitute","Swagger"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Double-Edge","Zap Cannon","Hydro Pump","Hidden Power Ground"]},
+	},
+	"Haunter": {
+		"UU Showdown Usage": {"level":100,"item":"","moves":["Explosion","Psychic","Thunderbolt","Destiny Bond"]},
 	},
 	"Heracross": {
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Megahorn","Rest","Sleep Talk","Earthquake"]},
@@ -169,9 +193,11 @@ var SETDEX_GSC = {
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["High Jump Kick","Return","Counter","Hidden Power Ghost"]},
 	},
 	"Hitmonlee": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["High Jump Kick","Meditate","Mach Punch","Reversal"]},
 		"OU Meditate": {"level":100,"item":"Leftovers","moves":["High Jump Kick","Meditate","Hidden Power Rock","Return"]},
 	},
 	"Hitmontop": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["High Jump Kick","Curse","Rapid Spin","Hidden Power Ghost"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["High Jump Kick","Curse","Counter","Hidden Power Ghost"]},
 	},
 	"Ho-Oh": {
@@ -184,6 +210,7 @@ var SETDEX_GSC = {
 		"OU SunnyBeam": {"level":100,"item":"Leftovers","moves":["Fire Blast","Crunch","Sunny Day","Solar Beam"]},
 	},
 	"Hypno": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Psychic","Thunder Wave","Reflect","Rest"]},
 		"OU Support": {"level":100,"item":"Leftovers","moves":["Thunder Wave","Psychic","Light Screen","Reflect"]},
 		"OU Offensive": {"level":100,"item":"Leftovers","moves":["Psychic","Thunder Punch","Ice Punch","Reflect"]},
 	},
@@ -191,6 +218,7 @@ var SETDEX_GSC = {
 		"OU Baton Pass": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Hidden Power Water","Agility","Baton Pass"]},
 	},
 	"Jumpluff": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Leech Seed","Sleep Powder","Stun Spore","Encore"]},
 		"OU Status Support": {"level":100,"item":"Leftovers","moves":["Sleep Powder","Stun Spore","Leech Seed","Encore"]},
 	},
 	"Jynx": {
@@ -199,7 +227,11 @@ var SETDEX_GSC = {
 		"OU Sleep Trapper": {"level":100,"item":"Leftovers","moves":["Ice Beam","Lovely Kiss","Mean Look","Nightmare"]},
 	},
 	"Kabutops": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Ancient Power","Swords Dance","Hydro Pump","Double-Edge"]},
 		"OU Swords Dance": {"level":100,"item":"Leftovers","moves":["Swords Dance","Ancient Power","Hydro Pump","Hidden Power Ground"]},
+	},
+	"Kadabra": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Psychic","Recover","Fire Punch","Thunder Punch"]},
 	},
 	"Kangaskhan": {
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Curse","Rest","Return","Roar"]},
@@ -213,6 +245,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Swords Dance","Double-Edge","Rest","Sleep Talk"]},
 	},
 	"Lanturn": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Surf","Thunderbolt","Rest","Sleep Talk"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Surf","Thunderbolt","Rest","Sleep Talk"]},
 		"OU Parafusion": {"level":100,"item":"Leftovers","moves":["Surf","Thunderbolt","Thunder Wave","Confuse Ray"]},
 	},
@@ -239,9 +272,11 @@ var SETDEX_GSC = {
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Curse","Rock Slide","Earthquake","Fire Blast"]},
 	},
 	"Magmar": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Fire Blast","Thunder Punch","Cross Chop","Hidden Power Water"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Fire Blast","Cross Chop","Thunder Punch","Hidden Power Water"]},
 	},
 	"Magneton": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Thunder Wave","Thunderbolt","Substitute","Hidden Power Grass"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Thunderbolt","Thunder Wave","Hidden Power Water","Substitute"]},
 	},
 	"Mantine": {
@@ -271,6 +306,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Fire Blast","Hidden Power Grass"]},
 	},
 	"Mr. Mime": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Encore","Psychic","Thunderbolt","Baton Pass"]},
 		"OU Encore Support": {"level":100,"item":"Leftovers","moves":["Psychic","Thunderbolt","Encore","Light Screen"]},
 	},
 	"Muk": {
@@ -283,9 +319,11 @@ var SETDEX_GSC = {
 		"OU Mixed Sweeper": {"level":100,"item":"Leftovers","moves":["Earthquake","Lovely Kiss","Ice Beam","Thunder"]},
 	},
 	"Nidoqueen": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Ice Beam","Thunder","Lovely Kiss"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Earthquake","Lovely Kiss","Thunder","Ice Beam"]},
 	},
 	"Ninetales": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Fire Blast","Flamethrower","Toxic","Roar"]},
 		"OU Hypnosis": {"level":100,"item":"Leftovers","moves":["Hypnosis","Toxic","Roar","Fire Blast"]},
 	},
 	"Noctowl": {
@@ -296,6 +334,7 @@ var SETDEX_GSC = {
 		"OU Mixed Sweeper": {"level":100,"item":"Leftovers","moves":["Flamethrower","Surf","Return","Ice Beam"]},
 	},
 	"Omastar": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Rest","Surf","Ice Beam","Sleep Talk"]},
 		"OU Support": {"level":100,"item":"Leftovers","moves":["Surf","Rest","Haze","Reflect"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Hydro Pump","Ice Beam"]},
 	},
@@ -312,35 +351,47 @@ var SETDEX_GSC = {
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Return","Hidden Power Flying","Toxic","Steel Wing"]},
 	},
 	"Pikachu": {
+		"UU Showdown Usage": {"level":100,"item":"Light Ball","moves":["Thunderbolt","Surf","Quick Attack","Hidden Power Ice"]},
 		"OU Light Ball": {"level":100,"item":"Light Ball","moves":["Thunderbolt","Surf","Sing","Hidden Power Fire"]},
 	},
 	"Piloswine": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Ice Beam","Rest","Sleep Talk"]},
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Earthquake","Blizzard","Curse","Roar"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Earthquake","Blizzard"]},
 	},
+	"Pineco": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Spikes","Explosion","Rapid Spin","Hidden Power Bug"]},
+	},
 	"Pinsir": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Swords Dance","Hidden Power Bug","Submission","Body Slam"]},
 		"OU Swords Dance": {"level":100,"item":"Leftovers","moves":["Swords Dance","Body Slam","Submission","Hidden Power Bug"]},
 		"OU RestTalk": {"level":100,"item":"Leftovers","moves":["Rest","Sleep Talk","Swords Dance","Body Slam"]},
 	},
 	"Politoed": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Belly Drum","Lovely Kiss","Surf","Earthquake"]},
 		"OU Belly Drum": {"level":100,"item":"Leftovers","moves":["Belly Drum","Surf","Lovely Kiss","Body Slam"]},
 	},
 	"Poliwrath": {
+		"UU Showdown Usage": {"level":100,"item":"","moves":["Belly Drum","Earthquake","Lovely Kiss","Return"]},
 		"OU Belly Drum": {"level":100,"item":"Leftovers","moves":["Belly Drum","Lovely Kiss","Hydro Pump","Body Slam"]},
 	},
 	"Porygon2": {
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Recover","Return","Curse","Ice Beam"]},
 	},
 	"Primeape": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Cross Chop","Rock Slide","Meditate","Hidden Power Bug"]},
 		"OU Physical Attacker": {"level":100,"item":"Leftovers","moves":["Cross Chop","Rock Slide","Hidden Power Bug","Meditate"]},
 	},
 	"Quagsire": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Rest","Belly Drum","Hidden Power Rock"]},
 		"OU Belly Drum": {"level":100,"item":"Leftovers","moves":["Earthquake","Hidden Power Rock","Belly Drum","Rest"]},
 	},
 	"Qwilfish": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Spikes","Sludge Bomb","Hydro Pump","Curse"]},
 		"OU Spikes": {"level":100,"item":"Leftovers","moves":["Curse","Sludge Bomb","Hydro Pump","Spikes"]},
 	},
 	"Raichu": {
+		"UU Showdown Usage": {"level":100,"item":"","moves":["Surf","Thunderbolt","Thunder Wave","Seismic Toss"]},
 		"OU Rain Dance": {"level":100,"item":"Leftovers","moves":["Thunder","Surf","Rain Dance","Substitute"]},
 		"OU Thunder Wave": {"level":100,"item":"Miracle Berry","moves":["Thunderbolt","Surf","Thunder Wave","Seismic Toss"]},
 		"OU Support": {"level":100,"item":"Leftovers","moves":["Charm","Encore","Hidden Power Water","Thunderbolt"]},
@@ -360,6 +411,7 @@ var SETDEX_GSC = {
 		"OU Curse": {"level":100,"item":"Leftovers","moves":["Earthquake","Rock Slide","Curse","Roar"]},
 	},
 	"Sandslash": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Earthquake","Swords Dance","Rock Slide","Substitute"]},
 		"OU Swords Dance": {"level":100,"item":"Leftovers","moves":["Swords Dance","Earthquake","Rock Slide","Substitute"]},
 	},
 	"Scizor": {
@@ -367,6 +419,7 @@ var SETDEX_GSC = {
 		"OU Swords Dance Sweeper": {"level":100,"item":"Leftovers","moves":["Swords Dance","Substitute","Steel Wing","Hidden Power Bug"]},
 	},
 	"Scyther": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Swords Dance","Baton Pass","Wing Attack","Hidden Power Bug"]},
 		"OU Baton Pass": {"level":100,"item":"Leftovers","moves":["Hidden Power Bug","Return","Swords Dance","Baton Pass"]},
 	},
 	"Seaking": {
@@ -374,15 +427,18 @@ var SETDEX_GSC = {
 		"OU Special Attacker": {"level":100,"item":"Leftovers","moves":["Surf","Ice Beam","Rest","Sleep Talk"]},
 	},
 	"Shuckle": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Rollout","Defense Curl","Encore","Rest"]},
 		"OU Wrap": {"level":100,"item":"Leftovers","moves":["Toxic","Wrap","Rest","Encore"]},
 	},
 	"Skarmory": {
 		"OU Physical Wall": {"level":100,"item":"Leftovers","moves":["Whirlwind","Drill Peck","Rest","Curse"]},
 	},
 	"Slowbro": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Surf","Rest","Psychic","Thunder Wave"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Surf","Psychic","Thunder Wave","Rest"]},
 	},
 	"Slowking": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Surf","Psychic","Rest","Sleep Talk"]},
 		"OU Special Attacker": {"level":100,"item":"Leftovers","moves":["Surf","Psychic","Thunder Wave","Rest"]},
 	},
 	"Smeargle": {
@@ -399,6 +455,7 @@ var SETDEX_GSC = {
 		"OU MixLax": {"level":100,"item":"Leftovers","moves":["Double-Edge","Earthquake","Fire Blast","Self-Destruct"]},
 	},
 	"Stantler": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Return","Earthquake","Confuse Ray","Hypnosis"]},
 		"OU Screen Support": {"level":100,"item":"Leftovers","moves":["Confuse Ray","Return","Reflect","Earthquake"]},
 	},
 	"Starmie": {
@@ -408,6 +465,7 @@ var SETDEX_GSC = {
 		"OU Curse + Roar": {"level":100,"item":"Leftovers","moves":["Earthquake","Curse","Roar","Explosion"]},
 	},
 	"Sudowoodo": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Rock Slide","Earthquake","Self-Destruct","Curse"]},
 		"OU Physical Attacker": {"level":100,"item":"Leftovers","moves":["Curse","Rock Slide","Earthquake","Self-Destruct"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Self-Destruct","Rock Slide","Thunder Punch","Fire Punch"]},
 	},
@@ -465,22 +523,27 @@ var SETDEX_GSC = {
 		"OU Swords Dance": {"level":100,"item":"Leftovers","moves":["Swords Dance","Body Slam","Giga Drain","Sleep Powder"]},
 	},
 	"Victreebel": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Sludge Bomb","Giga Drain","Swords Dance","Sleep Powder"]},
 		"OU Swords Dance": {"level":100,"item":"Leftovers","moves":["Sleep Powder","Swords Dance","Sludge Bomb","Giga Drain"]},
 		"OU Growth": {"level":100,"item":"Leftovers","moves":["Sleep Powder","Growth","Giga Drain","Hidden Power Fire"]},
 	},
 	"Vileplume": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Sludge Bomb","Moonlight","Swords Dance","Sleep Powder"]},
 		"OU Standard": {"level":100,"item":"Leftovers","moves":["Sleep Powder","Leech Seed","Sludge Bomb","Moonlight"]},
 	},
 	"Weezing": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Sludge Bomb","Explosion","Thunder","Pain Split"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Thunder","Fire Blast","Sludge Bomb","Explosion"]},
 	},
 	"Wigglytuff": {
+		"UU Showdown Usage": {"level":100,"item":"Leftovers","moves":["Body Slam","Rest","Sleep Talk","Curse"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Double-Edge","Ice Beam","Thunderbolt","Thunder Wave"]},
 	},
 	"Wobbuffet": {
-		"OU Oh, no! It's Wobbuffet! (Counter + Mirror Coat)": {"level":100,"item":"Leftovers","moves":["Counter","Mirror Coat","Destiny Bond","Safeguard"]},
+		"OU Oh, no! It&#39;s Wobbuffet! (Counter + Mirror Coat)": {"level":100,"item":"Leftovers","moves":["Counter","Mirror Coat","Destiny Bond","Safeguard"]},
 	},
 	"Xatu": {
+		"UU Showdown Usage": {"level":100,"item":"","moves":["Psychic","Drill Peck","Giga Drain","Thief"]},
 		"OU Mixed Attacker": {"level":100,"item":"Leftovers","moves":["Psychic","Drill Peck","Confuse Ray","Giga Drain"]},
 	},
 	"Yanma": {

--- a/js/data/setdex_rby.js
+++ b/js/data/setdex_rby.js
@@ -1,5 +1,6 @@
 var SETDEX_RBY = {
 	"Aerodactyl": {
+		"UU Showdown Usage": {"level":100,"moves":["Hyper Beam","Fire Blast","Double-Edge","Sky Attack"]},
 		"OU Physical Attacker": {"level":100,"moves":["Sky Attack","Reflect","Double-Edge","Hyper Beam"]},
 	},
 	"Alakazam": {
@@ -9,15 +10,18 @@ var SETDEX_RBY = {
 		"UU Wrapper": {"level":100,"moves":["Earthquake","Wrap","Glare","Hyper Beam"]},
 	},
 	"Arcanine": {
+		"UU Showdown Usage": {"level":100,"moves":["Fire Blast","Body Slam","Flamethrower","Hyper Beam"]},
 		"OU Anti-Lead": {"level":100,"moves":["Fire Blast","Body Slam","Hyper Beam","Reflect"]},
 	},
 	"Articuno": {
+		"UU Showdown Usage": {"level":100,"moves":["Blizzard","Ice Beam","Hyper Beam","Agility"]},
 		"OU Standard": {"level":100,"moves":["Blizzard","Agility","Double-Edge","Hyper Beam"]},
 	},
 	"Beedrill": {
 		"UU Agility + Swords Dance": {"level":100,"moves":["Twineedle","Hyper Beam","Swords Dance","Agility"]},
 	},
 	"Blastoise": {
+		"UU Showdown Usage": {"level":100,"moves":["Hydro Pump","Blizzard","Ice Beam","Earthquake"]},
 		"OU All-Out Attacker": {"level":100,"moves":["Surf","Blizzard","Body Slam","Mimic"]},
 	},
 	"Butterfree": {
@@ -27,9 +31,11 @@ var SETDEX_RBY = {
 		"OU Special Wall": {"level":100,"moves":["Ice Beam","Soft-Boiled","Thunder Wave","Thunderbolt"]},
 	},
 	"Charizard": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Fire Blast","Flamethrower","Hyper Beam"]},
 		"OU Swords Dance": {"level":100,"moves":["Fire Blast","Earthquake","Swords Dance","Body Slam"]},
 	},
 	"Clefable": {
+		"UU Showdown Usage": {"level":100,"moves":["Thunder Wave","Thunderbolt","Blizzard","Body Slam"]},
 		"OU Offensive": {"level":100,"moves":["Blizzard","Body Slam","Hyper Beam","Thunderbolt"]},
 		"OU Status Platform": {"level":100,"moves":["Blizzard","Thunder Wave","Sing","Thunder"]},
 	},
@@ -43,12 +49,15 @@ var SETDEX_RBY = {
 		"UU Transformer": {"level":100,"moves":["Transform"]},
 	},
 	"Dodrio": {
+		"UU Showdown Usage": {"level":100,"moves":["Drill Peck","Body Slam","Hyper Beam","Agility"]},
 		"OU Physical Sweeper": {"level":100,"moves":["Drill Peck","Body Slam","Hyper Beam","Mimic"]},
 	},
 	"Dragonite": {
+		"UU Showdown Usage": {"level":100,"moves":["Hyper Beam","Blizzard","Surf","Wrap"]},
 		"OU AgiliWrap": {"level":100,"moves":["Agility","Wrap","Hyper Beam","Surf"]},
 	},
 	"Dugtrio": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Rock Slide","Slash","Substitute"]},
 		"OU Physical Attacker": {"level":100,"moves":["Earthquake","Slash","Sand Attack","Substitute"]},
 	},
 	"Electabuzz": {
@@ -81,8 +90,15 @@ var SETDEX_RBY = {
 	"Golem": {
 		"OU Standard": {"level":100,"moves":["Body Slam","Earthquake","Rock Slide","Explosion"]},
 	},
+	"Graveler": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Explosion","Rock Slide","Body Slam"]},
+	},
 	"Gyarados": {
+		"UU Showdown Usage": {"level":100,"moves":["Blizzard","Hydro Pump","Thunderbolt","Surf"]},
 		"OU Mixed Attacker": {"level":100,"moves":["Blizzard","Thunderbolt","Body Slam","Hyper Beam"]},
+	},
+	"Haunter": {
+		"UU Showdown Usage": {"level":100,"moves":["Psychic","Hypnosis","Thunderbolt","Explosion"]},
 	},
 	"Hitmonchan": {
 		"UU Physical Sweeper": {"level":100,"moves":["Body Slam","Submission","Seismic Toss","Counter"]},
@@ -91,6 +107,7 @@ var SETDEX_RBY = {
 		"UU Physical Attacker": {"level":100,"moves":["Body Slam","Counter","High Jump Kick","Seismic Toss"]},
 	},
 	"Hypno": {
+		"UU Showdown Usage": {"level":100,"moves":["Psychic","Hypnosis","Thunder Wave","Rest"]},
 		"OU Support": {"level":100,"moves":["Psychic","Thunder Wave","Hypnosis","Rest"]},
 	},
 	"Jolteon": {
@@ -100,9 +117,14 @@ var SETDEX_RBY = {
 		"OU Lovely Kiss": {"level":100,"moves":["Lovely Kiss","Blizzard","Psychic","Mimic"]},
 	},
 	"Kabutops": {
+		"UU Showdown Usage": {"level":100,"moves":["Hydro Pump","Swords Dance","Blizzard","Hyper Beam"]},
 		"OU Swords Dance": {"level":100,"moves":["Swords Dance","Body Slam","Surf","Hyper Beam"]},
 	},
+	"Kadabra": {
+		"UU Showdown Usage": {"level":100,"moves":["Psychic","Recover","Thunder Wave","Reflect"]},
+	},
 	"Kangaskhan": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Body Slam","Hyper Beam","Blizzard"]},
 		"OU Physical Attacker": {"level":100,"moves":["Body Slam","Hyper Beam","Earthquake","Surf"]},
 	},
 	"Kingler": {
@@ -115,6 +137,7 @@ var SETDEX_RBY = {
 		"UU Swords Dance": {"level":100,"moves":["Swords Dance","Earthquake","Hyper Beam","Body Slam"]},
 	},
 	"Machamp": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Rock Slide","Body Slam","Hyper Beam"]},
 		"OU All-Out Attacker": {"level":100,"moves":["Body Slam","Earthquake","Hyper Beam","Submission"]},
 	},
 	"Magmar": {
@@ -137,21 +160,26 @@ var SETDEX_RBY = {
 		"Uber Defensive": {"level":100,"moves":["Psychic","Barrier","Thunder Wave","Recover"]},
 	},
 	"Moltres": {
+		"UU Showdown Usage": {"level":100,"moves":["Fire Blast","Hyper Beam","Fire Spin","Agility"]},
 		"OU Agility + Fire Spin": {"level":100,"moves":["Agility","Fire Blast","Fire Spin","Hyper Beam"]},
 	},
 	"Mr. Mime": {
+		"UU Showdown Usage": {"level":100,"moves":["Psychic","Thunderbolt","Thunder Wave","Seismic Toss"]},
 		"OU Offensive": {"level":100,"moves":["Psychic","Thunder Wave","Thunderbolt","Seismic Toss"]},
 	},
 	"Muk": {
 		"UU Physical Attacker": {"level":100,"moves":["Sludge","Body Slam","Screech","Explosion"]},
 	},
 	"Nidoking": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Thunderbolt","Rock Slide","Body Slam"]},
 		"OU Mixed Attacker": {"level":100,"moves":["Earthquake","Blizzard","Thunder","Body Slam"]},
 	},
 	"Nidoqueen": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Thunder","Fire Blast","Ice Beam"]},
 		"OU Mixed Attacker": {"level":100,"moves":["Earthquake","Blizzard","Thunderbolt","Body Slam"]},
 	},
 	"Ninetales": {
+		"UU Showdown Usage": {"level":100,"moves":["Fire Blast","Confuse Ray","Body Slam","Hyper Beam"]},
 		"OU Anti-Sleep Lead": {"level":100,"moves":["Fire Blast","Body Slam","Confuse Ray","Fire Spin"]},
 	},
 	"Omastar": {
@@ -164,10 +192,15 @@ var SETDEX_RBY = {
 		"UU Spore": {"level":100,"moves":["Spore","Stun Spore","Slash","Mega Drain"]},
 	},
 	"Persian": {
+		"UU Showdown Usage": {"level":100,"moves":["Slash","Hyper Beam","Bubble Beam","Thunderbolt"]},
 		"OU Slash": {"level":100,"moves":["Slash","Bubble Beam","Hyper Beam","Thunderbolt"]},
 	},
 	"Pidgeot": {
+		"UU Showdown Usage": {"level":100,"moves":["Quick Attack","Double-Edge","Hyper Beam","Sky Attack"]},
 		"OU Standard": {"level":100,"moves":["Double-Edge","Hyper Beam","Mimic","Mirror Move"]},
+	},
+	"Pikachu": {
+		"UU Showdown Usage": {"level":100,"moves":["Thunderbolt","Thunder","Quick Attack","Surf"]},
 	},
 	"Pinsir": {
 		"UU Swords Dance": {"level":100,"moves":["Swords Dance","Hyper Beam","Body Slam","Submission"]},
@@ -185,6 +218,7 @@ var SETDEX_RBY = {
 		"UU Physical Sweeper": {"level":100,"moves":["Submission","Rock Slide","Body Slam","Focus Energy"]},
 	},
 	"Raichu": {
+		"UU Showdown Usage": {"level":100,"moves":["Thunder Wave","Thunderbolt","Surf","Thunder"]},
 		"OU Standard": {"level":100,"moves":["Thunderbolt","Thunder Wave","Surf","Body Slam"]},
 	},
 	"Rapidash": {
@@ -197,6 +231,7 @@ var SETDEX_RBY = {
 		"OU Physical Sweeper": {"level":100,"moves":["Earthquake","Rock Slide","Substitute","Body Slam"]},
 	},
 	"Sandslash": {
+		"UU Showdown Usage": {"level":100,"moves":["Earthquake","Rock Slide","Swords Dance","Hyper Beam"]},
 		"OU Swords Dance": {"level":100,"moves":["Earthquake","Swords Dance","Hyper Beam","Substitute"]},
 	},
 	"Scyther": {
@@ -227,6 +262,7 @@ var SETDEX_RBY = {
 		"OU Standard": {"level":100,"moves":["Body Slam","Hyper Beam","Earthquake","Blizzard"]},
 	},
 	"Tentacruel": {
+		"UU Showdown Usage": {"level":100,"moves":["Blizzard","Wrap","Surf","Hyper Beam"]},
 		"OU Wrap + Swords Dance": {"level":100,"moves":["Swords Dance","Wrap","Hyper Beam","Surf"]},
 	},
 	"Vaporeon": {
@@ -236,9 +272,11 @@ var SETDEX_RBY = {
 		"UU Double Powder": {"level":100,"moves":["Psychic","Mega Drain","Sleep Powder","Stun Spore"]},
 	},
 	"Venusaur": {
+		"UU Showdown Usage": {"level":100,"moves":["Sleep Powder","Razor Leaf","Leech Seed","Body Slam"]},
 		"OU Sleep Powder": {"level":100,"moves":["Razor Leaf","Sleep Powder","Swords Dance","Body Slam"]},
 	},
 	"Victreebel": {
+		"UU Showdown Usage": {"level":100,"moves":["Sleep Powder","Razor Leaf","Stun Spore","Wrap"]},
 		"OU Swords Dance": {"level":100,"moves":["Razor Leaf","Swords Dance","Sleep Powder","Hyper Beam"]},
 		"OU Wrapper": {"level":100,"moves":["Razor Leaf","Stun Spore","Wrap","Hyper Beam"]},
 	},

--- a/js/data/setdex_rse.js
+++ b/js/data/setdex_rse.js
@@ -1,4 +1,7 @@
 var SETDEX_ADV = {
+	"Abra": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Synchronize","item":"Twisted Spoon","moves":["Psychic","Fire Punch","Ice Punch","Thunder Punch"]},
+	},
 	"Absol": {
 		"UU Swords Dance + Baton Pass": {"level":100,"evs":{"at":32,"hp":252,"sp":224},"nature":"Adamant","item":"Leftovers","moves":["Swords Dance","Shadow Ball","Hidden Power Fighting","Baton Pass"]},
 		"OU Calm Mind + Baton Pass": {"level":100,"evs":{"hp":252,"sp":216,"sa":40},"nature":"Timid","item":"Leftovers","moves":["Calm Mind","Thunderbolt","Ice Beam","Baton Pass"]},
@@ -35,6 +38,7 @@ var SETDEX_ADV = {
 		"OU SubPunch": {"level":100,"evs":{"at":156,"hp":252,"sa":100},"nature":"Quiet","item":"Leftovers","moves":["Focus Punch","Thunderbolt","Substitute","Thunder Wave"]},
 	},
 	"Arbok": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Earthquake","Sludge Bomb","Rock Slide","Glare"]},
 		"UU Glare": {"level":100,"evs":{"at":252,"hp":148,"sp":108},"nature":"Adamant","ability":"Intimidate","item":"Leftovers","moves":["Glare","Sludge Bomb","Earthquake","Rock Slide"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Sludge Bomb","Earthquake","Rock Slide","Hidden Power Ghost"]},
 		"OU Glare": {"level":100,"evs":{"at":252,"hp":148,"sp":108},"nature":"Adamant","ability":"Intimidate","item":"Leftovers","moves":["Glare","Sludge Bomb","Earthquake","Rock Slide"]},
@@ -78,6 +82,7 @@ var SETDEX_ADV = {
 		"NU Endeavor": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","item":"Liechi Berry","moves":["Endeavor","Substitute","Hidden Power Bug","Sludge Bomb"]},
 	},
 	"Bellossom": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Leftovers","moves":["Sleep Powder","Sunny Day","Solar Beam","Hidden Power Fire"]},
 		"UU SunnyBeamer": {"level":100,"evs":{"hp":8,"sp":248,"sa":252},"nature":"Modest","item":"Leftovers","moves":["Sunny Day","Solar Beam","Hidden Power Fire","Sleep Powder"]},
 		"UU Double Powder": {"level":100,"evs":{"sd":176,"hp":244,"sa":88},"nature":"Calm","item":"Leftovers","moves":["Stun Spore","Sleep Powder","Hidden Power Grass","Moonlight"]},
 	},
@@ -108,6 +113,7 @@ var SETDEX_ADV = {
 		"NU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","item":"Choice Band","moves":["Silver Wind","Aerial Ace","Sleep Powder","Hidden Power Fighting"]},
 	},
 	"Cacturne": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sand Veil","item":"Leftovers","moves":["Spikes","Leech Seed","Giga Drain","Hidden Power Dark"]},
 		"UU Destiny Bond": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","item":"Salac Berry","moves":["Endure","Destiny Bond","Focus Punch","Hidden Power Ghost"]},
 		"OU SubSeed": {"level":100,"evs":{"hp":28,"sp":228,"sa":252},"nature":"Timid","item":"Leftovers","moves":["Leech Seed","Substitute","Needle Arm","Hidden Power Ice"]},
 		"OU SubPunch": {"level":100,"evs":{"at":96,"hp":160,"sa":252},"nature":"Quiet","item":"Leftovers","moves":["Substitute","Focus Punch","Thunder Punch","Leech Seed"]},
@@ -140,11 +146,15 @@ var SETDEX_ADV = {
 		"OU Special Attacker": {"level":100,"evs":{"at":24,"sp":244,"sa":240},"nature":"Rash","item":"Leftovers","moves":["Substitute","Hidden Power Grass","Fire Blast","Focus Punch"]},
 		"OU Physical Attacker": {"level":100,"evs":{"at":252,"hp":140,"sp":116},"nature":"Lonely","item":"Leftovers","moves":["Dragon Dance","Aerial Ace","Hidden Power Grass","Fire Blast"]},
 	},
+	"Charmeleon": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Leftovers","moves":["Fire Blast","Rock Slide","Dragon Dance","Dragon Claw"]},
+	},
 	"Chimecho": {
 		"NU Calm Mind": {"level":100,"evs":{"sd":60,"df":116,"hp":252,"sa":80},"nature":"Modest","item":"Leftovers","moves":["Calm Mind","Heal Bell","Hidden Power Electric","Psychic"]},
 		"NU Support": {"level":100,"evs":{"sd":60,"df":116,"hp":252,"sa":80},"nature":"Modest","item":"Leftovers","moves":["Yawn","Reflect","Toxic","Psychic"]},
 	},
 	"Clamperl": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":252,"sp":4,"sa":252},"nature":"Modest","ability":"Shell Armor","item":"DeepSeaTooth","moves":["Ice Beam","Surf","Toxic","Hidden Power Electric"]},
 		"OU Special Sweeper": {"level":100,"evs":{"hp":252,"sp":4,"sa":252},"nature":"Modest","item":"Deep Sea Tooth","moves":["Surf","Ice Beam","Hidden Power Electric","Toxic"]},
 		"OU Staller": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Bold","item":"Deep Sea Scale","moves":["Barrier","Rest","Sleep Talk","Toxic"]},
 	},
@@ -168,6 +178,9 @@ var SETDEX_ADV = {
 	},
 	"Cloyster": {
 		"OU Utility": {"level":100,"evs":{"sd":148,"df":16,"hp":252,"sp":4,"sa":88},"nature":"Bold","item":"Leftovers","moves":["Spikes","Rapid Spin","Surf","Explosion"]},
+	},
+	"Combusken": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Naughty","ability":"Blaze","item":"Salac Berry","moves":["Fire Blast","Thunder Punch","Flamethrower","Reversal"]},
 	},
 	"Corsola": {
 		"NU Special Attacker": {"level":100,"evs":{"sd":120,"df":136,"sa":252},"nature":"Modest","ability":"Natural Cure","item":"Leftovers","moves":["Recover","Surf","Ice Beam","Toxic"]},
@@ -226,6 +239,9 @@ var SETDEX_ADV = {
 	"Dewgong": {
 		"NU Defensive": {"level":100,"evs":{"sd":16,"df":144,"hp":252,"sa":96},"nature":"Calm","item":"Leftovers","moves":["Ice Beam","Surf","Encore","Rest"]},
 	},
+	"Diglett": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Arena Trap","item":"Choice Band","moves":["Rock Slide","Earthquake","Sludge Bomb","Double-Edge"]},
+	},
 	"Ditto": {
 		"NU Transform": {"level":100,"evs":{"sd":128,"df":128,"hp":252},"nature":"Impish","item":"Metal Powder","moves":["Transform"]},
 	},
@@ -236,6 +252,9 @@ var SETDEX_ADV = {
 	"Donphan": {
 		"OU Tank": {"level":100,"evs":{"df":188,"at":44,"hp":252,"sp":24},"nature":"Impish","item":"Leftovers","moves":["Earthquake","Hidden Power Rock","Rest","Rapid Spin"]},
 		"OU Choice Band": {"level":100,"evs":{"df":216,"at":188,"hp":80,"sp":24},"nature":"Adamant","item":"Choice Band","moves":["Earthquake","Rock Slide","Hidden Power Bug","Rapid Spin"]},
+	},
+	"Dragonair": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":252,"sp":252},"nature":"Timid","ability":"Shed Skin","item":"Leftovers","moves":["Thunderbolt","Fire Blast","Thunder Wave","Ice Beam"]},
 	},
 	"Dragonite": {
 		"OU Standard Dragon Dance": {"level":100,"evs":{"at":204,"hp":52,"sp":184,"sa":68},"nature":"Lonely","item":"Leftovers","moves":["Hidden Power Flying","Earthquake","Dragon Dance","Thunder"]},
@@ -248,6 +267,7 @@ var SETDEX_ADV = {
 		"OU Trapper": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"ivs":{"sd":30,"df":30,"at":30},"nature":"Jolly","ability":"Arena Trap","item":"Choice Band","moves":["Earthquake","Rock Slide","Aerial Ace","Hidden Power Bug"]},
 	},
 	"Dunsparce": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":104,"df":64,"at":136,"hp":204},"nature":"Adamant","ability":"Serene Grace","item":"Leftovers","moves":["Rock Slide","Headbutt","Shadow Ball","Thunder Wave"]},
 		"UU Paraflinch": {"level":100,"evs":{"sd":104,"df":64,"at":136,"hp":204},"nature":"Adamant","ability":"Serene Grace","item":"Leftovers","moves":["Headbutt","Thunder Wave","Shadow Ball","Rock Slide"]},
 	},
 	"Dusclops": {
@@ -286,6 +306,7 @@ var SETDEX_ADV = {
 		"Uber SubSeed": {"level":100,"evs":{"sd":96,"hp":124,"sp":96,"sa":188},"nature":"Modest","item":"Leftovers","moves":["Substitute","Solar Beam","Leech Seed","Explosion"]},
 	},
 	"Exploud": {
+		"UU Showdown Usage": {"level":100,"evs":{"at":156,"hp":252,"sa":100},"nature":"Mild","ability":"Soundproof","item":"Leftovers","moves":["Earthquake","Shadow Ball","Flamethrower","Double-Edge"]},
 		"OU Mixed Attacker": {"level":100,"evs":{"at":180,"hp":220,"sp":108},"nature":"Adamant","item":"Leftovers","moves":["Return","Shadow Ball","Substitute","Flamethrower"]},
 	},
 	"Farfetch'd": {
@@ -303,6 +324,7 @@ var SETDEX_ADV = {
 		"OU SubPunch": {"level":100,"evs":{"df":136,"at":116,"hp":136,"sa":120},"nature":"Brave","item":"Leftovers","moves":["Substitute","Focus Punch","Surf","Rest"]},
 	},
 	"Flareon": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":146,"sa":112},"nature":"Brave","ability":"Flash Fire","item":"Leftovers","moves":["Wish","Protect","Flamethrower","Overheat"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":146,"sa":112},"nature":"Brave","item":"Choice Band","moves":["Body Slam","Overheat","Shadow Ball","Quick Attack"]},
 	},
 	"Flygon": {
@@ -337,11 +359,15 @@ var SETDEX_ADV = {
 	},
 	"Glalie": {
 		"NU Spiker": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Hasty","item":"Leftovers","moves":["Ice Beam","Explosion","Spikes","Crunch"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":72,"df":176,"hp":252,"sp":8},"nature":"Relaxed","ability":"Inner Focus","item":"Leftovers","moves":["Explosion","Spikes","Ice Beam","Protect"]},
 	},
 	"Gligar": {
 		"UU Swords Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Hyper Cutter","item":"Leftovers","moves":["Earthquake","Hidden Power Flying","Iron Tail","Swords Dance"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Hyper Cutter","item":"Choice Band","moves":["Earthquake","Hidden Power Flying","Quick Attack","Iron Tail"]},
 		"UU Swords Dance + Salac": {"level":100,"evs":{"at":252,"hp":60,"sp":196},"nature":"Adamant","ability":"Hyper Cutter","item":"Salac Berry","moves":["Earthquake","Swords Dance","Hidden Power Flying","Substitute"]},
+	},
+	"Golbat": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Leftovers","moves":["Sludge Bomb","Aerial Ace","Hidden Power Ground","Shadow Ball"]},
 	},
 	"Golduck": {
 		"UU Calm Mind": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","item":"Leftovers","moves":["Calm Mind","Surf","Hypnosis","Ice Beam"]},
@@ -364,11 +390,17 @@ var SETDEX_ADV = {
 		"OU Bulk Up": {"level":100,"evs":{"sd":12,"df":16,"at":252,"hp":172,"sp":56},"nature":"Adamant","item":"Leftovers","moves":["Bulk Up","Return","Earthquake","Rest"]},
 		"OU SubPunch": {"level":100,"evs":{"sd":24,"df":36,"at":252,"hp":196},"nature":"Adamant","item":"Leftovers","moves":["Focus Punch","Substitute","Return","Shadow Ball"]},
 	},
+	"Graveler": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":252,"sp":4},"nature":"Adamant","ability":"Rock Head","item":"Leftovers","moves":["Earthquake","Explosion","Rock Slide","Double-Edge"]},
+	},
 	"Groudon": {
 		"Uber Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","item":"Leftovers","moves":["Swords Dance","Earthquake","Hidden Power Ghost","Overheat"]},
 		"Uber Choice Band": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","item":"Choice Band","moves":["Earthquake","Rock Slide","Hidden Power Bug","Overheat"]},
 		"Uber Substitute + Salac": {"level":100,"evs":{"sd":8,"at":252,"hp":44,"sp":204},"nature":"Jolly","item":"Salac Berry","moves":["Substitute","Swords Dance","Earthquake","Hidden Power Ghost"]},
 		"Uber RestTalk": {"level":100,"evs":{"df":184,"at":72,"hp":252},"nature":"Adamant","item":"Leftovers","moves":["Rest","Sleep Talk","Earthquake","Hidden Power Ghost"]},
+	},
+	"Grovyle": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Overgrow","item":"Leftovers","moves":["Leaf Blade","Thunder Punch","Crunch","Substitute"]},
 	},
 	"Grumpig": {
 		"UU Special Sweeper": {"level":100,"evs":{"hp":200,"sp":88,"sa":220},"nature":"Calm","ability":"Thick Fat","item":"Leftovers","moves":["Calm Mind","Psychic","Hidden Power Dark","Substitute"]},
@@ -385,6 +417,10 @@ var SETDEX_ADV = {
 		"OU Choice Band": {"level":100,"evs":{"sd":116,"df":112,"at":252,"sp":28},"nature":"Adamant","ability":"Guts","item":"Choice Band","moves":["Cross Chop","Rock Slide","Hidden Power Ghost","Fake Out"]},
 		"OU Focus Punch": {"level":100,"evs":{"sd":192,"df":192,"at":96,"sp":28},"nature":"Adamant","ability":"Guts","item":"Leftovers","moves":["Focus Punch","Counter","Rock Slide","Hidden Power Ghost"]},
 	},
+	"Haunter": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Leftovers","moves":["Thunderbolt","Psychic","Substitute","Giga Drain"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Leftovers","moves":["Thunderbolt","Giga Drain","Destiny Bond","Psychic"]},
+	},
 	"Heracross": {
 		"OU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Guts","item":"Choice Band","moves":["Megahorn","Focus Punch","Rock Slide","Sleep Talk"]},
 		"OU RestTalk": {"level":100,"evs":{"at":252,"hp":192,"sp":64},"nature":"Adamant","ability":"Guts","item":"Leftovers","moves":["Megahorn","Rock Slide","Rest","Sleep Talk"]},
@@ -393,6 +429,7 @@ var SETDEX_ADV = {
 		"OU SubSalac": {"level":100,"evs":{"df":4,"at":252,"sp":252},"ivs":{"hp":30},"nature":"Adamant","ability":"Swarm","item":"Salac Berry","moves":["Substitute","Swords Dance","Megahorn","Rock Slide"]},
 	},
 	"Hitmonchan": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Keen Eye","item":"Leftovers","moves":["Hidden Power Ghost","Sky Uppercut","Mach Punch","Rock Slide"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Choice Band","moves":["Sky Uppercut","Hidden Power Ghost","Earthquake","Rock Slide"]},
 		"UU Bulk Up": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Leftovers","moves":["Sky Uppercut","Hidden Power Ghost","Earthquake","Bulk Up"]},
 	},
@@ -467,6 +504,7 @@ var SETDEX_ADV = {
 		"UU Reversal": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","item":"Salac Berry","moves":["Endure","Reversal","Return","Shadow Ball"]},
 	},
 	"Kecleon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Sassy","ability":"Color Change","item":"Leftovers","moves":["Shadow Ball","Toxic","Body Slam","Protect"]},
 		"UU RestTalk": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Careful","item":"Leftovers","moves":["Rest","Sleep Talk","Return","Brick Break"]},
 		"OU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","item":"Choice Band","moves":["Return","Shadow Ball","Focus Punch","Trick"]},
 	},
@@ -475,6 +513,7 @@ var SETDEX_ADV = {
 		"OU Dragon Dance + Flail": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Lonely","item":"Liechi Berry","moves":["Substitute","Flail","Dragon Dance","Hydro Pump"]},
 	},
 	"Kingler": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":204},"nature":"Adamant","ability":"Hyper Cutter","item":"Leftovers","moves":["Swords Dance","Body Slam","Hidden Power Ghost","Substitute"]},
 		"UU Swords Dance + Flail": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Naughty","ability":"Hyper Cutter","item":"Salac Berry","moves":["Endure","Swords Dance","Flail","Crabhammer"]},
 		"UU Knock Off": {"level":100,"evs":{"at":200,"hp":252,"sp":56},"nature":"Adamant","item":"Leftovers","moves":["Body Slam","Knock Off","Swords Dance","Crabhammer"]},
 	},
@@ -484,6 +523,9 @@ var SETDEX_ADV = {
 		"Uber Tank": {"level":100,"evs":{"df":244,"hp":240,"sp":24},"nature":"Modest","item":"Leftovers","moves":["Surf","Calm Mind","Rest","Sleep Talk"]},
 		"Uber Water Spout": {"level":100,"evs":{"df":148,"hp":108,"sa":252},"nature":"Modest","item":"Leftovers","moves":["Water Spout","Ice Beam","Rest","Sleep Talk"]},
 		"Uber Choice Band": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Brave","item":"Choice Band","moves":["Brick Break","Hidden Power Ghost","Surf","Rock Slide"]},
+	},
+	"Lairon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Sturdy","item":"Leftovers","moves":["Earthquake","Rock Slide","Iron Tail","Double-Edge"]},
 	},
 	"Lanturn": {
 		"UU RestTalk": {"level":100,"evs":{"sd":218,"hp":40,"sa":252},"nature":"Modest","ability":"Volt Absorb","item":"Leftovers","moves":["Rest","Sleep Talk","Thunderbolt","Surf"]},
@@ -516,6 +558,7 @@ var SETDEX_ADV = {
 		"NU Choice Band": {"level":100,"evs":{"at":252,"hp":168,"sp":88},"nature":"Adamant","ability":"Own Tempo","item":"Choice Band","moves":["Body Slam","Earthquake","Rock Slide","Sleep Talk"]},
 		"NU SubPunch": {"level":100,"evs":{"df":4,"at":252,"hp":252},"ivs":{"sp":0},"nature":"Brave","ability":"Own Tempo","item":"Leftovers","moves":["Substitute","Focus Punch","Body Slam","Earthquake"]},
 		"NU Curse": {"level":100,"evs":{"sd":144,"at":112,"hp":252},"nature":"Careful","ability":"Own Tempo","item":"Leftovers","moves":["Curse","Return","Rest","Earthquake"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Oblivious","item":"Leftovers","moves":["Protect","Wish","Body Slam","Heal Bell"]},
 	},
 	"Linoone": {
 		"UU Belly Drum": {"level":100,"evs":{"df":12,"at":252,"hp":108,"sp":136},"nature":"Adamant","item":"Leftovers","moves":["Belly Drum","Extreme Speed","Shadow Ball","Hidden Power Ground"]},
@@ -548,12 +591,19 @@ var SETDEX_ADV = {
 		"OU Bulk Up": {"level":100,"evs":{"at":252,"hp":128,"sp":128},"nature":"Adamant","item":"Leftovers","moves":["Bulk Up","Cross Chop","Rock Slide","Hidden Power Ghost"]},
 		"OU RestTalk": {"level":100,"evs":{"df":156,"at":96,"hp":252,"sp":4},"nature":"Adamant","item":"Leftovers","moves":["Rest","Sleep Talk","Cross Chop","Rock Slide"]},
 	},
+	"Machoke": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Guts","item":"Leftovers","moves":["Rock Slide","Earthquake","Cross Chop","Brick Break"]},
+	},
 	"Magcargo": {
 		"NU RestTalk": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Modest","ability":"Flame Body","item":"Leftovers","moves":["Rest","Sleep Talk","Flamethrower","Hidden Power Grass"]},
 		"NU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Brave","ability":"Flame Body","item":"Choice Band","moves":["Self-Destruct","Earthquake","Rock Slide","Overheat"]},
 	},
 	"Magmar": {
+		"UU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flame Body","item":"Petaya Berry","moves":["Thunder Punch","Fire Blast","Psychic","Substitute"]},
 		"OU Mixed Sweeper": {"level":100,"evs":{"at":64,"sp":192,"sa":252},"nature":"Mild","item":"Leftovers","moves":["Flamethrower","Cross Chop","Thunder Punch","Hidden Power Grass"]},
+	},
+	"Magnemite": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":220,"df":96,"sa":192},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Thunderbolt","Thunder Wave","Substitute","Hidden Power Fire"]},
 	},
 	"Magneton": {
 		"OU Offensive": {"level":100,"evs":{"hp":68,"sp":188,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Leftovers","moves":["Thunderbolt","Hidden Power Grass","Substitute","Toxic"]},
@@ -596,6 +646,9 @@ var SETDEX_ADV = {
 		"OU Mixed Attacker": {"level":100,"evs":{"at":160,"hp":188,"sa":160},"nature":"Brave","item":"Leftovers","moves":["Psychic","Hidden Power Fire","Meteor Mash","Explosion"]},
 		"OU RestTalk": {"level":100,"evs":{"sd":32,"df":40,"at":176,"hp":252,"sp":8},"nature":"Adamant","item":"Leftovers","moves":["Rest","Sleep Talk","Meteor Mash","Earthquake"]},
 		"OU 200 Metagame": {"level":100,"evs":{"at":252,"hp":160,"sp":96},"nature":"Adamant","item":"Leftovers","moves":["Meteor Mash","Earthquake","Sludge Bomb","Toxic"]},
+	},
+	"Metang": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Clear Body","item":"Leftovers","moves":["Meteor Mash","Earthquake","Explosion","Agility"]},
 	},
 	"Mew": {
 		"Uber Calm Mind + BoltBeam": {"level":100,"evs":{"hp":36,"sp":220,"sa":252},"nature":"Timid","item":"Leftovers","moves":["Calm Mind","Soft-Boiled","Thunderbolt","Ice Beam"]},
@@ -701,6 +754,7 @@ var SETDEX_ADV = {
 		"NU Skarmory Counter": {"level":100,"evs":{"df":4,"hp":252,"sa":252},"nature":"Relaxed","ability":"Magnet Pull","item":"Leftovers","moves":["Thunderbolt","Taunt","Mimic","Explosion"]},
 	},
 	"Octillery": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":196,"sa":60},"nature":"Brave","ability":"Suction Cups","item":"Leftovers","moves":["Surf","Thunder Wave","Sludge Bomb","Rock Blast"]},
 		"OU Physical Attacker": {"level":100,"evs":{"at":252,"hp":196,"sa":60},"nature":"Brave","item":"Leftovers","moves":["Sludge Bomb","Rock Blast","Surf","Hidden Power Fighting"]},
 		"OU Special Attacker": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Modest","item":"Leftovers","moves":["Surf","Ice Beam","Flamethrower","Thunder Wave"]},
 	},
@@ -728,6 +782,7 @@ var SETDEX_ADV = {
 		"NU Substitute": {"level":100,"evs":{"at":252,"hp":48,"sp":208},"nature":"Jolly","item":"Leftovers","moves":["Substitute","Return","Aerial Ace","Hidden Power Ground"]},
 	},
 	"Pikachu": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Static","item":"Light Ball","moves":["Thunderbolt","Surf","Substitute","Hidden Power Ice"]},
 		"OU Light Ball Sweeper": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","item":"Light Ball","moves":["Thunderbolt","Hidden Power Ice","Substitute","Surf"]},
 	},
 	"Piloswine": {
@@ -746,6 +801,9 @@ var SETDEX_ADV = {
 	"Politoed": {
 		"UU Special Attacker + Hypnosis": {"level":100,"evs":{"hp":252,"sp":100,"sa":156},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Surf","Hypnosis","Ice Beam","Hidden Power Grass"]},
 	},
+	"Poliwhirl": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Water Absorb","item":"Salac Berry","moves":["Earthquake","Belly Drum","Substitute","Frustration"]},
+	},
 	"Poliwrath": {
 		"UU Belly Drum": {"level":100,"evs":{"df":24,"at":252,"hp":28,"sp":204},"nature":"Jolly","ability":"Water Absorb","item":"Salac Berry","moves":["Substitute","Belly Drum","Brick Break","Hidden Power Ghost"]},
 		"UU SubPunch": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Water Absorb","item":"Leftovers","moves":["Substitute","Hypnosis","Focus Punch","Hidden Power Ghost"]},
@@ -761,9 +819,15 @@ var SETDEX_ADV = {
 		"UU Bulk Up": {"level":100,"evs":{"at":252,"hp":32,"sp":224},"nature":"Jolly","item":"Leftovers","moves":["Bulk Up","Cross Chop","Substitute","Rock Slide"]},
 		"UU Reversal": {"level":100,"evs":{"at":252,"hp":80,"sp":176},"nature":"Adamant","item":"Salac Berry","moves":["Substitute","Reversal","Focus Punch","Hidden Power Ghost"]},
 	},
+	"Pupitar": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Shed Skin","item":"Leftovers","moves":["Earthquake","Rock Slide","Dragon Dance","Hidden Power Flying"]},
+	},
 	"Quagsire": {
 		"UU Curse": {"level":100,"evs":{"sd":192,"at":64,"hp":252},"nature":"Brave","ability":"Water Absorb","item":"Leftovers","moves":["Curse","Earthquake","Ice Beam","Rest"]},
 		"UU Counter": {"level":100,"evs":{"sd":88,"df":100,"at":68,"hp":252},"nature":"Relaxed","ability":"Water Absorb","item":"Leftovers","moves":["Counter","Earthquake","Toxic","Surf"]},
+	},
+	"Quilava": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":12,"hp":60,"sp":184,"sa":252},"nature":"Timid","ability":"Blaze","item":"Petaya Berry","moves":["Substitute","Flamethrower","Hidden Power Grass","Fire Blast"]},
 	},
 	"Qwilfish": {
 		"UU Spiker": {"level":100,"evs":{"sd":24,"hp":252,"sp":232},"nature":"Jolly","ability":"Poison Point","item":"Leftovers","moves":["Substitute","Sludge Bomb","Destiny Bond","Spikes"]},
@@ -825,8 +889,10 @@ var SETDEX_ADV = {
 	"Roselia": {
 		"NU Spiker": {"level":100,"evs":{"sd":252,"hp":252,"sp":4},"nature":"Calm","ability":"Natural Cure","item":"Leftovers","moves":["Hidden Power Grass","Spikes","Leech Seed","Synthesis"]},
 		"NU SubSeed": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Natural Cure","item":"Leftovers","moves":["Magical Leaf","Hidden Power Ice","Leech Seed","Substitute"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":216,"df":40,"hp":252},"nature":"Calm","ability":"Natural Cure","item":"Leftovers","moves":["Spikes","Leech Seed","Synthesis","Stun Spore"]},
 	},
 	"Sableye": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":208,"df":48,"hp":252},"nature":"Bold","ability":"Keen Eye","item":"Leftovers","moves":["Recover","Toxic","Seismic Toss","Calm Mind"]},
 		"UU Knock Off": {"level":100,"evs":{"sd":208,"df":48,"hp":252},"nature":"Bold","item":"Leftovers","moves":["Seismic Toss","Toxic","Knock Off","Recover"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":76,"sp":180},"nature":"Adamant","item":"Choice Band","moves":["Shadow Ball","Focus Punch","Brick Break","Fake Out"]},
 		"UU Calm Mind": {"level":100,"evs":{"hp":252,"sp":176,"sa":80},"nature":"Modest","item":"Leftovers","moves":["Calm Mind","Hidden Power Dark","Water Pulse","Recover"]},
@@ -861,12 +927,16 @@ var SETDEX_ADV = {
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Choice Band","moves":["Aerial Ace","Hidden Power Rock","Silver Wind","Steel Wing"]},
 		"UU Reversal": {"level":100,"evs":{"at":252,"hp":128,"sp":128},"nature":"Adamant","item":"Salac Berry","moves":["Hidden Power Bug","Endure","Swords Dance","Reversal"]},
 	},
+	"Seadra": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Poison Point","item":"Leftovers","moves":["Ice Beam","Hydro Pump","Hidden Power Grass","Endure"]},
+	},
 	"Seaking": {
 		"NU Rain Dance Sweeper": {"level":100,"evs":{"at":184,"sp":72,"sa":252},"nature":"Mild","ability":"Swift Swim","item":"Leftovers","moves":["Rain Dance","Surf","Megahorn","Hidden Power Grass"]},
 		"NU Flail": {"level":100,"evs":{"at":252,"sp":72,"sa":184},"nature":"Lonely","ability":"Water Veil","item":"Liechi Berry","moves":["Agility","Substitute","Hydro Pump","Flail"]},
 		"NU Choice Band": {"level":100,"evs":{"at":252,"sp":108,"sa":148},"nature":"Lonely","ability":"Water Veil","item":"Choice Band","moves":["Megahorn","Ice Beam","Hydro Pump","Hidden Power Ground"]},
 	},
 	"Seviper": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Shed Skin","item":"Leftovers","moves":["Sludge Bomb","Earthquake","Glare","Substitute"]},
 		"UU Physically-oriented": {"level":100,"evs":{"at":252,"hp":116,"sp":140},"nature":"Naughty","item":"Choice Band","moves":["Sludge Bomb","Earthquake","Hidden Power Ghost","Giga Drain"]},
 		"UU Specially-oriented": {"level":100,"evs":{"hp":116,"sp":140,"sa":252},"nature":"Modest","item":"Leftovers","moves":["Crunch","Flamethrower","Hidden Power Ice","Giga Drain"]},
 	},
@@ -875,8 +945,12 @@ var SETDEX_ADV = {
 		"UU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Lonely","item":"Choice Band","moves":["Hidden Power Flying","Earthquake","Hydro Pump","Frustration"]},
 	},
 	"Shedinja": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"sp":252},"nature":"Adamant","ability":"Wonder Guard","item":"Lum Berry","moves":["Shadow Ball","Toxic","Hidden Power Bug","Swords Dance"]},
 		"UU Protect": {"level":100,"evs":{"at":252,"sp":252},"nature":"Adamant","item":"Quick Claw","moves":["Shadow Ball","Silver Wind","Swords Dance","Protect"]},
 		"UU Choice Band": {"level":100,"evs":{"at":252,"sp":252},"nature":"Adamant","item":"Choice Band","moves":["Toxic","Hidden Power Fighting","Shadow Ball","Silver Wind"]},
+	},
+	"Shelgon": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Rock Head","item":"Leftovers","moves":["Double-Edge","Dragon Dance","Brick Break","Rock Slide"]},
 	},
 	"Shiftry": {
 		"UU Choice Band": {"level":100,"evs":{"at":252,"hp":60,"sp":196},"nature":"Adamant","ability":"Early Bird","item":"Choice Band","moves":["Brick Break","Shadow Ball","Quick Attack","Explosion"]},
@@ -886,6 +960,7 @@ var SETDEX_ADV = {
 		"Uber Swords Dance": {"level":100,"evs":{"at":252,"hp":160,"sp":96},"nature":"Adamant","ability":"Chlorophyll","item":"Leftovers","moves":["Swords Dance","Shadow Ball","Brick Break","Explosion"]},
 	},
 	"Shuckle": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Careful","ability":"Sturdy","item":"Leftovers","moves":["Toxic","Rest","Sleep Talk","Substitute"]},
 		"UU Staller": {"level":100,"evs":{"sd":28,"df":228,"hp":252},"nature":"Careful","item":"Leftovers","moves":["Toxic","Encore","Protect","Wrap"]},
 		"UU Rollout": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Careful","item":"Leftovers","moves":["Defense Curl","Rollout","Rest","Toxic"]},
 	},
@@ -980,6 +1055,7 @@ var SETDEX_ADV = {
 		"OU Endeavor": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","item":"Liechi Berry","moves":["Substitute","Endeavor","Baton Pass","Return"]},
 	},
 	"Tangela": {
+		"NU Showdown Usage": {"level":100,"evs":{"hp":196,"sp":60,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Leftovers","moves":["Sleep Powder","Hidden Power Fire","Giga Drain","Sunny Day"]},
 		"UU SunnyBeam": {"level":100,"evs":{"hp":196,"sp":60,"sa":252},"nature":"Modest","item":"Leftovers","moves":["Sunny Day","Sleep Powder","Solar Beam","Hidden Power Fire"]},
 	},
 	"Tauros": {
@@ -1057,6 +1133,7 @@ var SETDEX_ADV = {
 		"UU SunnyBeam": {"level":100,"evs":{"at":152,"sp":104,"sa":252},"nature":"Rash","item":"Leftovers","moves":["Sunny Day","Solar Beam","Hidden Power Fire","Sludge Bomb"]},
 	},
 	"Vigoroth": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Vital Spirit","item":"Leftovers","moves":["Earthquake","Shadow Ball","Bulk Up","Slack Off"]},
 		"OU Flail + Reversal": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","item":"Salac Berry","moves":["Endure","Flail","Reversal","Bulk Up"]},
 		"OU SubPunch": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Adamant","item":"Salac Berry","moves":["Substitute","Bulk Up","Focus Punch","Flail"]},
 		"OU Bulk Up": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Adamant","item":"Leftovers","moves":["Bulk Up","Return","Earthquake","Slack Off"]},
@@ -1081,6 +1158,9 @@ var SETDEX_ADV = {
 		"UU Encore": {"level":100,"evs":{"sd":120,"df":136,"hp":252},"nature":"Bold","item":"Leftovers","moves":["Ice Beam","Toxic","Encore","Surf"]},
 		"UU Curse": {"level":100,"evs":{"sd":16,"at":216,"hp":224,"sa":52},"nature":"Sassy","item":"Leftovers","moves":["Curse","Earthquake","Ice Beam","Rest"]},
 	},
+	"Wartortle": {
+		"NU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Torrent","item":"Leftovers","moves":["Surf","Rapid Spin","Ice Beam","Haze"]},
+	},
 	"Weezing": {
 		"OU Defensive": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Impish","item":"Leftovers","moves":["Sludge Bomb","Haze","Will-O-Wisp","Pain Split"]},
 		"OU Offensive": {"level":100,"evs":{"at":178,"hp":252,"sp":12,"sa":68},"nature":"Brave","item":"Leftovers","moves":["Sludge Bomb","Flamethrower","Haze","Explosion"]},
@@ -1103,6 +1183,7 @@ var SETDEX_ADV = {
 		"UU Thief": {"level":100,"evs":{"hp":252,"sp":224,"sa":32},"nature":"Timid","ability":"Synchronize","item":"Lum Berry","moves":["Calm Mind","Thief","Psychic","Wish"]},
 	},
 	"Yanma": {
+		"NU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sa":252},"nature":"Naughty","ability":"Speed Boost","item":"Liechi Berry","moves":["Detect","Psychic","Silver Wind","Double-Edge"]},
 		"UU Reversal": {"level":100,"evs":{"at":252,"hp":8,"sp":248},"nature":"Adamant","ability":"Speed Boost","item":"Liechi Berry","moves":["Protect","Substitute","Reversal","Hidden Power Bug"]},
 		"UU All-Out Attacker": {"level":100,"evs":{"sd":248,"df":248,"hp":12},"nature":"Jolly","ability":"Compound Eyes","item":"Leftovers","moves":["Hypnosis","Aerial Ace","Signal Beam","Hidden Power Rock"]},
 	},

--- a/js/data/setdex_sm.js
+++ b/js/data/setdex_sm.js
@@ -23,6 +23,7 @@ var SETDEX_SM = {
 		"ORAS UU All-out Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Absolite","moves":["Knock Off","Sucker Punch","Pursuit","Superpower"]},
 	},
 	"Absol-Mega": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Magic Bounce","item":"Absolite","moves":["Knock Off","Sucker Punch","Superpower","Swords Dance"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Absolite","moves":["Swords Dance","Knock Off","Sucker Punch","Superpower"]},
 		"ORAS UU All-out Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Absolite","moves":["Knock Off","Sucker Punch","Pursuit","Superpower"]},
 	},
@@ -40,7 +41,9 @@ var SETDEX_SM = {
 		"Battle Spot Singles Swords Dance": {"level":50,"evs":{"sd":4,"at":252,"hp":252},"nature":"Brave","ability":"Stance Change","item":"Weakness Policy","moves":["Swords Dance","Shadow Sneak","Iron Head","Sacred Sword"]},
 	},
 	"Aegislash-Shield": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Sassy","ability":"Stance Change","item":"Leftovers","moves":["King\u0027s Shield","Shadow Sneak","Gyro Ball","Toxic"]},
 		"ORAS Uber Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Stance Change","item":"Leftovers","moves":["King\u0027s Shield","Gyro Ball","Toxic","Pursuit"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Stance Change","item":"Leftovers","moves":["King\u0027s Shield","Shadow Ball","Wide Guard","Flash Cannon"]},
 		"ORAS Doubles Wide Guard Tank": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"ivs":{"at":0,"sp":0},"nature":"Quiet","ability":"Stance Change","item":"Weakness Policy","moves":["Shadow Ball","Flash Cannon","Wide Guard","King\u0027s Shield"]},
 		"ORAS Doubles Substitute Leftovers": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"ivs":{"at":0,"sp":0},"nature":"Quiet","ability":"Stance Change","item":"Leftovers","moves":["Shadow Ball","Flash Cannon","Substitute","King\u0027s Shield"]},
 		"Battle Spot Singles RETURN OF THE CRUMBLER (Special Attacker)": {"level":50,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Stance Change","item":"Weakness Policy","moves":["Shadow Ball","Shadow Sneak","King\u0027s Shield","Sacred Sword"]},
@@ -49,6 +52,7 @@ var SETDEX_SM = {
 	},
 	"Aerodactyl": {
 		"ORAS RU Life Orb": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Life Orb","moves":["Stone Edge","Earthquake","Pursuit","Aerial Ace"]},
+		"UU Showdown Usage": {"level":100,"evs":{"at":8,"hp":168,"sp":252,"sa":80},"nature":"Hasty","ability":"Unnerve","item":"Focus Sash","moves":["Stealth Rock","Taunt","Stone Edge","Fire Blast"]},
 		"ORAS UU All-out Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Stone Edge","Wing Attack","Earthquake","Roost"]},
 		"ORAS UU Hone Claws": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Hone Claws","Stone Edge","Wing Attack","Earthquake"]},
 		"ORAS UU Bulky Aerodactyl": {"level":100,"evs":{"df":156,"hp":248,"sp":104},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Taunt","Roost","Toxic","Stone Edge"]},
@@ -59,6 +63,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Mega Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Rock Slide","Aerial Ace","Aqua Tail","Wide Guard"]},
 	},
 	"Aerodactyl-Mega": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Tough Claws","item":"Aerodactylite","moves":["Stone Edge","Earthquake","Pursuit","Aerial Ace"]},
 		"ORAS UU All-out Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Stone Edge","Wing Attack","Earthquake","Roost"]},
 		"ORAS UU Hone Claws": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Hone Claws","Stone Edge","Wing Attack","Earthquake"]},
 		"ORAS UU Bulky Aerodactyl": {"level":100,"evs":{"df":156,"hp":248,"sp":104},"nature":"Jolly","ability":"Unnerve","item":"Aerodactylite","moves":["Taunt","Roost","Toxic","Stone Edge"]},
@@ -83,12 +88,14 @@ var SETDEX_SM = {
 		"LC Physical Attacker": {"level":5,"evs":{"df":76,"at":116,"hp":76,"sp":236},"nature":"Jolly","ability":"Skill Link","item":"Life Orb","moves":["Fury Swipes","Knock Off","Brick Break","Fake Out"]},
 	},
 	"Alakazam": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magic Guard","item":"Life Orb","moves":["Shadow Ball","Focus Blast","Psychic","Dazzling Gleam"]},
 		"OU Special Sweeper": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magic Guard","item":"Alakazite","moves":["Psychic","Shadow Ball","Focus Blast","Substitute"]},
 	},
 	"Alakazam-Mega": {
 		"OU Special Sweeper": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magic Guard","item":"Alakazite","moves":["Psychic","Shadow Ball","Focus Blast","Substitute"]},
 	},
 	"Alomomola": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":216,"df":252,"hp":40},"nature":"Bold","ability":"Regenerator","item":"Rocky Helmet","moves":["Wish","Protect","Scald","Toxic"]},
 		"OU Defensive Utility": {"level":100,"evs":{"sd":252,"df":220,"hp":36},"nature":"Calm","ability":"Regenerator","item":"Leftovers","moves":["Scald","Wish","Protect","Toxic"]},
 	},
 	"Altaria": {
@@ -117,7 +124,9 @@ var SETDEX_SM = {
 		"ORAS RU DON&#39;T USE AMBIPOM": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Technician","item":"Life Orb","moves":["Fake Out","Return","Low Kick","Knock Off"]},
 	},
 	"Amoonguss": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":92,"df":168,"hp":248},"nature":"Bold","ability":"Regenerator","item":"Black Sludge","moves":["Giga Drain","Spore","Clear Smog","Hidden Power Fire"]},
 		"OU Defensive Pivot": {"level":100,"evs":{"sd":216,"df":44,"hp":248},"nature":"Calm","ability":"Regenerator","item":"Black Sludge","moves":["Spore","Giga Drain","Clear Smog","Hidden Power Fire"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Regenerator","item":"Sitrus Berry","moves":["Spore","Rage Powder","Protect","Sludge Bomb"]},
 	},
 	"Ampharos": {
 		"ORAS PU Cleric": {"level":100,"evs":{"sd":8,"hp":248,"sa":252},"nature":"Modest","ability":"Static","item":"Leftovers","moves":["Heal Bell","Volt Switch","Hidden Power Ice","Focus Blast"]},
@@ -135,17 +144,24 @@ var SETDEX_SM = {
 	"Anorith": {
 		"LC Utility": {"level":5,"evs":{"df":36,"at":236,"sp":236},"nature":"Jolly","ability":"Battle Armor","item":"Berry Juice","moves":["Stealth Rock","Rapid Spin","Knock Off","Rock Blast"]},
 	},
+	"Araquanid": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"at":252,"hp":248},"nature":"Adamant","ability":"Water Bubble","item":"Choice Band","moves":["Liquidation","Leech Life","Poison Jab","Crunch"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Brave","ability":"Water Bubble","item":"Waterium Z","moves":["Liquidation","Protect","Wide Guard","Leech Life"]},
+	},
 	"Arbok": {
 		"ORAS PU Offensive Coil": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Black Sludge","moves":["Coil","Gunk Shot","Earthquake","Sucker Punch"]},
 		"ORAS NU Offensive Coil": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Life Orb","moves":["Coil","Gunk Shot","Earthquake","Sucker Punch"]},
 	},
 	"Arcanine": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"at":252,"hp":248},"nature":"Adamant","ability":"Intimidate","item":"Leftovers","moves":["Flare Blitz","Extreme Speed","Morning Sun","Will-O-Wisp"]},
 		"ORAS UU Defensive": {"level":100,"evs":{"df":252,"at":8,"hp":248},"nature":"Impish","ability":"Intimidate","item":"Leftovers","moves":["Morning Sun","Will-O-Wisp","Flare Blitz","Extreme Speed"]},
 		"ORAS UU Offensive": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Flash Fire","item":"Life Orb","moves":["Flare Blitz","Extreme Speed","Wild Charge","Close Combat"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":32,"hp":252,"sp":224},"nature":"Timid","ability":"Intimidate","item":"Leftovers","moves":["Snarl","Will-O-Wisp","Morning Sun","Flamethrower"]},
 		"VGC17 Helpful Pupper (Bulky Support)": {"level":50,"evs":{"sd":76,"df":188,"hp":244},"nature":"Calm","ability":"Intimidate","item":"Aguav Berry","moves":["Flamethrower","Snarl","Will-O-Wisp","Protect"]},
 		"VGC17 Attack Doggo (Physically Offensive)": {"level":50,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Firium Z","moves":["Flare Blitz","Wild Charge","Extreme Speed","Protect"]},
 	},
 	"Arceus": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Life Orb","moves":["Extreme Speed","Swords Dance","Earthquake","Shadow Claw"]},
 		"ORAS Uber Extreme Killer": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Life Orb","moves":["Swords Dance","Extreme Speed","Shadow Claw","Earthquake"]},
 		"ORAS Uber Bulky Extreme Killer": {"level":100,"evs":{"at":252,"hp":132,"sp":124},"nature":"Adamant","ability":"Multitype","item":"Life Orb","moves":["Swords Dance","Extreme Speed","Shadow Claw","Recover"]},
 	},
@@ -153,6 +169,7 @@ var SETDEX_SM = {
 		"ORAS Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","item":"Insect Plate","moves":["Swords Dance","X-Scissor","Earthquake","Stone Edge"]},
 	},
 	"Arceus-Dark": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":64,"hp":252,"sp":192},"nature":"Timid","ability":"Multitype","item":"Dread Plate","moves":["Judgment","Recover","Defog","Will-O-Wisp"]},
 		"ORAS Uber Calm Mind": {"level":100,"evs":{"df":80,"hp":252,"sp":176},"nature":"Timid","ability":"Multitype","item":"Dread Plate","moves":["Calm Mind","Judgment","Recover","Refresh"]},
 		"ORAS Uber Perish Trap": {"level":100,"evs":{"df":84,"hp":248,"sp":176},"nature":"Timid","ability":"Multitype","item":"Dread Plate","moves":["Perish Song","Whirlpool","Judgment","Recover"]},
 	},
@@ -164,6 +181,7 @@ var SETDEX_SM = {
 		"ORAS Uber Dual Status": {"level":100,"evs":{"df":84,"hp":248,"sp":176},"nature":"Timid","ability":"Multitype","item":"Zap Plate","moves":["Judgment","Recover","Will-O-Wisp","Toxic"]},
 	},
 	"Arceus-Fairy": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":186,"df":68,"hp":252},"nature":"Calm","ability":"Multitype","item":"Pixie Plate","moves":["Judgment","Recover","Toxic","Earth Power"]},
 		"ORAS Uber Offensive Utility": {"level":100,"evs":{"df":4,"hp":252,"sp":252},"nature":"Timid","ability":"Multitype","item":"Pixie Plate","moves":["Recover","Stone Edge","Earth Power","Judgment"]},
 		"ORAS Uber Stealth Rock": {"level":100,"evs":{"df":200,"hp":252,"sp":56},"nature":"Bold","ability":"Multitype","item":"Pixie Plate","moves":["Stealth Rock","Recover","Judgment","Toxic"]},
 	},
@@ -177,6 +195,7 @@ var SETDEX_SM = {
 		"ORAS Uber Stallbreaker": {"level":100,"evs":{"hp":132,"sp":176,"sa":200},"nature":"Modest","ability":"Multitype","item":"Sky Plate","moves":["Calm Mind","Judgment","Recover","Refresh"]},
 	},
 	"Arceus-Ghost": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Ghostium Z","moves":["Swords Dance","Shadow Force","Extreme Speed","Brick Break"]},
 		"ORAS Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Spooky Plate","moves":["Swords Dance","Shadow Force","Brick Break","Extreme Speed"]},
 		"ORAS Uber Calm Mind": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Multitype","item":"Spooky Plate","moves":["Calm Mind","Judgment","Focus Blast","Substitute"]},
 	},
@@ -184,6 +203,7 @@ var SETDEX_SM = {
 		"ORAS Uber Offensive Utility": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Multitype","item":"Meadow Plate","moves":["Grass Knot","Stone Edge","Ice Beam","Recover"]},
 	},
 	"Arceus-Ground": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Earth Plate","moves":["Recover","Judgment","Ice Beam","Defog"]},
 		"ORAS Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Earth Plate","moves":["Swords Dance","Earthquake","Stone Edge","Recover"]},
 		"ORAS Uber Special Attacker": {"level":100,"evs":{"df":88,"hp":252,"sp":168},"nature":"Bold","ability":"Multitype","item":"Earth Plate","moves":["Judgment","Ice Beam","Recover","Toxic"]},
 	},
@@ -200,6 +220,7 @@ var SETDEX_SM = {
 		"Uber Calm Mind Attacker": {"level":100,"evs":{"hp":252,"sp":252,"sa":4},"nature":"Timid","ability":"Multitype","item":"Stone Plate","moves":["Calm Mind","Will-O-Wisp","Recover","Judgment"]},
 	},
 	"Arceus-Steel": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Multitype","item":"Iron Plate","moves":["Recover","Judgment","Calm Mind","Earth Power"]},
 		"ORAS Uber Calm Mind": {"level":100,"evs":{"df":80,"hp":252,"sp":176},"nature":"Timid","ability":"Multitype","item":"Iron Plate","moves":["Calm Mind","Judgment","Recover","Earth Power"]},
 		"ORAS Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Multitype","item":"Iron Plate","moves":["Swords Dance","Iron Head","Earthquake","Stone Edge"]},
 	},
@@ -270,11 +291,14 @@ var SETDEX_SM = {
 		"LC Dragon Dance Sweeper": {"level":5,"evs":{"at":220,"hp":68,"sp":220},"nature":"Jolly","ability":"Mold Breaker","item":"Eviolite","moves":["Dragon Dance","Outrage","Superpower","Iron Tail"]},
 	},
 	"Azelf": {
+		"UU Showdown Usage": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Hasty","ability":"Levitate","item":"Focus Sash","moves":["Stealth Rock","Explosion","Taunt","Flamethrower"]},
 		"OU Suicide Lead": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Focus Sash","moves":["Stealth Rock","Taunt","Explosion","Skill Swap"]},
 	},
 	"Azumarill": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Huge Power","item":"Normalium Z","moves":["Aqua Jet","Play Rough","Belly Drum","Knock Off"]},
 		"OU Belly Drum": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Huge Power","item":"Normalium Z","moves":["Belly Drum","Aqua Jet","Play Rough","Knock Off"]},
 		"OU Choice Band": {"level":100,"evs":{"at":252,"hp":92,"sp":164},"nature":"Adamant","ability":"Huge Power","item":"Choice Band","moves":["Play Rough","Aqua Jet","Waterfall","Superpower"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":2,"at":252,"hp":236,"sp":20},"nature":"Adamant","ability":"Huge Power","item":"Sitrus Berry","moves":["Aqua Jet","Protect","Belly Drum","Knock Off"]},
 	},
 	"Azurill": {
 		"ORAS LC Trick Room Sweeper": {"level":5,"evs":{"sd":36,"df":116,"at":196,"hp":116},"ivs":{"sp":0},"nature":"Brave","ability":"Huge Power","item":"Life Orb","moves":["Return","Knock Off","Waterfall","Iron Tail"]},
@@ -337,6 +361,9 @@ var SETDEX_SM = {
 	"Bergmite": {
 		"ORAS LC Rapid Spin Support": {"level":5,"evs":{"sd":156,"df":236,"at":44,"sp":52},"nature":"Impish","ability":"Sturdy","item":"Eviolite","moves":["Avalanche","Rapid Spin","Recover","Rock Tomb"]},
 	},
+	"Bewear": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Fluffy","item":"Choice Band","moves":["Return","Ice Punch","Hammer Arm","Shadow Claw"]},
+	},
 	"Bibarel": {
 		"ORAS PU Curse": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Simple","item":"Chesto Berry","moves":["Curse","Waterfall","Quick Attack","Rest"]},
 	},
@@ -348,6 +375,7 @@ var SETDEX_SM = {
 		"ORAS LC Switcheroo": {"level":5,"evs":{"at":180,"hp":100,"sp":196},"nature":"Adamant","ability":"Tough Claws","item":"Choice Band","moves":["Switcheroo","Razor Shell","Stone Edge","Earthquake"]},
 	},
 	"Bisharp": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Defiant","item":"Life Orb","moves":["Knock Off","Sucker Punch","Iron Head","Swords Dance"]},
 		"OU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Defiant","item":"Life Orb","moves":["Knock Off","Iron Head","Sucker Punch","Swords Dance"]},
 		"Monotype Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Defiant","item":"Life Orb","moves":["Swords Dance","Knock Off","Sucker Punch","Iron Head"]},
 	},
@@ -359,6 +387,7 @@ var SETDEX_SM = {
 		"ORAS OU Rapid Spin": {"level":100,"evs":{"hp":184,"sp":72,"sa":252},"nature":"Modest","ability":"Rain Dish","item":"Blastoisinite","moves":["Rapid Spin","Scald","Dark Pulse","Aura Sphere"]},
 	},
 	"Blastoise-Mega": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Mega Launcher","item":"Blastoisinite","moves":["Dark Pulse","Rapid Spin","Scald","Ice Beam"]},
 		"ORAS UU Offensive Spinner": {"level":100,"evs":{"hp":184,"sp":72,"sa":252},"nature":"Modest","ability":"Rain Dish","item":"Blastoisinite","moves":["Rapid Spin","Scald","Dark Pulse","Ice Beam"]},
 		"ORAS UU All-out Attacker": {"level":100,"evs":{"hp":56,"sp":200,"sa":252},"nature":"Modest","ability":"Rain Dish","item":"Blastoisinite","moves":["Scald","Dark Pulse","Aura Sphere","Ice Beam"]},
 		"ORAS OU Rapid Spin": {"level":100,"evs":{"hp":184,"sp":72,"sa":252},"nature":"Modest","ability":"Rain Dish","item":"Blastoisinite","moves":["Rapid Spin","Scald","Dark Pulse","Aura Sphere"]},
@@ -370,6 +399,7 @@ var SETDEX_SM = {
 	"Blaziken-Mega": {
 	},
 	"Blissey": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Natural Cure","item":"Leftovers","moves":["Seismic Toss","Soft-Boiled","Toxic","Stealth Rock"]},
 		"ORAS UU De Blob (Cleric)": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Natural Cure","item":"Leftovers","moves":["Wish","Protect","Seismic Toss","Heal Bell"]},
 		"ORAS OU Calm Mind": {"level":100,"evs":{"sd":252,"df":252,"hp":4},"nature":"Bold","ability":"Natural Cure","item":"Leftovers","moves":["Calm Mind","Soft-Boiled","Thunderbolt","Ice Beam"]},
 		"ORAS Uber Support": {"level":100,"evs":{"sd":252,"df":252,"sp":4},"nature":"Calm","ability":"Natural Cure","item":"Shed Shell","moves":["Toxic","Seismic Toss","Wish","Protect"]},
@@ -394,8 +424,10 @@ var SETDEX_SM = {
 	"Bronzong": {
 		"ORAS RU Defensive": {"level":100,"evs":{"sd":184,"df":72,"hp":252},"nature":"Sassy","ability":"Levitate","item":"Leftovers","moves":["Stealth Rock","Gyro Ball","Toxic","Earthquake"]},
 		"ORAS RU Offensive Trick Room": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Brave","ability":"Levitate","item":"Macho Brace","moves":["Trick Room","Gyro Ball","Earthquake","Explosion"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Brave","ability":"Levitate","item":"Leftovers","moves":["Stealth Rock","Gyro Ball","Explosion","Trick Room"]},
 		"ORAS UU Tank": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Levitate","item":"Leftovers","moves":["Stealth Rock","Gyro Ball","Toxic","Earthquake"]},
 		"ORAS UU Trick Room Support": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"ivs":{"sp":0},"nature":"Brave","ability":"Levitate","item":"Macho Brace","moves":["Gyro Ball","Trick Room","Earthquake","Explosion"]},
+		"OU Showdown Usage": {"level":100,"evs":{"sd":124,"df":132,"hp":252},"nature":"Relaxed","ability":"Levitate","item":"Leftovers","moves":["Earthquake","Gyro Ball","Stealth Rock","Trick Room"]},
 		"ORAS OU Special Tank": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Levitate","item":"Leftovers","moves":["Gyro Ball","Earthquake","Stealth Rock","Hidden Power Ice"]},
 		"ORAS OU Trick Room Support": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"Levitate","item":"Mental Herb","moves":["Trick Room","Stealth Rock","Gyro Ball","Explosion"]},
 		"ORAS Uber Special Tank": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Sassy","ability":"Levitate","item":"Leftovers","moves":["Stealth Rock","Gyro Ball","Toxic","Protect"]},
@@ -411,6 +443,7 @@ var SETDEX_SM = {
 		"ORAS LC Life Orb Attacker": {"level":5,"evs":{"sd":36,"at":236,"sp":236},"nature":"Jolly","ability":"Water Veil","item":"Life Orb","moves":["Aqua Tail","Ice Punch","Brick Break","Aqua Jet"]},
 	},
 	"Bulbasaur": {
+		"LC Showdown Usage": {"level":5,"evs":{"sp":240,"sa":236},"nature":"Timid","ability":"Chlorophyll","item":"Eviolite","moves":["Sludge Bomb","Giga Drain","Hidden Power Fire","Growth"]},
 		"ORAS LC Life Orb Sun Sweeper": {"level":5,"evs":{"sp":240,"sa":240},"ivs":{"hp":0},"nature":"Modest","ability":"Chlorophyll","item":"Life Orb","moves":["Sludge Bomb","Solar Beam","Sleep Powder","Hidden Power Fire"]},
 		"ORAS LC Eviolite Growth": {"level":5,"evs":{"sp":240,"sa":240},"nature":"Timid","ability":"Chlorophyll","item":"Eviolite","moves":["Growth","Sleep Powder","Giga Drain","Hidden Power Fire"]},
 	},
@@ -426,6 +459,7 @@ var SETDEX_SM = {
 		"ORAS PU Quiver Dance": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Tinted Lens","item":"Life Orb","moves":["Sleep Powder","Quiver Dance","Bug Buzz","Energy Ball"]},
 	},
 	"Buzzwole": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Beast Boost","item":"Leftovers","moves":["Leech Life","Earthquake","Substitute","Focus Punch"]},
 		"Uber Physical Tank": {"level":100,"evs":{"sd":76,"df":184,"hp":248},"nature":"Impish","ability":"Beast Boost","item":"Leftovers","moves":["Hammer Arm","Toxic","Roost","Earthquake"]},
 	},
 	"Cacnea": {
@@ -469,6 +503,7 @@ var SETDEX_SM = {
 		"ORAS PU Chasing Rainbows": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Forecast","item":"Damp Rock","moves":["Rain Dance","Sunny Day","Hail","Weather Ball"]},
 	},
 	"Celebi": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Natural Cure","item":"Leftovers","moves":["Giga Drain","Psychic","Nasty Plot","Hidden Power Fire"]},
 		"ORAS UU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Natural Cure","item":"Leftovers","moves":["Nasty Plot","Giga Drain","Psychic","Dazzling Gleam"]},
 		"ORAS UU Utility": {"level":100,"evs":{"df":244,"hp":240,"sp":24},"nature":"Bold","ability":"Natural Cure","item":"Leftovers","moves":["Giga Drain","Recover","Thunder Wave","U-turn"]},
 		"ORAS UU Offensive Stealth Rock": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Natural Cure","item":"Life Orb","moves":["Stealth Rock","Leaf Storm","Psychic","Earth Power"]},
@@ -480,9 +515,11 @@ var SETDEX_SM = {
 		"OU Specially Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Sassy","ability":"Beast Boost","item":"Leftovers","moves":["Leech Seed","Protect","Heavy Slam","Flamethrower"]},
 		"OU Autotomize Sweeper": {"level":100,"evs":{"hp":84,"sp":172,"sa":252},"nature":"Modest","ability":"Beast Boost","item":"Flyinium Z","moves":["Autotomize","Air Slash","Fire Blast","Giga Drain"]},
 		"Uber Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Beast Boost","item":"Leftovers","moves":["Leech Seed","Toxic","Heavy Slam","Protect"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":176,"at":84,"hp":248},"nature":"Adamant","ability":"Beast Boost","item":"Leftovers","moves":["Leech Seed","Protect","Heavy Slam","Substitute"]},
 		"VGC17 Defensive": {"level":50,"evs":{"sd":116,"df":116,"at":44,"hp":228,"sp":4},"nature":"Adamant","ability":"Beast Boost","item":"Leftovers","moves":["Heavy Slam","Leech Seed","Substitute","Protect"]},
 	},
 	"Chandelure": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Choice Scarf","moves":["Shadow Ball","Energy Ball","Fire Blast","Flamethrower"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Choice Scarf","moves":["Fire Blast","Shadow Ball","Energy Ball","Trick"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Choice Specs","moves":["Fire Blast","Shadow Ball","Energy Ball","Trick"]},
 		"ORAS UU Substitute + Calm Mind": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Leftovers","moves":["Substitute","Calm Mind","Flamethrower","Shadow Ball"]},
@@ -490,6 +527,7 @@ var SETDEX_SM = {
 	},
 	"Chansey": {
 		"OU Utility": {"level":100,"evs":{"sd":252,"df":252,"hp":4},"nature":"Bold","ability":"Natural Cure","item":"Eviolite","moves":["Soft-Boiled","Seismic Toss","Stealth Rock","Aromatherapy"]},
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Natural Cure","item":"Eviolite","moves":["Soft-Boiled","Toxic","Heal Bell","Seismic Toss"]},
 	},
 	"Charizard": {
 		"ORAS NU Life Orb": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Life Orb","moves":["Fire Blast","Air Slash","Hidden Power Grass","Roost"]},
@@ -508,6 +546,7 @@ var SETDEX_SM = {
 		"Monotype Wallbreaker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Charizardite Y","moves":["Fire Blast","Focus Blast","Solar Beam","Roost"]},
 	},
 	"Charizard-Mega-X": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Tough Claws","item":"Charizardite X","moves":["Dragon Dance","Flare Blitz","Dragon Claw","Roost"]},
 		"ORAS OU Dragon Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Blaze","item":"Charizardite X","moves":["Dragon Dance","Flare Blitz","Dragon Claw","Roost"]},
 		"ORAS OU Bulky Will-O-Wisp": {"level":100,"evs":{"df":100,"hp":248,"sp":160},"nature":"Impish","ability":"Blaze","item":"Charizardite X","moves":["Will-O-Wisp","Flare Blitz","Roost","Earthquake"]},
 		"ORAS OU Swords Dance": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Adamant","ability":"Blaze","item":"Charizardite X","moves":["Swords Dance","Roost","Flare Blitz","Dragon Claw"]},
@@ -517,7 +556,9 @@ var SETDEX_SM = {
 		"Battle Spot Singles Defensive": {"level":50,"evs":{"df":116,"hp":164,"sp":228},"nature":"Jolly","ability":"Blaze","item":"Charizardite X","moves":["Will-O-Wisp","Roost","Dragon Claw","Earthquake"]},
 	},
 	"Charizard-Mega-Y": {
+		"OU Showdown Usage": {"level":100,"evs":{"df":4,"hp":32,"sp":220,"sa":252},"nature":"Timid","ability":"Drought","item":"Charizardite Y","moves":["Solar Beam","Roost","Focus Blast","Fire Blast"]},
 		"ORAS OU Wallbreaker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Charizardite Y","moves":["Fire Blast","Solar Beam","Focus Blast","Roost"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Drought","item":"Charizardite Y","moves":["Protect","Heat Wave","Solar Beam","Overheat"]},
 		"ORAS Doubles Sun Attacker": {"level":100,"evs":{"df":64,"hp":248,"sp":108,"sa":88},"nature":"Modest","ability":"Blaze","item":"Charizardite Y","moves":["Heat Wave","Solar Beam","Overheat","Protect"]},
 		"Battle Spot Singles Drought Attacker": {"level":50,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Blaze","item":"Charizardite Y","moves":["Flamethrower","Solar Beam","Focus Blast","Overheat"]},
 		"Battle Spot Doubles Drought Attacker": {"level":50,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Blaze","item":"Charizardite Y","moves":["Heat Wave","Solar Beam","Overheat","Protect"]},
@@ -539,6 +580,7 @@ var SETDEX_SM = {
 		"ORAS LC Chlorophyll Sweeper": {"level":5,"evs":{"df":76,"sp":236,"sa":180},"ivs":{"hp":9},"nature":"Modest","ability":"Chlorophyll","item":"Life Orb","moves":["Solar Beam","Weather Ball","Dazzling Gleam","Healing Wish"]},
 	},
 	"Chesnaught": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Bulletproof","item":"Leftovers","moves":["Drain Punch","Spiky Shield","Spikes","Leech Seed"]},
 		"ORAS UU Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Bulletproof","item":"Leftovers","moves":["Spikes","Leech Seed","Spiky Shield","Drain Punch"]},
 		"ORAS UU Specially Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Bulletproof","item":"Leftovers","moves":["Spikes","Leech Seed","Spiky Shield","Drain Punch"]},
 		"ORAS UU Fast Taunt": {"level":100,"evs":{"df":84,"hp":252,"sp":172},"nature":"Impish","ability":"Bulletproof","item":"Leftovers","moves":["Spikes","Taunt","Leech Seed","Drain Punch"]},
@@ -558,6 +600,7 @@ var SETDEX_SM = {
 		"ORAS PU Defensive Healing Wish": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Levitate","item":"Leftovers","moves":["Healing Wish","Recover","Psychic","Heal Bell"]},
 	},
 	"Chinchou": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":212,"hp":236,"sp":60},"nature":"Bold","ability":"Volt Absorb","item":"Choice Scarf","moves":["Volt Switch","Scald","Ice Beam","Hidden Power Ground"]},
 		"ORAS LC Choice Scarf Pivot": {"level":5,"evs":{"df":52,"sp":224,"sa":232},"nature":"Timid","ability":"Volt Absorb","item":"Choice Scarf","moves":["Volt Switch","Scald","Ice Beam","Hidden Power Ground"]},
 		"ORAS LC Bulky Attacker": {"level":5,"evs":{"df":212,"hp":76,"sp":60,"sa":152},"nature":"Bold","ability":"Volt Absorb","item":"Berry Juice","moves":["Scald","Volt Switch","Ice Beam","Heal Bell"]},
 		"ORAS LC RestTalk": {"level":5,"evs":{"sd":148,"df":212,"hp":76,"sp":60},"nature":"Bold","ability":"Volt Absorb","item":"Eviolite","moves":["Rest","Sleep Talk","Scald","Volt Switch"]},
@@ -600,6 +643,7 @@ var SETDEX_SM = {
 		"Battle Spot Singles Smash &#39;n&#39; Sweep": {"level":50,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Skill Link","item":"Focus Sash","moves":["Shell Smash","Icicle Spear","Rock Blast","Ice Shard"]},
 	},
 	"Cobalion": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Fightinium Z","moves":["Close Combat","Iron Head","Swords Dance","Stealth Rock"]},
 		"ORAS UU Offensive Pivot": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Justified","item":"Leftovers","moves":["Stealth Rock","Close Combat","Volt Switch","Iron Head"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Justified","item":"Leftovers","moves":["Close Combat","Iron Head","Swords Dance","Stone Edge"]},
 		"ORAS UU Calm Mind": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Justified","item":"Leftovers","moves":["Calm Mind","Focus Blast","Flash Cannon","Hidden Power Ghost"]},
@@ -617,6 +661,7 @@ var SETDEX_SM = {
 		"ORAS NU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Speed Boost","item":"Eviolite","moves":["Swords Dance","Flare Blitz","Low Kick","Protect"]},
 	},
 	"Conkeldurr": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Guts","item":"Assault Vest","moves":["Mach Punch","Knock Off","Drain Punch","Ice Punch"]},
 		"ORAS UU Assault Vest": {"level":100,"evs":{"sd":252,"df":4,"at":252},"nature":"Adamant","ability":"Guts","item":"Assault Vest","moves":["Drain Punch","Knock Off","Thunder Punch","Mach Punch"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Iron Fist","item":"Choice Band","moves":["Hammer Arm","Mach Punch","Knock Off","Poison Jab"]},
 		"ORAS UU Bulk Up": {"level":100,"evs":{"sd":252,"at":16,"hp":240},"nature":"Adamant","ability":"Guts","item":"Leftovers","moves":["Bulk Up","Drain Punch","Knock Off","Mach Punch"]},
@@ -626,6 +671,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Offensive Support": {"level":100,"evs":{"df":16,"at":240,"hp":252},"nature":"Brave","ability":"Guts","item":"Sitrus Berry","moves":["Drain Punch","Mach Punch","Ice Punch","Knock Off"]},
 	},
 	"Corphish": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":76,"at":196,"sp":236},"nature":"Adamant","ability":"Adaptability","item":"Eviolite","moves":["Aqua Jet","Knock Off","Crabhammer","Swords Dance"]},
 		"ORAS LC Wallbreaker": {"level":5,"evs":{"df":76,"at":196,"sp":236},"nature":"Adamant","ability":"Adaptability","item":"Eviolite","moves":["Crabhammer","Knock Off","Aqua Jet","Swords Dance"]},
 		"ORAS LC Dragon Dance": {"level":5,"evs":{"df":76,"at":196,"sp":236},"nature":"Jolly","ability":"Adaptability","item":"Eviolite","moves":["Dragon Dance","Crabhammer","Knock Off","Aqua Jet"]},
 		"ORAS LC Choice Band": {"level":5,"evs":{"df":76,"at":196,"sp":236},"nature":"Adamant","ability":"Adaptability","item":"Choice Band","moves":["Aqua Jet","Crabhammer","Knock Off","Switcheroo"]},
@@ -634,6 +680,7 @@ var SETDEX_SM = {
 		"ORAS PU Specially Defensive": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Regenerator","item":"Leftovers","moves":["Stealth Rock","Recover","Scald","Toxic"]},
 	},
 	"Cottonee": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":40,"df":36,"hp":36,"sp":232,"sa":144},"nature":"Timid","ability":"Prankster","item":"Eviolite","moves":["Encore","Dazzling Gleam","Memento","Giga Drain"]},
 		"ORAS LC Offensive": {"level":5,"evs":{"sd":40,"df":40,"hp":36,"sp":232,"sa":144},"nature":"Timid","ability":"Prankster","item":"Eviolite","moves":["Dazzling Gleam","Hidden Power Fighting","Encore","Knock Off"]},
 		"ORAS LC Utility": {"level":5,"evs":{"sd":196,"df":196,"hp":116},"nature":"Bold","ability":"Prankster","item":"Eviolite","moves":["Encore","Knock Off","Giga Drain","Memento"]},
 	},
@@ -644,11 +691,13 @@ var SETDEX_SM = {
 		"ORAS NU Specially Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Sassy","ability":"Storm Drain","item":"Leftovers","moves":["Stealth Rock","Recover","Giga Drain","Rock Slide"]},
 	},
 	"Cranidos": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":36,"at":236,"sp":212},"nature":"Adamant","ability":"Sheer Force","item":"Life Orb","moves":["Zen Headbutt","Rock Slide","Earthquake","Superpower"]},
 		"ORAS LC Life Orb Attacker": {"level":5,"evs":{"df":36,"at":236,"sp":212},"nature":"Jolly","ability":"Sheer Force","item":"Life Orb","moves":["Rock Slide","Superpower","Zen Headbutt","Crunch"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"df":36,"at":236,"sp":212},"nature":"Adamant","ability":"Mold Breaker","item":"Choice Scarf","moves":["Stone Edge","Earthquake","Superpower","Zen Headbutt"]},
 		"ORAS LC Support": {"level":5,"evs":{"df":116,"at":156,"sp":212},"nature":"Jolly","ability":"Sheer Force","item":"Berry Juice","moves":["Pursuit","Rock Slide","Zen Headbutt","Stealth Rock"]},
 	},
 	"Crawdaunt": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Adaptability","item":"Life Orb","moves":["Knock Off","Aqua Jet","Crabhammer","Swords Dance"]},
 		"OU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Adaptability","item":"Choice Band","moves":["Knock Off","Crabhammer","Aqua Jet","Crunch"]},
 		"OU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Adaptability","item":"Life Orb","moves":["Swords Dance","Knock Off","Crabhammer","Aqua Jet"]},
 	},
@@ -665,11 +714,13 @@ var SETDEX_SM = {
 		"Battle Spot Singles Defensive Support": {"level":50,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Levitate","item":"Rocky Helmet","moves":["Ice Beam","Moonlight","Psychic","Lunar Dance"]},
 	},
 	"Croagunk": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":116,"df":116,"hp":52,"sp":36,"sa":188},"nature":"Modest","ability":"Dry Skin","item":"Eviolite","moves":["Vacuum Wave","Sludge Bomb","Knock Off","Drain Punch"]},
 		"ORAS LC Mixed Utility": {"level":5,"evs":{"sd":116,"df":116,"at":28,"hp":132,"sa":108},"nature":"Quiet","ability":"Dry Skin","item":"Eviolite","moves":["Knock Off","Sludge Bomb","Vacuum Wave","Drain Punch"]},
 		"ORAS LC Physical Attacker": {"level":5,"evs":{"sd":116,"df":116,"at":188,"hp":52,"sp":36},"nature":"Adamant","ability":"Dry Skin","item":"Eviolite","moves":["Drain Punch","Gunk Shot","Sucker Punch","Bulk Up"]},
 		"ORAS LC Nasty Plot Wallbreaker": {"level":5,"evs":{"sd":116,"df":116,"hp":52,"sp":36,"sa":188},"nature":"Modest","ability":"Dry Skin","item":"Eviolite","moves":["Nasty Plot","Sludge Bomb","Vacuum Wave","Shadow Ball"]},
 	},
 	"Crobat": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Infiltrator","item":"Black Sludge","moves":["Brave Bird","U-turn","Roost","Defog"]},
 		"ORAS UU Support": {"level":100,"evs":{"df":48,"hp":248,"sp":212},"nature":"Jolly","ability":"Infiltrator","item":"Black Sludge","moves":["Brave Bird","U-turn","Defog","Roost"]},
 		"ORAS UU BRAVE BAT (Choice Band)": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Infiltrator","item":"Choice Band","moves":["Brave Bird","U-turn","Cross Poison","Defog"]},
 	},
@@ -693,6 +744,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Special Attacker": {"level":100,"evs":{"hp":72,"sp":184,"sa":252},"nature":"Timid","ability":"Bad Dreams","item":"Life Orb","moves":["Dark Pulse","Ice Beam","Will-O-Wisp","Protect"]},
 	},
 	"Darmanitan": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sheer Force","item":"Choice Scarf","moves":["Flare Blitz","U-turn","Earthquake","Rock Slide"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sheer Force","item":"Choice Scarf","moves":["Flare Blitz","Rock Slide","U-turn","Earthquake"]},
 		"ORAS UU Wallbreaker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sheer Force","item":"Choice Band","moves":["Flare Blitz","Rock Slide","Earthquake","U-turn"]},
 	},
@@ -700,6 +752,9 @@ var SETDEX_SM = {
 	},
 	"Darumaka": {
 		"ORAS LC Choice": {"level":5,"evs":{"at":196,"hp":116,"sp":196},"nature":"Jolly","ability":"Hustle","item":"Choice Scarf","moves":["Flare Blitz","U-turn","Rock Slide","Superpower"]},
+	},
+	"Decidueye": {
+		"UU Showdown Usage": {"level":100,"evs":{"at":248,"hp":8,"sp":252},"nature":"Jolly","ability":"Overgrow","item":"Decidium Z","moves":["Spirit Shackle","Leaf Blade","Swords Dance","Sucker Punch"]},
 	},
 	"Dedenne": {
 		"ORAS PU SubRecycle": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cheek Pouch","item":"Petaya Berry","moves":["Substitute","Recycle","Thunderbolt","Grass Knot"]},
@@ -726,6 +781,7 @@ var SETDEX_SM = {
 	},
 	"Deoxys-Attack": {
 		"Uber All-out Attacker": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Rash","ability":"Pressure","item":"Life Orb","moves":["Psycho Boost","Ice Beam","Superpower","Extreme Speed"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Naive","ability":"Pressure","item":"Focus Sash","moves":["Psycho Boost","Superpower","Knock Off","Protect"]},
 	},
 	"Deoxys-Defense": {
 		"ORAS Uber Spikes": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Pressure","item":"Leftovers","moves":["Spikes","Recover","Skill Swap","Toxic"]},
@@ -735,6 +791,12 @@ var SETDEX_SM = {
 	},
 	"Dewgong": {
 		"ORAS PU Specially Defensive": {"level":100,"evs":{"sd":252,"hp":248,"sa":8},"nature":"Calm","ability":"Thick Fat","item":"Leftovers","moves":["Toxic","Protect","Surf","Perish Song"]},
+	},
+	"Dewpider": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":100,"df":20,"at":196,"hp":52,"sp":140},"nature":"Adamant","ability":"Water Bubble","item":"Choice Specs","moves":["Liquidation","Leech Life","Poison Jab","Surf"]},
+	},
+	"Dhelmise": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"at":252,"hp":248},"nature":"Adamant","ability":"Steelworker","item":"Assault Vest","moves":["Power Whip","Anchor Shot","Rapid Spin","Shadow Claw"]},
 	},
 	"Dialga": {
 		"Uber Offensive Stealth Rock": {"level":100,"evs":{"df":4,"hp":252,"sa":252},"nature":"Modest","ability":"Pressure","item":"Shuca Berry","moves":["Stealth Rock","Draco Meteor","Fire Blast","Toxic"]},
@@ -767,6 +829,7 @@ var SETDEX_SM = {
 		"ORAS OU Choice Scarf": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Huge Power","item":"Choice Scarf","moves":["Earthquake","Return","Knock Off","U-turn"]},
 	},
 	"Diglett": {
+		"LC Showdown Usage": {"level":5,"evs":{"at":236,"hp":36,"sp":236},"nature":"Jolly","ability":"Arena Trap","item":"Life Orb","moves":["Earthquake","Rock Slide","Sucker Punch","Memento"]},
 		"ORAS LC Trapper": {"level":5,"evs":{"at":236,"hp":36,"sp":236},"nature":"Jolly","ability":"Arena Trap","item":"Life Orb","moves":["Earthquake","Rock Slide","Sucker Punch","Substitute"]},
 	},
 	"Diglett-Alola": {
@@ -776,7 +839,9 @@ var SETDEX_SM = {
 		"ORAS PU Revenge Killer": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"ivs":{"sd":30,"sp":1,"sa":30},"nature":"Relaxed","ability":"Imposter","item":"Choice Scarf","moves":["Transform"]},
 		"ORAS NU Imposter": {"level":100,"evs":{"df":252,"hp":248},"ivs":{"df":30,"at":0,"sp":1},"nature":"Relaxed","ability":"Imposter","item":"Choice Scarf","moves":["Transform"]},
 		"ORAS RU Imposter": {"level":100,"evs":{"df":252,"at":8,"hp":248},"nature":"Relaxed","ability":"Imposter","item":"Choice Scarf","moves":["Transform"]},
+		"OU Showdown Usage": {"level":100,"evs":{"df":4,"hp":252,"sp":252},"nature":"Timid","ability":"Imposter","item":"Choice Scarf","moves":["","Transform"]},
 		"ORAS OU Imposter": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"ivs":{"sp":0},"nature":"Relaxed","ability":"Imposter","item":"Choice Scarf","moves":["Transform"]},
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Imposter","item":"Choice Scarf","moves":["","Transform"]},
 		"ORAS Uber Revenge Killer": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"ivs":{"sp":0},"nature":"Relaxed","ability":"Imposter","item":"Choice Scarf","moves":["Transform"]},
 	},
 	"Dodrio": {
@@ -789,11 +854,13 @@ var SETDEX_SM = {
 		"LC Choice Scarf": {"level":5,"evs":{"at":236,"sp":236},"nature":"Jolly","ability":"Early Bird","item":"Choice Scarf","moves":["Brave Bird","Knock Off","Jump Kick","Return"]},
 	},
 	"Donphan": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"df":212,"at":40,"hp":248},"nature":"Impish","ability":"Sturdy","item":"Leftovers","moves":["Earthquake","Rapid Spin","Ice Shard","Stealth Rock"]},
 		"ORAS UU Defensive Spinner": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Sturdy","item":"Leftovers","moves":["Earthquake","Rapid Spin","Stealth Rock","Knock Off"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"at":252,"hp":52,"sp":204},"nature":"Adamant","ability":"Sturdy","item":"Choice Band","moves":["Earthquake","Ice Shard","Knock Off","Gunk Shot"]},
 		"ORAS UU Offensive Spinner": {"level":100,"evs":{"at":252,"hp":172,"sp":84},"nature":"Adamant","ability":"Sturdy","item":"Assault Vest","moves":["Rapid Spin","Earthquake","Knock Off","Ice Shard"]},
 	},
 	"Doublade": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":192,"at":48,"hp":252,"sp":16},"nature":"Adamant","ability":"No Guard","item":"Eviolite","moves":["Shadow Sneak","Swords Dance","Iron Head","Sacred Sword"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"sd":16,"at":252,"hp":240},"nature":"Adamant","ability":"No Guard","item":"Eviolite","moves":["Swords Dance","Shadow Sneak","Iron Head","Sacred Sword"]},
 		"ORAS OU Mixed Wall": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"ivs":{"sp":0},"nature":"Sassy","ability":"No Guard","item":"Eviolite","moves":["Gyro Ball","Toxic","Sleep Talk","Rest"]},
 	},
@@ -824,6 +891,7 @@ var SETDEX_SM = {
 		"ORAS NU Mixed Offensive": {"level":100,"evs":{"at":88,"sp":180,"sa":240},"ivs":{"hp":30},"nature":"Rash","ability":"Unburden","item":"Sitrus Berry","moves":["Substitute","Acrobatics","Will-O-Wisp","Hex"]},
 	},
 	"Drilbur": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":76,"df":36,"at":76,"hp":36,"sp":212},"nature":"Jolly","ability":"Mold Breaker","item":"Berry Juice","moves":["Earthquake","Rapid Spin","Rock Slide","Stealth Rock"]},
 		"ORAS LC Support": {"level":5,"evs":{"sd":76,"df":36,"at":76,"hp":36,"sp":212},"nature":"Jolly","ability":"Mold Breaker","item":"Berry Juice","moves":["Earthquake","Rapid Spin","Rock Slide","Stealth Rock"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"df":36,"at":236,"sp":212},"nature":"Jolly","ability":"Mold Breaker","item":"Choice Scarf","moves":["Earthquake","Rock Slide","Poison Jab","Rapid Spin"]},
 	},
@@ -868,6 +936,7 @@ var SETDEX_SM = {
 		"ORAS PU Quiver Dance": {"level":100,"evs":{"sd":192,"hp":248,"sp":68},"nature":"Calm","ability":"Shield Dust","item":"Black Sludge","moves":["Quiver Dance","Iron Defense","Bug Buzz","Roost"]},
 	},
 	"Dwebble": {
+		"LC Showdown Usage": {"level":5,"evs":{"at":236,"sp":236},"nature":"Adamant","ability":"Sturdy","item":"Berry Juice","moves":["Rock Blast","Knock Off","Shell Smash","Earthquake"]},
 		"ORAS LC Entry Hazard Layer": {"level":5,"evs":{"at":236,"sp":236},"nature":"Jolly","ability":"Sturdy","item":"Berry Juice","moves":["Stealth Rock","Spikes","Rock Blast","Knock Off"]},
 		"ORAS LC SturdyJuice Smash": {"level":5,"evs":{"at":236,"sp":236},"nature":"Adamant","ability":"Sturdy","item":"Berry Juice","moves":["Shell Smash","Rock Blast","Earthquake","Substitute"]},
 	},
@@ -895,6 +964,7 @@ var SETDEX_SM = {
 		"ORAS NU All-Out Attacker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Soundproof","item":"Life Orb","moves":["Thunderbolt","Volt Switch","Hidden Power Grass","Signal Beam"]},
 	},
 	"Elekid": {
+		"LC Showdown Usage": {"level":5,"evs":{"sp":236,"sa":240},"nature":"Timid","ability":"Vital Spirit","item":"Eviolite","moves":["Volt Switch","Thunderbolt","Hidden Power Grass","Psychic"]},
 		"ORAS LC Special Attacker": {"level":5,"evs":{"sp":236,"sa":240},"ivs":{"hp":0},"nature":"Timid","ability":"Static","item":"Life Orb","moves":["Thunderbolt","Volt Switch","Psychic","Hidden Power Ground"]},
 		"ORAS LC Physical Attacker": {"level":5,"evs":{"at":252,"sp":236},"ivs":{"hp":0},"nature":"Hasty","ability":"Static","item":"Life Orb","moves":["Wild Charge","Cross Chop","Fire Punch","Volt Switch"]},
 	},
@@ -913,9 +983,11 @@ var SETDEX_SM = {
 		"ORAS PU Support": {"level":100,"evs":{"df":8,"hp":248,"sp":252},"nature":"Jolly","ability":"Motor Drive","item":"Leftovers","moves":["Taunt","U-turn","Roost","Encore"]},
 	},
 	"Empoleon": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":248,"sp":8},"nature":"Calm","ability":"Torrent","item":"Leftovers","moves":["Scald","Defog","Roar","Stealth Rock"]},
 		"OU Specially Defensive": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Torrent","item":"Leftovers","moves":["Scald","Defog","Toxic","Roar"]},
 	},
 	"Entei": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Pressure","item":"Choice Band","moves":["Extreme Speed","Stone Edge","Sacred Fire","Flare Blitz"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Pressure","item":"Choice Band","moves":["Sacred Fire","Flare Blitz","Extreme Speed","Stone Edge"]},
 		"ORAS OU All-Out Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Pressure","item":"Choice Band","moves":["Sacred Fire","Extreme Speed","Stone Edge","Bulldoze"]},
 		"ORAS Doubles Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Pressure","item":"Safety Goggles","moves":["Sacred Fire","Stone Edge","Extreme Speed","Protect"]},
@@ -940,6 +1012,7 @@ var SETDEX_SM = {
 		"OU Bulky Spinner": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Mold Breaker","item":"Leftovers","moves":["Rapid Spin","Earthquake","Iron Head","Toxic"]},
 		"Uber Suicide Lead": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Mold Breaker","item":"Focus Sash","moves":["Earthquake","Stealth Rock","Toxic","Rapid Spin"]},
 		"Uber Sand Rush Drill": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Sand Rush","item":"Life Orb","moves":["Earthquake","Iron Head","Rock Slide","Swords Dance"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Rush","item":"Life Orb","moves":["Iron Head","Rock Slide","Protect","Drill Run"]},
 		"Battle Spot Singles Choice Scarf": {"level":50,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Mold Breaker","item":"Choice Scarf","moves":["Earthquake","Iron Head","Rock Slide","Horn Drill"]},
 		"Battle Spot Singles Sand Sweeper": {"level":50,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Rush","item":"Groundium Z","moves":["Earthquake","Iron Head","Rock Slide","Swords Dance"]},
 		"Battle Spot Singles Versatile Attacker": {"level":50,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Mold Breaker","item":"Focus Sash","moves":["Earthquake","Iron Head","Rock Slide","Swords Dance"]},
@@ -974,6 +1047,7 @@ var SETDEX_SM = {
 	"Ferrothorn": {
 		"OU Utility": {"level":100,"evs":{"sd":168,"df":88,"hp":252},"nature":"Relaxed","ability":"Iron Barbs","item":"Leftovers","moves":["Spikes","Leech Seed","Gyro Ball","Power Whip"]},
 		"Uber Support": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Sassy","ability":"Iron Barbs","item":"Leftovers","moves":["Spikes","Leech Seed","Gyro Ball","Power Whip"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Brave","ability":"Iron Barbs","item":"Leftovers","moves":["Gyro Ball","Power Whip","Leech Seed","Protect"]},
 	},
 	"Finneon": {
 		"ORAS LC Defog": {"level":5,"evs":{"sd":232,"df":152,"hp":44,"sa":48},"nature":"Timid","ability":"Storm Drain","item":"Berry Juice","moves":["Defog","Scald","U-turn","Hidden Power Fighting"]},
@@ -1009,6 +1083,7 @@ var SETDEX_SM = {
 		"ORAS RU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Choice Band","moves":["Earthquake","Outrage","U-turn","Dragon Claw"]},
 		"ORAS RU Defog Support": {"level":100,"evs":{"at":144,"hp":112,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Leftovers","moves":["Defog","Roost","Earthquake","U-turn"]},
 		"ORAS RU Choice Scarf": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Choice Scarf","moves":["Earthquake","U-turn","Outrage","Aerial Ace"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Dragonium Z","moves":["Earthquake","Dragon Dance","Outrage","Fire Punch"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Levitate","item":"Choice Scarf","moves":["Outrage","Earthquake","U-turn","Defog"]},
 		"ORAS Uber Defog": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Levitate","item":"Leftovers","moves":["Defog","Roost","Toxic","Earth Power"]},
 	},
@@ -1019,6 +1094,7 @@ var SETDEX_SM = {
 		"LC Defensive": {"level":5,"evs":{"sd":160,"df":160,"hp":124},"nature":"Bold","ability":"Regenerator","item":"Eviolite","moves":["Spore","Sludge Bomb","Giga Drain","Clear Smog"]},
 	},
 	"Forretress": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Relaxed","ability":"Sturdy","item":"Leftovers","moves":["Rapid Spin","Volt Switch","Gyro Ball","Spikes"]},
 		"ORAS UU Defensive Rapid Spin": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Sturdy","item":"Leftovers","moves":["Rapid Spin","Stealth Rock","Volt Switch","Gyro Ball"]},
 		"ORAS UU Custap": {"level":100,"evs":{"at":252,"sp":252},"ivs":{"sd":0,"df":0,"hp":0},"nature":"Hasty","ability":"Sturdy","item":"Custap Berry","moves":["Stealth Rock","Explosion","Spikes","Rapid Spin"]},
 	},
@@ -1029,6 +1105,7 @@ var SETDEX_SM = {
 		"ORAS NU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Mold Breaker","item":"Choice Band","moves":["Outrage","Superpower","Iron Tail","Dragon Claw"]},
 	},
 	"Frillish": {
+		"LC Showdown Usage": {"level":5,"evs":{"hp":76,"sp":196,"sa":236},"nature":"Timid","ability":"Water Absorb","item":"Choice Scarf","moves":["Water Spout","Shadow Ball","Hydro Pump","Energy Ball"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"hp":76,"sp":196,"sa":236},"nature":"Timid","ability":"Water Absorb","item":"Choice Scarf","moves":["Water Spout","Shadow Ball","Ice Beam","Trick"]},
 		"ORAS LC Defensive": {"level":5,"evs":{"sd":76,"df":116,"hp":236,"sa":76},"nature":"Bold","ability":"Cursed Body","item":"Eviolite","moves":["Scald","Shadow Ball","Recover","Will-O-Wisp"]},
 		"ORAS NU Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Water Absorb","item":"Eviolite","moves":["Will-O-Wisp","Night Shade","Recover","Taunt"]},
@@ -1042,6 +1119,7 @@ var SETDEX_SM = {
 		"ORAS NU All-out Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Naive","ability":"Protean","item":"Life Orb","moves":["Hydro Pump","Ice Beam","Gunk Shot","Toxic Spikes"]},
 	},
 	"Froslass": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":8,"hp":248,"sp":252},"nature":"Timid","ability":"Cursed Body","item":"Focus Sash","moves":["Spikes","Taunt","Will-O-Wisp","Icy Wind"]},
 		"ORAS UU Spikes Lead": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Cursed Body","item":"Focus Sash","moves":["Taunt","Destiny Bond","Spikes","Icy Wind"]},
 		"ORAS OU Suicide Spiker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Focus Sash","moves":["Taunt","Spikes","Destiny Bond","Ice Beam"]},
 	},
@@ -1084,6 +1162,7 @@ var SETDEX_SM = {
 	"Garchomp-Mega": {
 	},
 	"Gardevoir": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Choice Scarf","moves":["Moonblast","Psyshock","Trick","Calm Mind"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Choice Scarf","moves":["Moonblast","Psychic","Healing Wish","Trick"]},
 		"ORAS UU Calm Mind": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Leftovers","moves":["Calm Mind","Moonblast","Psyshock","Substitute"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Trace","item":"Choice Specs","moves":["Moonblast","Psyshock","Focus Blast","Trick"]},
@@ -1104,16 +1183,20 @@ var SETDEX_SM = {
 	"Gastrodon": {
 		"ORAS NU Physically Defensive": {"level":100,"evs":{"df":244,"hp":252,"sp":12},"nature":"Bold","ability":"Storm Drain","item":"Leftovers","moves":["Scald","Earth Power","Recover","Toxic"]},
 		"ORAS RU Defensive": {"level":100,"evs":{"df":244,"hp":252,"sp":12},"nature":"Bold","ability":"Storm Drain","item":"Leftovers","moves":["Scald","Recover","Toxic","Earth Power"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":108,"df":152,"hp":248},"nature":"Sassy","ability":"Storm Drain","item":"Leftovers","moves":["Recover","Scald","Toxic","Earthquake"]},
 		"ORAS UU Curse": {"level":100,"evs":{"sd":108,"df":148,"hp":252},"nature":"Sassy","ability":"Storm Drain","item":"Leftovers","moves":["Curse","Recover","Earthquake","Scald"]},
 		"ORAS OU Curse": {"level":100,"evs":{"sd":144,"df":112,"hp":252},"nature":"Sassy","ability":"Storm Drain","item":"Leftovers","moves":["Curse","Scald","Earthquake","Recover"]},
 		"ORAS OU Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Storm Drain","item":"Leftovers","moves":["Scald","Earthquake","Toxic","Recover"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":88,"df":48,"hp":252,"sa":120},"nature":"Quiet","ability":"Storm Drain","item":"Sitrus Berry","moves":["Earth Power","Ice Beam","Recover","Protect"]},
 		"ORAS Doubles Recover + 3 Attacks": {"level":100,"evs":{"sd":52,"df":176,"hp":232,"sa":48},"ivs":{"sp":0},"nature":"Quiet","ability":"Storm Drain","item":"Sitrus Berry","moves":["Scald","Earth Power","Ice Beam","Recover"]},
 	},
 	"Genesect": {
 		"ORAS Uber Choice Scarf": {"level":100,"evs":{"at":248,"sp":252,"sa":8},"nature":"Naive","ability":"Download","item":"Choice Scarf","moves":["U-turn","Iron Head","Ice Beam","Explosion"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":100,"sp":252,"sa":156},"nature":"Naive","ability":"Download","item":"Choice Scarf","moves":["U-turn","Iron Head","Ice Beam","Thunderbolt"]},
 		"ORAS Doubles Choice Scarf": {"level":100,"evs":{"at":252,"sp":192,"sa":64},"nature":"Naive","ability":"Download","item":"Choice Scarf","moves":["U-turn","Iron Head","Ice Beam","Explosion"]},
 	},
 	"Gengar": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Life Orb","moves":["Shadow Ball","Sludge Wave","Focus Blast","Taunt"]},
 		"OU Life Orb Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Life Orb","moves":["Shadow Ball","Sludge Wave","Focus Blast","Taunt"]},
 		"Uber Utility Trapper": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Gengarite","moves":["Taunt","Destiny Bond","Focus Blast","Shadow Ball"]},
 		"Uber Substitute + 3 Attacks": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Gengarite","moves":["Focus Blast","Shadow Ball","Sludge Wave","Substitute"]},
@@ -1123,6 +1206,7 @@ var SETDEX_SM = {
 		"Uber Utility Trapper": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Gengarite","moves":["Taunt","Destiny Bond","Focus Blast","Shadow Ball"]},
 		"Uber Substitute + 3 Attacks": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Gengarite","moves":["Focus Blast","Shadow Ball","Sludge Wave","Substitute"]},
 		"Uber Hex Trapper": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Cursed Body","item":"Gengarite","moves":["Will-O-Wisp","Focus Blast","Hex","Sludge Wave"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Shadow Tag","item":"Gengarite","moves":["Protect","Shadow Ball","Sludge Bomb","Icy Wind"]},
 	},
 	"Geodude": {
 		"ORAS LC Stealth Rock Lead": {"level":5,"evs":{"sd":36,"df":196,"at":196,"hp":36,"sp":36},"nature":"Adamant","ability":"Sturdy","item":"Berry Juice","moves":["Stealth Rock","Sucker Punch","Earthquake","Rock Blast"]},
@@ -1132,14 +1216,17 @@ var SETDEX_SM = {
 	},
 	"Gigalith": {
 		"ORAS PU Tank": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Sturdy","item":"Leftovers","moves":["Stealth Rock","Stone Edge","Superpower","Toxic"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Sand Stream","item":"Leftovers","moves":["Stealth Rock","Toxic","Earthquake","Stone Edge"]},
 	},
 	"Girafarig": {
 		"ORAS PU Baton Pass": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sap Sipper","item":"Life Orb","moves":["Nasty Plot","Baton Pass","Psychic","Hyper Voice"]},
 	},
 	"Giratina": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Pressure","item":"Leftovers","moves":["Defog","Will-O-Wisp","Roar","Hex"]},
 		"ORAS Uber The Great Wall (Physically Defensive)": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Pressure","item":"Leftovers","moves":["Will-O-Wisp","Roar","Rest","Sleep Talk"]},
 	},
 	"Giratina-Origin": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":252,"sp":12,"sa":244},"nature":"Modest","ability":"Levitate","item":"Griseous Orb","moves":["Defog","Draco Meteor","Hex","Shadow Sneak"]},
 		"ORAS Uber ParaHex": {"level":100,"evs":{"df":252,"sp":12,"sa":244},"nature":"Modest","ability":"Levitate","item":"Griseous Orb","moves":["Hex","Draco Meteor","Thunder Wave","Defog"]},
 		"ORAS Uber Physical Defog": {"level":100,"evs":{"df":248,"at":248,"sp":12},"nature":"Adamant","ability":"Levitate","item":"Griseous Orb","moves":["Defog","Shadow Sneak","Dragon Tail","Shadow Force"]},
 	},
@@ -1162,6 +1249,7 @@ var SETDEX_SM = {
 		"ORAS UU Standard": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Impish","ability":"Hyper Cutter","item":"Eviolite","moves":["Roost","Earthquake","Defog","U-turn"]},
 	},
 	"Gliscor": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":184,"hp":252,"sp":72},"nature":"Impish","ability":"Poison Heal","item":"Toxic Orb","moves":["Earthquake","Roost","Stealth Rock","Toxic"]},
 		"ORAS OU Swords Dance Stallbreaker": {"level":100,"evs":{"sd":200,"df":8,"hp":244,"sp":56},"nature":"Careful","ability":"Poison Heal","item":"Toxic Orb","moves":["Swords Dance","Earthquake","Knock Off","Roost"]},
 		"ORAS OU Taunt Stallbreaker": {"level":100,"evs":{"sd":200,"df":8,"hp":244,"sp":56},"nature":"Careful","ability":"Poison Heal","item":"Toxic Orb","moves":["Taunt","Toxic","Roost","Earthquake"]},
 	},
@@ -1190,11 +1278,15 @@ var SETDEX_SM = {
 	"Golett": {
 		"ORAS LC Tank": {"level":5,"evs":{"df":196,"at":164,"hp":44,"sp":76},"nature":"Adamant","ability":"Iron Fist","item":"Eviolite","moves":["Drain Punch","Earthquake","Stealth Rock","Ice Punch"]},
 	},
+	"Golisopod": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Emergency Exit","item":"Lum Berry","moves":["Leech Life","First Impression","Aqua Jet","Liquidation"]},
+	},
 	"Golurk": {
 		"ORAS NU Stealth Rock": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"No Guard","item":"Colbur Berry","moves":["Stealth Rock","Earthquake","Ice Punch","Dynamic Punch"]},
 		"ORAS NU Wallbreaker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Iron Fist","item":"Choice Band","moves":["Earthquake","Shadow Punch","Ice Punch","Zen Headbutt"]},
 	},
 	"Goodra": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"hp":248,"sa":252},"nature":"Modest","ability":"Sap Sipper","item":"Assault Vest","moves":["Draco Meteor","Thunderbolt","Fire Blast","Earthquake"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"at":252,"hp":212,"sp":44},"nature":"Adamant","ability":"Sap Sipper","item":"Choice Band","moves":["Outrage","Earthquake","Power Whip","Iron Tail"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"hp":212,"sp":44,"sa":252},"nature":"Modest","ability":"Sap Sipper","item":"Choice Specs","moves":["Draco Meteor","Fire Blast","Sludge Bomb","Thunderbolt"]},
 		"ORAS UU Assault Vest": {"level":100,"evs":{"sd":8,"hp":248,"sa":252},"nature":"Modest","ability":"Sap Sipper","item":"Assault Vest","moves":["Draco Meteor","Fire Blast","Sludge Bomb","Dragon Tail"]},
@@ -1251,6 +1343,9 @@ var SETDEX_SM = {
 	"Grimer": {
 		"ORAS LC Bulky Attacker": {"level":5,"evs":{"sd":36,"df":196,"at":196,"hp":36},"nature":"Adamant","ability":"Sticky Hold","item":"Berry Juice","moves":["Gunk Shot","Fire Punch","Shadow Sneak","Thief"]},
 	},
+	"Grimer-Alola": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":196,"at":116,"hp":196},"nature":"Relaxed","ability":"Poison Touch","item":"Eviolite","moves":["Knock Off","Shadow Sneak","Pursuit","Gunk Shot"]},
+	},
 	"Groudon": {
 		"Uber Defensive Stealth Rock": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Careful","ability":"Drought","item":"Red Orb","moves":["Stealth Rock","Precipice Blades","Roar","Lava Plume"]},
 		"Uber Rock Polish": {"level":100,"evs":{"sd":36,"at":240,"hp":168,"sp":64},"nature":"Adamant","ability":"Drought","item":"Red Orb","moves":["Rock Polish","Precipice Blades","Swords Dance","Stone Edge"]},
@@ -1298,6 +1393,7 @@ var SETDEX_SM = {
 		"ORAS NU Choice Scarf": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Scarf","moves":["Sludge Bomb","Shadow Ball","Trick","Destiny Bond"]},
 	},
 	"Hawlucha": {
+		"UU Showdown Usage": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Jolly","ability":"Unburden","item":"Sitrus Berry","moves":["Acrobatics","High Jump Kick","Swords Dance","Substitute"]},
 		"OU SubSD": {"level":100,"evs":{"at":244,"hp":12,"sp":252},"nature":"Jolly","ability":"Unburden","item":"Sitrus Berry","moves":["Substitute","Swords Dance","Acrobatics","High Jump Kick"]},
 	},
 	"Haxorus": {
@@ -1314,6 +1410,7 @@ var SETDEX_SM = {
 	"Heatran": {
 		"OU Offensive": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Grassium Z","moves":["Magma Storm","Earth Power","Solar Beam","Taunt"]},
 		"OU Bulky": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Flash Fire","item":"Leftovers","moves":["Taunt","Toxic","Lava Plume","Stealth Rock"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Flash Fire","item":"Shuca Berry","moves":["Protect","Earth Power","Heat Wave","Substitute"]},
 		"Monotype Offensive (Steel)": {"level":100,"evs":{"at":24,"sp":252,"sa":232},"nature":"Timid","ability":"Flash Fire","item":"Grassium Z","moves":["Lava Plume","Earth Power","Stone Edge","Solar Beam"]},
 		"Monotype Defensive (Steel)": {"level":100,"evs":{"sd":136,"hp":248,"sp":124},"nature":"Calm","ability":"Flash Fire","item":"Leftovers","moves":["Lava Plume","Earth Power","Toxic","Stealth Rock"]},
 	},
@@ -1338,6 +1435,8 @@ var SETDEX_SM = {
 		"LC Physical Wall": {"level":5,"evs":{"sd":180,"df":132,"at":20,"hp":132,"sp":20},"nature":"Careful","ability":"Sand Stream","item":"Eviolite","moves":["Slack Off","Stealth Rock","Earthquake","Whirlwind"]},
 	},
 	"Hippowdon": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":176,"df":84,"hp":248},"nature":"Impish","ability":"Sand Stream","item":"Leftovers","moves":["Earthquake","Slack Off","Stealth Rock","Whirlwind"]},
+		"OU Showdown Usage": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Impish","ability":"Sand Stream","item":"Leftovers","moves":["Slack Off","Stealth Rock","Earthquake","Whirlwind"]},
 		"ORAS OU Mixed Wall": {"level":100,"evs":{"sd":112,"df":144,"hp":252},"nature":"Impish","ability":"Sand Stream","item":"Leftovers","moves":["Earthquake","Stealth Rock","Slack Off","Stone Edge"]},
 	},
 	"Hitmonchan": {
@@ -1360,9 +1459,11 @@ var SETDEX_SM = {
 		"Uber Choice Band": {"level":100,"evs":{"sd":52,"at":208,"hp":248},"nature":"Adamant","ability":"Regenerator","item":"Choice Band","moves":["Brave Bird","Sacred Fire","Earthquake","Sleep Talk"]},
 	},
 	"Honchkrow": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Moxie","item":"Flyinium Z","moves":["Brave Bird","Sucker Punch","Superpower","Night Slash"]},
 		"ORAS UU Murderkrow": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Moxie","item":"Life Orb","moves":["Brave Bird","Sucker Punch","Pursuit","Superpower"]},
 	},
 	"Honedge": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":140,"df":116,"at":196,"sp":52},"nature":"Adamant","ability":"No Guard","item":"Eviolite","moves":["Shadow Sneak","Iron Head","Sacred Sword","Pursuit"]},
 		"ORAS LC Specially Defensive": {"level":5,"evs":{"sd":220,"df":36,"at":116,"hp":76,"sp":52},"nature":"Careful","ability":"No Guard","item":"Berry Juice","moves":["Iron Head","Shadow Sneak","Pursuit","Sacred Sword"]},
 	},
 	"Hoopa": {
@@ -1375,6 +1476,7 @@ var SETDEX_SM = {
 		"OU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magician","item":"Choice Specs","moves":["Dark Pulse","Psyshock","Focus Blast","Thunderbolt"]},
 		"OU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Magician","item":"Choice Band","moves":["Hyperspace Fury","Drain Punch","Gunk Shot","Zen Headbutt"]},
 		"OU Choice Scarf": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Hasty","ability":"Magician","item":"Choice Scarf","moves":["Hyperspace Fury","Psychic","Gunk Shot","Drain Punch"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"df":48,"at":60,"hp":188,"sa":212},"nature":"Quiet","ability":"Magician","item":"Sitrus Berry","moves":["Hyperspace Fury","Hyperspace Hole","Protect","Trick Room"]},
 	},
 	"Hoppip": {
 		"ORAS LC Offensive Support": {"level":5,"evs":{"at":236,"hp":76,"sp":196},"nature":"Jolly","ability":"Infiltrator","item":"Berry Juice","moves":["Sleep Powder","Acrobatics","Substitute","Swords Dance"]},
@@ -1394,6 +1496,7 @@ var SETDEX_SM = {
 		"ORAS OU Utility Attacker": {"level":100,"evs":{"df":8,"hp":40,"sp":252,"sa":208},"nature":"Timid","ability":"Flash Fire","item":"Houndoominite","moves":["Nasty Plot","Fire Blast","Dark Pulse","Will-O-Wisp"]},
 	},
 	"Houndour": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":36,"at":36,"sp":236,"sa":196},"nature":"Hasty","ability":"Flash Fire","item":"Life Orb","moves":["Dark Pulse","Fire Blast","Sucker Punch","Destiny Bond"]},
 		"ORAS LC Mixed Attacker": {"level":5,"evs":{"sd":36,"at":36,"sp":236,"sa":196},"ivs":{"hp":0},"nature":"Hasty","ability":"Early Bird","item":"Life Orb","moves":["Fire Blast","Dark Pulse","Sucker Punch","Destiny Bond"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"sd":36,"at":36,"sp":236,"sa":196},"nature":"Hasty","ability":"Flash Fire","item":"Choice Scarf","moves":["Fire Blast","Dark Pulse","Destiny Bond","Pursuit"]},
 	},
@@ -1401,7 +1504,9 @@ var SETDEX_SM = {
 		"ORAS PU Shell Smash": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Naughty","ability":"Water Veil","item":"White Herb","moves":["Shell Smash","Waterfall","Sucker Punch","Ice Beam"]},
 	},
 	"Hydreigon": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Scarf","moves":["Dark Pulse","Draco Meteor","Fire Blast","U-turn"]},
 		"OU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Specs","moves":["Dark Pulse","Draco Meteor","Flash Cannon","Fire Blast"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Dark Pulse","Draco Meteor","Protect","Tailwind"]},
 	},
 	"Hypno": {
 		"ORAS PU NastyPass": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Calm","ability":"Insomnia","item":"Leftovers","moves":["Nasty Plot","Baton Pass","Substitute","Psychic"]},
@@ -1410,6 +1515,7 @@ var SETDEX_SM = {
 		"ORAS PU Substitute + Baton Pass": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Prankster","item":"Leftovers","moves":["Substitute","Baton Pass","Encore","Bug Buzz"]},
 	},
 	"Infernape": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Blaze","item":"Choice Scarf","moves":["Close Combat","Flare Blitz","U-turn","Mach Punch"]},
 		"ORAS UU Nasty Plot": {"level":100,"evs":{"at":136,"sp":252,"sa":120},"nature":"Naive","ability":"Blaze","item":"Life Orb","moves":["Nasty Plot","Fire Blast","Close Combat","Grass Knot"]},
 		"ORAS UU All-Out Attacker": {"level":100,"evs":{"at":168,"sp":252,"sa":88},"nature":"Naive","ability":"Blaze","item":"Life Orb","moves":["Fire Blast","Close Combat","Grass Knot","Earthquake"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Iron Fist","item":"Choice Band","moves":["Close Combat","Flare Blitz","Mach Punch","U-turn"]},
@@ -1426,6 +1532,7 @@ var SETDEX_SM = {
 	},
 	"Jellicent": {
 		"ORAS RU Utility": {"level":100,"evs":{"df":216,"hp":248,"sp":44},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Taunt","Will-O-Wisp","Recover","Scald"]},
+		"UU Showdown Usage": {"level":100,"evs":{"df":224,"hp":240,"sp":44},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Recover","Will-O-Wisp","Hex","Taunt"]},
 		"ORAS UU Physically Defensive": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Recover","Scald","Will-O-Wisp","Taunt"]},
 		"ORAS Doubles Bulky Trick Room Setter": {"level":100,"evs":{"sd":52,"df":204,"hp":252},"ivs":{"sp":0},"nature":"Relaxed","ability":"Water Absorb","item":"Safety Goggles","moves":["Trick Room","Hydro Pump","Will-O-Wisp","Protect"]},
 	},
@@ -1460,12 +1567,14 @@ var SETDEX_SM = {
 		"ORAS RU Seduction Smasher": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Dry Skin","item":"Leftovers","moves":["Lovely Kiss","Nasty Plot","Ice Beam","Substitute"]},
 	},
 	"Kabuto": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":76,"df":36,"at":116,"hp":116,"sp":156},"nature":"Adamant","ability":"Weak Armor","item":"Eviolite","moves":["Rapid Spin","Stealth Rock","Rock Slide","Waterfall"]},
 		"ORAS LC Support": {"level":5,"evs":{"df":196,"at":196,"hp":116},"nature":"Adamant","ability":"Battle Armor","item":"Eviolite","moves":["Rapid Spin","Rock Slide","Aqua Jet","Waterfall"]},
 	},
 	"Kabutops": {
 		"ORAS NU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Swift Swim","item":"Life Orb","moves":["Swords Dance","Stone Edge","Aqua Jet","Waterfall"]},
 		"ORAS NU Choice Scarf": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Choice Scarf","moves":["Waterfall","Stone Edge","Rapid Spin","Superpower"]},
 		"ORAS RU Offensive Rapid Spin": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Weak Armor","item":"Life Orb","moves":["Rapid Spin","Stone Edge","Waterfall","Superpower"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Stone Edge","Waterfall","Aqua Jet","Swords Dance"]},
 		"ORAS OU Physical Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Waterfall","Stone Edge","Swords Dance","Aqua Jet"]},
 	},
 	"Kadabra": {
@@ -1481,6 +1590,7 @@ var SETDEX_SM = {
 	},
 	"Kangaskhan-Mega": {
 		"ORAS Uber Physical Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Scrappy","item":"Kangaskhanite","moves":["Fake Out","Return","Crunch","Power-Up Punch"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Parental Bond","item":"Kangaskhanite","moves":["Fake Out","Sucker Punch","Seismic Toss","Power-Up Punch"]},
 		"ORAS Doubles Power-Up Punch": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Scrappy","item":"Kangaskhanite","moves":["Return","Power-Up Punch","Sucker Punch","Fake Out"]},
 		"ORAS Doubles All-out Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Scrappy","item":"Kangaskhanite","moves":["Double-Edge","Low Kick","Sucker Punch","Fake Out"]},
 	},
@@ -1489,6 +1599,7 @@ var SETDEX_SM = {
 		"ORAS LC Swords Dance": {"level":5,"evs":{"sd":76,"df":76,"at":236,"sp":116},"nature":"Adamant","ability":"No Guard","item":"Eviolite","moves":["Swords Dance","Megahorn","Drill Run","Knock Off"]},
 	},
 	"Kartana": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Beast Boost","item":"Choice Scarf","moves":["Leaf Blade","Sacred Sword","Smart Strike","Swords Dance"]},
 		"VGC17 Sash Attacker": {"level":50,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Beast Boost","item":"Focus Sash","moves":["Leaf Blade","Smart Strike","Sacred Sword","Detect"]},
 		"VGC17 Assault Vest": {"level":50,"evs":{"sd":164,"hp":92,"sp":252},"nature":"Jolly","ability":"Beast Boost","item":"Assault Vest","moves":["Leaf Blade","Smart Strike","Sacred Sword","Night Slash"]},
 	},
@@ -1496,11 +1607,13 @@ var SETDEX_SM = {
 		"ORAS NU Mixed Wallbreaker": {"level":100,"evs":{"at":192,"sp":116,"sa":200},"nature":"Mild","ability":"Protean","item":"Life Orb","moves":["Sucker Punch","Fire Blast","Grass Knot","Knock Off"]},
 	},
 	"Keldeo": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Justified","item":"Choice Scarf","moves":["Secret Sword","Scald","Hydro Pump","Icy Wind"]},
 		"OU Choice Scarf": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Justified","item":"Choice Scarf","moves":["Scald","Secret Sword","Hydro Pump","Hidden Power Electric"]},
 		"OU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Justified","item":"Choice Specs","moves":["Scald","Hydro Pump","Secret Sword","Hidden Power Electric"]},
 	},
 	"Kingdra": {
 		"OU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Choice Specs","moves":["Surf","Draco Meteor","Hydro Pump","Ice Beam"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Protect","Muddy Water","Draco Meteor","Hydro Pump"]},
 	},
 	"Kingler": {
 		"ORAS PU Agility Sweeper": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Hyper Cutter","item":"Splash Plate","moves":["Agility","Crabhammer","Knock Off","Superpower"]},
@@ -1509,6 +1622,7 @@ var SETDEX_SM = {
 		"ORAS PU RestTalk": {"level":100,"evs":{"sd":100,"df":156,"hp":252},"nature":"Impish","ability":"Clear Body","item":"Eviolite","moves":["Shift Gear","Gear Grind","Rest","Sleep Talk"]},
 	},
 	"Klefki": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":200,"df":48,"hp":248,"sp":12},"nature":"Careful","ability":"Prankster","item":"Leftovers","moves":["Spikes","Thunder Wave","Play Rough","Toxic"]},
 		"OU Spikes": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Prankster","item":"Leftovers","moves":["Spikes","Thunder Wave","Play Rough","Foul Play"]},
 		"Uber Support": {"level":100,"evs":{"sd":252,"at":4,"hp":252},"nature":"Careful","ability":"Prankster","item":"Leftovers","moves":["Spikes","Thunder Wave","Toxic","Play Rough"]},
 	},
@@ -1519,6 +1633,7 @@ var SETDEX_SM = {
 		"ORAS LC Defensive": {"level":5,"evs":{"sd":236,"df":236,"hp":36},"nature":"Bold","ability":"Levitate","item":"Eviolite","moves":["Will-O-Wisp","Pain Split","Sludge Bomb","Fire Blast"]},
 	},
 	"Kommo-o": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Bulletproof","item":"Choice Specs","moves":["Clanging Scales","Flamethrower","Focus Blast","Flash Cannon"]},
 		"VGC17 Fightinium Z": {"level":50,"evs":{"hp":244,"sp":12,"sa":252},"nature":"Modest","ability":"Bulletproof","item":"Fightinium Z","moves":["Focus Blast","Clanging Scales","Flamethrower","Protect"]},
 	},
 	"Krabby": {
@@ -1532,6 +1647,7 @@ var SETDEX_SM = {
 		"ORAS PU Choice Band": {"level":100,"evs":{"at":252,"hp":24,"sp":232},"nature":"Adamant","ability":"Intimidate","item":"Choice Band","moves":["Earthquake","Knock Off","Pursuit","Stone Edge"]},
 	},
 	"Krookodile": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Scarf","moves":["Earthquake","Knock Off","Pursuit","Stealth Rock"]},
 		"ORAS UU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Band","moves":["Earthquake","Knock Off","Stone Edge","Pursuit"]},
 		"ORAS UU Non-Choice Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Dread Plate","moves":["Knock Off","Earthquake","Taunt","Pursuit"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Moxie","item":"Choice Scarf","moves":["Earthquake","Knock Off","Stone Edge","Pursuit"]},
@@ -1550,6 +1666,7 @@ var SETDEX_SM = {
 		"OU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Choice Specs","moves":["Draco Meteor","Ice Beam","Earth Power","Hidden Power Fire"]},
 	},
 	"Kyurem-Black": {
+		"OU Showdown Usage": {"level":100,"evs":{"at":252,"sp":252,"sa":4},"nature":"Lonely","ability":"Teravolt","item":"Icium Z","moves":["Ice Beam","Fusion Bolt","Freeze Shock","Dragon Claw"]},
 		"ORAS OU Mixed Wallbreaker": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Mild","ability":"Teravolt","item":"Life Orb","moves":["Ice Beam","Earth Power","Fusion Bolt","Roost"]},
 		"ORAS OU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Teravolt","item":"Choice Band","moves":["Outrage","Fusion Bolt","Iron Head","Dragon Claw"]},
 		"ORAS OU Substitute Attacker": {"level":100,"evs":{"hp":56,"sp":252,"sa":200},"nature":"Mild","ability":"Teravolt","item":"Leftovers","moves":["Substitute","Ice Beam","Fusion Bolt","Earth Power"]},
@@ -1558,12 +1675,14 @@ var SETDEX_SM = {
 		"ORAS Doubles Choice Scarf": {"level":100,"evs":{"at":176,"sp":224,"sa":108},"nature":"Naive","ability":"Teravolt","item":"Choice Scarf","moves":["Ice Beam","Fusion Bolt","Dragon Claw","Iron Head"]},
 	},
 	"Kyurem-White": {
+		"Uber Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Naive","ability":"Turboblaze","item":"Choice Specs","moves":["Ice Beam","Draco Meteor","Fusion Flare","Earth Power"]},
 		"ORAS Uber Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Turboblaze","item":"Choice Specs","moves":["Ice Beam","Draco Meteor","Fusion Flare","Focus Blast"]},
 		"ORAS Uber Life Orb Attacker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Turboblaze","item":"Life Orb","moves":["Ice Beam","Draco Meteor","Fusion Flare","Roost"]},
 		"ORAS Uber Choice Scarf": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Turboblaze","item":"Choice Scarf","moves":["Ice Beam","Draco Meteor","Earth Power","Fusion Flare"]},
 	},
 	"Landorus": {
 		"ORAS Uber All-out Attacker": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Rash","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Knock Off","Rock Slide","Hidden Power Ice"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Protect","Sludge Bomb","Hidden Power Ice"]},
 		"ORAS Doubles Life Orb Attacker": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Sludge Bomb","Rock Slide","Protect"]},
 	},
 	"Landorus-Therian": {
@@ -1571,6 +1690,7 @@ var SETDEX_SM = {
 		"OU Physically Defensive": {"level":100,"evs":{"sd":24,"df":216,"hp":252,"sp":16},"nature":"Impish","ability":"Intimidate","item":"Rocky Helmet","moves":["Earthquake","Stealth Rock","Hidden Power Ice","U-turn"]},
 		"OU Choice Scarf": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Scarf","moves":["Earthquake","U-turn","Stone Edge","Knock Off"]},
 		"OU Double Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Rockium Z","moves":["Swords Dance","Rock Polish","Earthquake","Stone Edge"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Intimidate","item":"Choice Scarf","moves":["Earthquake","U-turn","Rock Slide","Superpower"]},
 	},
 	"Lanturn": {
 		"ORAS NU Assault Vest": {"level":100,"evs":{"sd":132,"sp":124,"sa":252},"nature":"Modest","ability":"Volt Absorb","item":"Assault Vest","moves":["Scald","Volt Switch","Ice Beam","Hidden Power Fire"]},
@@ -1590,6 +1710,7 @@ var SETDEX_SM = {
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"df":36,"at":244,"hp":36,"sp":188},"nature":"Jolly","ability":"Guts","item":"Choice Scarf","moves":["Rock Slide","Earthquake","Superpower","Crunch"]},
 	},
 	"Latias": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Draco Meteor","Psyshock","Defog","Roost"]},
 		"OU Offensive Support": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"ivs":{"at":0},"nature":"Timid","ability":"Levitate","item":"Soul Dew","moves":["Draco Meteor","Psyshock","Healing Wish","Defog"]},
 	},
 	"Latias-Mega": {
@@ -1629,6 +1750,7 @@ var SETDEX_SM = {
 		"ORAS RU Offensive Support": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Prankster","item":"Black Glasses","moves":["Encore","Knock Off","U-turn","Sucker Punch"]},
 	},
 	"Lileep": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":140,"df":140,"hp":228},"nature":"Calm","ability":"Storm Drain","item":"Eviolite","moves":["Recover","Giga Drain","Stealth Rock","Ancient Power"]},
 		"ORAS LC Tank": {"level":5,"evs":{"sd":140,"df":140,"hp":228},"nature":"Calm","ability":"Storm Drain","item":"Eviolite","moves":["Stealth Rock","Giga Drain","Recover","Ancient Power"]},
 	},
 	"Lilligant": {
@@ -1664,29 +1786,36 @@ var SETDEX_SM = {
 		"ORAS LC Life Orb": {"level":5,"evs":{"df":116,"sp":196,"sa":196},"ivs":{"hp":19},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Surf","Rain Dance","Giga Drain","Ice Beam"]},
 	},
 	"Lucario": {
-		"Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Justified","item":"Lucarionite","moves":["Swords Dance","Close Combat","Bullet Punch","Iron Tail"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Justified","item":"Life Orb","moves":["Close Combat","Swords Dance","Extreme Speed","Bullet Punch"]},
+		"Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Lucarionite","moves":["Swords Dance","Close Combat","Bullet Punch","Iron Tail"]},
 		"Battle Spot Singles Physical Attacker": {"level":50,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Lucarionite","moves":["Close Combat","Iron Tail","Extreme Speed","Swords Dance"]},
 		"Battle Spot Singles Special Attacker": {"level":50,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Inner Focus","item":"Lucarionite","moves":["Nasty Plot","Aura Sphere","Flash Cannon","Vacuum Wave"]},
 	},
 	"Lucario-Mega": {
-		"Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Justified","item":"Lucarionite","moves":["Swords Dance","Close Combat","Bullet Punch","Iron Tail"]},
+		"Uber Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Lucarionite","moves":["Swords Dance","Close Combat","Bullet Punch","Iron Tail"]},
 		"Battle Spot Singles Physical Attacker": {"level":50,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Inner Focus","item":"Lucarionite","moves":["Close Combat","Iron Tail","Extreme Speed","Swords Dance"]},
 		"Battle Spot Singles Special Attacker": {"level":50,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Inner Focus","item":"Lucarionite","moves":["Nasty Plot","Aura Sphere","Flash Cannon","Vacuum Wave"]},
 	},
 	"Ludicolo": {
 		"ORAS NU Rain Dance": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Giga Drain","Ice Beam","Rain Dance"]},
 		"ORAS RU Swift Swim Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Giga Drain","Ice Beam","Rain Dance"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Giga Drain","Ice Beam","Hydro Pump","Rain Dance"]},
 		"ORAS UU Rain Dance Sweeper": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Giga Drain","Ice Beam","Rain Dance"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Swift Swim","item":"Life Orb","moves":["Swords Dance","Waterfall","Seed Bomb","Ice Punch"]},
 		"ORAS OU Rain Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Giga Drain","Ice Beam","Focus Blast"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":28,"sp":228,"sa":224},"nature":"Modest","ability":"Swift Swim","item":"Assault Vest","moves":["Giga Drain","Hydro Pump","Fake Out","Ice Beam"]},
 		"ORAS Doubles Special Attacker": {"level":100,"evs":{"hp":104,"sp":152,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Assault Vest","moves":["Fake Out","Hydro Pump","Giga Drain","Ice Beam"]},
 		"ORAS Doubles Life Orb Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Giga Drain","Ice Beam","Protect"]},
 	},
 	"Lugia": {
+		"Uber Showdown Usage": {"level":100,"evs":{"df":120,"hp":252,"sp":136},"nature":"Bold","ability":"Multiscale","item":"Leftovers","moves":["Roost","Toxic","Whirlwind","Ice Beam"]},
 		"ORAS Uber Physically Defensive": {"level":100,"evs":{"df":120,"hp":252,"sp":136},"nature":"Bold","ability":"Multiscale","item":"Leftovers","moves":["Roost","Whirlwind","Toxic","Ice Beam"]},
 	},
 	"Lumineon": {
 		"ORAS PU Defog": {"level":100,"evs":{"df":248,"hp":252,"sp":8},"nature":"Bold","ability":"Storm Drain","item":"Leftovers","moves":["Defog","Scald","U-turn","Toxic"]},
+	},
+	"Lunala": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Shadow Shield","item":"Choice Scarf","moves":["Moongeist Beam","Psyshock","Focus Blast","Ice Beam"]},
 	},
 	"Lunatone": {
 		"ORAS PU Rock Polish": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Levitate","item":"Life Orb","moves":["Rock Polish","Psychic","Ancient Power","Earth Power"]},
@@ -1696,6 +1825,9 @@ var SETDEX_SM = {
 	},
 	"Luxray": {
 		"ORAS PU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Intimidate","item":"Choice Band","moves":["Wild Charge","Ice Fang","Superpower","Volt Switch"]},
+	},
+	"Lycanroc": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sand Rush","item":"Focus Sash","moves":["Stone Edge","Accelerock","Stealth Rock","Taunt"]},
 	},
 	"Machamp": {
 		"ORAS UU Assault Vest": {"level":100,"evs":{"at":252,"hp":172,"sp":84},"nature":"Adamant","ability":"No Guard","item":"Assault Vest","moves":["Dynamic Punch","Knock Off","Heavy Slam","Stone Edge"]},
@@ -1708,6 +1840,7 @@ var SETDEX_SM = {
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"df":36,"at":196,"hp":36,"sp":236},"nature":"Jolly","ability":"No Guard","item":"Choice Scarf","moves":["Dynamic Punch","Knock Off","Rock Slide","Poison Jab"]},
 	},
 	"Magby": {
+		"LC Showdown Usage": {"level":5,"evs":{"at":236,"sp":252},"nature":"Jolly","ability":"Flame Body","item":"Berry Juice","moves":["Mach Punch","Belly Drum","Thunder Punch","Fire Punch"]},
 		"ORAS LC Belly Drum": {"level":5,"evs":{"at":236,"sp":252},"ivs":{"hp":29},"nature":"Jolly","ability":"Vital Spirit","item":"Berry Juice","moves":["Belly Drum","Fire Punch","Mach Punch","Return"]},
 		"ORAS LC Life Orb": {"level":5,"evs":{"at":236,"sp":252},"ivs":{"hp":0},"nature":"Jolly","ability":"Vital Spirit","item":"Life Orb","moves":["Flare Blitz","Cross Chop","Mach Punch","Return"]},
 	},
@@ -1718,6 +1851,7 @@ var SETDEX_SM = {
 		"OU Shift Gear": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Soul-Heart","item":"Steelium Z","moves":["Flash Cannon","Aura Sphere","Thunderbolt","Shift Gear"]},
 		"OU Assault Vest": {"level":100,"evs":{"sd":8,"hp":248,"sa":252},"nature":"Modest","ability":"Soul-Heart","item":"Assault Vest","moves":["Fleur Cannon","Flash Cannon","Volt Switch","Aura Sphere"]},
 		"OU Choice Specs": {"level":100,"evs":{"hp":212,"sp":44,"sa":252},"nature":"Modest","ability":"Soul-Heart","item":"Choice Specs","moves":["Fleur Cannon","Flash Cannon","Volt Switch","Aura Sphere"]},
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Calm","ability":"Soul-Heart","item":"Leftovers","moves":["Heart Swap","Fleur Cannon","Flash Cannon","Pain Split"]},
 	},
 	"Magmortar": {
 		"ORAS NU Assault Vest Tank": {"level":100,"evs":{"hp":64,"sp":192,"sa":252},"nature":"Modest","ability":"Vital Spirit","item":"Assault Vest","moves":["Fire Blast","Thunderbolt","Hidden Power Grass","Flame Charge"]},
@@ -1729,6 +1863,7 @@ var SETDEX_SM = {
 	},
 	"Magneton": {
 		"ORAS RU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Analytic","item":"Choice Specs","moves":["Volt Switch","Thunderbolt","Flash Cannon","Hidden Power Water"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magnet Pull","item":"Choice Specs","moves":["Flash Cannon","Volt Switch","Thunderbolt","Hidden Power Fire"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magnet Pull","item":"Choice Specs","moves":["Thunderbolt","Flash Cannon","Volt Switch","Hidden Power Ice"]},
 		"ORAS OU Choice Scarf": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Magnet Pull","item":"Choice Scarf","moves":["Volt Switch","Thunderbolt","Flash Cannon","Hidden Power Fire"]},
 	},
@@ -1747,14 +1882,17 @@ var SETDEX_SM = {
 		"Battle Spot Singles Assault Vest": {"level":50,"evs":{"sd":252,"at":212,"hp":44},"nature":"Adamant","ability":"Snow Cloak","item":"Assault Vest","moves":["Earthquake","Ice Shard","Icicle Spear","Fissure"]},
 	},
 	"Manaphy": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Hydration","item":"Waterium Z","moves":["Tail Glow","Surf","Energy Ball","Ice Beam"]},
 		"ORAS OU Tail Glow + 3 Attacks": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Hydration","item":"Leftovers","moves":["Tail Glow","Scald","Ice Beam","Energy Ball"]},
 		"ORAS OU Tail Glow + Rain Dance": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Hydration","item":"Leftovers","moves":["Tail Glow","Rain Dance","Scald","Psychic"]},
 		"ORAS OU Calm Mind": {"level":100,"evs":{"df":240,"hp":252,"sp":16},"nature":"Bold","ability":"Hydration","item":"Leftovers","moves":["Calm Mind","Scald","Rain Dance","Rest"]},
 		"ORAS Doubles Tail Glow": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Hydration","item":"Safety Goggles","moves":["Scald","Ice Beam","Tail Glow","Protect"]},
 	},
 	"Mandibuzz": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Overcoat","item":"Leftovers","moves":["Roost","Defog","Foul Play","Toxic"]},
 		"ORAS UU Specially Defensive": {"level":100,"evs":{"sd":216,"hp":240,"sp":52},"nature":"Careful","ability":"Overcoat","item":"Leftovers","moves":["Roost","Knock Off","Taunt","Defog"]},
 		"ORAS UU Physically Defensive": {"level":100,"evs":{"df":216,"hp":240,"sp":52},"nature":"Impish","ability":"Overcoat","item":"Leftovers","moves":["Roost","Foul Play","Taunt","Defog"]},
+		"OU Showdown Usage": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Overcoat","item":"Leftovers","moves":["Roost","Defog","Foul Play","Whirlwind"]},
 		"ORAS OU Utility Buzzard": {"level":100,"evs":{"sd":108,"df":136,"hp":248,"sp":16},"nature":"Bold","ability":"Overcoat","item":"Leftovers","moves":["Foul Play","Roost","Taunt","Defog"]},
 		"Monotype Physically Defensive Defogger (Dark)": {"level":100,"evs":{"df":244,"hp":248,"sp":16},"nature":"Impish","ability":"Overcoat","item":"Rocky Helmet","moves":["Roost","Foul Play","Defog","U-turn"]},
 	},
@@ -1775,6 +1913,7 @@ var SETDEX_SM = {
 		"ORAS NU SubToxic": {"level":100,"evs":{"hp":8,"sp":252,"sa":248},"nature":"Modest","ability":"Water Absorb","item":"Leftovers","moves":["Substitute","Toxic","Scald","Air Slash"]},
 		"ORAS NU Mixed Defensive Defog": {"level":100,"evs":{"sd":16,"df":240,"hp":252},"nature":"Calm","ability":"Water Absorb","item":"Leftovers","moves":["Defog","Scald","Air Slash","Toxic"]},
 		"ORAS NU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Choice Specs","moves":["Hydro Pump","Scald","Air Slash","Signal Beam"]},
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Scald","Roost","Defog","Toxic"]},
 	},
 	"Mantyke": {
 		"ORAS LC Rain Dance": {"level":5,"evs":{"df":36,"hp":76,"sp":196,"sa":200},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Rain Dance","Air Slash","Hidden Power Ground"]},
@@ -1782,6 +1921,9 @@ var SETDEX_SM = {
 	},
 	"Maractus": {
 		"ORAS PU Spikes Lead": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Water Absorb","item":"Focus Sash","moves":["Spikes","Bullet Seed","Endeavor","Sucker Punch"]},
+	},
+	"Mareanie": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":180,"df":180,"hp":36,"sp":76,"sa":12},"nature":"Bold","ability":"Regenerator","item":"Eviolite","moves":["Recover","Scald","Toxic Spikes","Sludge Bomb"]},
 	},
 	"Mareep": {
 		"ORAS LC Dual Screens": {"level":5,"evs":{"sd":76,"df":196,"hp":236},"nature":"Bold","ability":"Static","item":"Eviolite","moves":["Light Screen","Reflect","Thunder Wave","Thunderbolt"]},
@@ -1792,6 +1934,7 @@ var SETDEX_SM = {
 	},
 	"Marowak-Alola": {
 		"OU Utility Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Lightning Rod","item":"Thick Club","moves":["Shadow Bone","Fire Punch","Bonemerang","Will-O-Wisp"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":8,"at":252,"hp":248},"nature":"Adamant","ability":"Lightning Rod","item":"Thick Club","moves":["Flare Blitz","Bonemerang","Protect","Shadow Bone"]},
 		"VGC17 Offensive": {"level":50,"evs":{"sd":68,"df":4,"at":180,"hp":252,"sp":4},"nature":"Adamant","ability":"Lightning Rod","item":"Thick Club","moves":["Flare Blitz","Shadow Bone","Bonemerang","Detect"]},
 	},
 	"Masquerain": {
@@ -1843,6 +1986,7 @@ var SETDEX_SM = {
 		"ORAS RU Dual Screens": {"level":100,"evs":{"df":236,"hp":248,"sp":24},"nature":"Timid","ability":"Prankster","item":"Light Clay","moves":["Reflect","Light Screen","Thunder Wave","Psyshock"]},
 	},
 	"Meowth": {
+		"LC Showdown Usage": {"level":5,"evs":{"at":236,"sp":196,"sa":36},"nature":"Hasty","ability":"Technician","item":"Life Orb","moves":["Fake Out","Water Pulse","Feint","Double-Edge"]},
 		"ORAS LC Mixed Attacker": {"level":5,"evs":{"sd":36,"at":236,"sp":196,"sa":36},"ivs":{"hp":19},"nature":"Hasty","ability":"Technician","item":"Life Orb","moves":["Fake Out","Feint","Water Pulse","Aerial Ace"]},
 		"ORAS LC Nasty Plot": {"level":5,"evs":{"df":76,"sp":200,"sa":200},"ivs":{"hp":19},"nature":"Modest","ability":"Technician","item":"Life Orb","moves":["Nasty Plot","Round","Water Pulse","Hidden Power Fire"]},
 	},
@@ -1857,20 +2001,24 @@ var SETDEX_SM = {
 		"ORAS RU Offensive Stealth Rock": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Colbur Berry","moves":["Stealth Rock","Healing Wish","Psyshock","Dazzling Gleam"]},
 	},
 	"Metagross": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Clear Body","item":"Shuca Berry","moves":["Meteor Mash","Earthquake","Stealth Rock","Bullet Punch"]},
 		"OU All Out Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Clear Body","item":"Metagrossite","moves":["Meteor Mash","Zen Headbutt","Earthquake","Thunder Punch"]},
 		"VGC17 Bulky Attacker": {"level":50,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Clear Body","item":"Assault Vest","moves":["Meteor Mash","Bullet Punch","Zen Headbutt","Hammer Arm"]},
 		"VGC17 Psychium Z": {"level":50,"evs":{"at":252,"hp":132,"sp":124},"nature":"Jolly","ability":"Clear Body","item":"Psychium Z","moves":["Zen Headbutt","Meteor Mash","Bullet Punch","Protect"]},
 	},
 	"Metagross-Mega": {
 		"OU All Out Attacker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Clear Body","item":"Metagrossite","moves":["Meteor Mash","Zen Headbutt","Earthquake","Thunder Punch"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Tough Claws","item":"Metagrossite","moves":["Zen Headbutt","Protect","Iron Head","Ice Punch"]},
 	},
 	"Metang": {
 		"ORAS PU Offensive Stealth Rock": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Clear Body","item":"Eviolite","moves":["Stealth Rock","Meteor Mash","Earthquake","Bullet Punch"]},
 	},
 	"Mew": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":228,"hp":252,"sp":28},"nature":"Careful","ability":"Synchronize","item":"Leftovers","moves":["Stealth Rock","Soft-Boiled","Taunt","Psychic"]},
 		"OU Utility": {"level":100,"evs":{"sd":200,"hp":252,"sp":56},"nature":"Careful","ability":"Synchronize","item":"Leftovers","moves":["Taunt","Soft-Boiled","Will-O-Wisp","Knock Off"]},
 	},
 	"Mewtwo": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Life Orb","moves":["Psystrike","Ice Beam","Taunt","Fire Blast"]},
 		"ORAS Uber Special Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Life Orb","moves":["Psystrike","Focus Blast","Ice Beam","Fire Blast"]},
 		"ORAS Uber Physical Attacker": {"level":100,"evs":{"df":144,"at":112,"sp":252},"nature":"Jolly","ability":"Pressure","item":"Mewtwonite X","moves":["Low Kick","Taunt","Earthquake","Ice Punch"]},
 	},
@@ -1881,12 +2029,14 @@ var SETDEX_SM = {
 		"ORAS Uber Special Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Life Orb","moves":["Psystrike","Focus Blast","Ice Beam","Fire Blast"]},
 	},
 	"Mienfoo": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":36,"at":236,"sp":236},"nature":"Jolly","ability":"Regenerator","item":"Eviolite","moves":["Knock Off","U-turn","Drain Punch","High Jump Kick"]},
 		"ORAS LC Bulky Attacker": {"level":5,"evs":{"sd":36,"df":196,"sp":236},"nature":"Jolly","ability":"Regenerator","item":"Eviolite","moves":["Drain Punch","Knock Off","U-turn","Taunt"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"sd":36,"at":236,"sp":236},"nature":"Adamant","ability":"Regenerator","item":"Choice Scarf","moves":["High Jump Kick","Knock Off","U-turn","Drain Punch"]},
 		"ORAS LC Life Orb": {"level":5,"evs":{"df":36,"at":236,"sp":236},"nature":"Jolly","ability":"Regenerator","item":"Life Orb","moves":["High Jump Kick","Knock Off","U-turn","Fake Out"]},
 		"ORAS LC Baton Pass": {"level":5,"evs":{"sd":196,"df":116,"at":76,"hp":76},"nature":"Impish","ability":"Regenerator","item":"Eviolite","moves":["Baton Pass","Swords Dance","Drain Punch","Knock Off"]},
 	},
 	"Mienshao": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Reckless","item":"Choice Scarf","moves":["U-turn","High Jump Kick","Knock Off","Stone Edge"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Reckless","item":"Choice Scarf","moves":["High Jump Kick","U-turn","Knock Off","Stone Edge"]},
 		"ORAS UU Life Orb": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Regenerator","item":"Life Orb","moves":["High Jump Kick","Knock Off","U-turn","Poison Jab"]},
 		"ORAS UU SubPass": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Regenerator","item":"Life Orb","moves":["Substitute","Baton Pass","High Jump Kick","Stone Edge"]},
@@ -1896,6 +2046,7 @@ var SETDEX_SM = {
 	},
 	"Milotic": {
 		"ORAS UU Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Marvel Scale","item":"Leftovers","moves":["Scald","Ice Beam","Haze","Recover"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Competitive","item":"Maranga Berry","moves":["Scald","Recover","Protect","Icy Wind"]},
 		"ORAS Doubles Defensive": {"level":100,"evs":{"df":188,"hp":252,"sp":44,"sa":24},"nature":"Bold","ability":"Competitive","item":"Sitrus Berry","moves":["Scald","Icy Wind","Recover","Protect"]},
 		"ORAS Doubles Offensive": {"level":100,"evs":{"df":80,"hp":72,"sp":168,"sa":188},"nature":"Modest","ability":"Competitive","item":"Life Orb","moves":["Hydro Pump","Ice Beam","Recover","Protect"]},
 		"VGC17 Anti-Intimidate Tank": {"level":50,"evs":{"sd":4,"df":76,"hp":252,"sp":4,"sa":172},"nature":"Calm","ability":"Competitive","item":"Sitrus Berry","moves":["Scald","Ice Beam","Recover","Protect"]},
@@ -1908,6 +2059,7 @@ var SETDEX_SM = {
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"df":80,"sp":200,"sa":200},"nature":"Timid","ability":"Technician","item":"Choice Scarf","moves":["Psychic","Hidden Power Fighting","Healing Wish","Baton Pass"]},
 	},
 	"Mimikyu": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Disguise","item":"Life Orb","moves":["Play Rough","Shadow Claw","Swords Dance","Shadow Sneak"]},
 		"Battle Spot Singles Swords Dance": {"level":50,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Disguise","item":"Life Orb","moves":["Swords Dance","Play Rough","Shadow Sneak","Shadow Claw"]},
 		"Monotype Swords Dance (Ghost)": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Disguise","item":"Ghostium Z","moves":["Swords Dance","Shadow Sneak","Play Rough","Shadow Claw"]},
 	},
@@ -1966,6 +2118,7 @@ var SETDEX_SM = {
 	"Muk-Alola": {
 		"OU Assault Vest": {"level":100,"evs":{"sd":16,"at":240,"hp":252},"nature":"Adamant","ability":"Poison Touch","item":"Assault Vest","moves":["Knock Off","Pursuit","Poison Jab","Shadow Sneak"]},
 		"Uber Pursuit Trapper": {"level":100,"evs":{"sd":176,"at":80,"hp":252},"nature":"Adamant","ability":"Poison Touch","item":"Assault Vest","moves":["Pursuit","Knock Off","Poison Jab","Shadow Sneak"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":184,"df":4,"at":68,"hp":252},"nature":"Brave","ability":"Gluttony","item":"Figy Berry","moves":["Knock Off","Protect","Poison Jab","Shadow Sneak"]},
 		"VGC17 Tanky Trash (Bulky Attacker)": {"level":50,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Gluttony","item":"Figy Berry","moves":["Knock Off","Poison Jab","Imprison","Protect"]},
 		"VGC17 Setup Sludge (Setup Attacker)": {"level":50,"evs":{"sd":40,"df":172,"at":44,"hp":252},"nature":"Brave","ability":"Gluttony","item":"Figy Berry","moves":["Knock Off","Poison Jab","Curse","Protect"]},
 	},
@@ -1992,12 +2145,15 @@ var SETDEX_SM = {
 		"ORAS PU Entry Hazards; Natu-day": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Bold","ability":"Magic Bounce","item":"Eviolite","moves":["Psychic","U-turn","Thunder Wave","Roost"]},
 	},
 	"Necrozma": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Prism Armor","item":"Leftovers","moves":["Stealth Rock","Moonlight","Psychic","Calm Mind"]},
 		"OU Stored Power": {"level":100,"evs":{"df":144,"hp":252,"sp":112},"nature":"Bold","ability":"Prism Armor","item":"Leftovers","moves":["Calm Mind","Morning Sun","Stored Power","Iron Defense"]},
 	},
 	"Nidoking": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Sludge Wave","Ice Beam","Thunderbolt"]},
 		"OU Life Orb Attacker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Sludge Wave","Ice Beam","Flamethrower"]},
 	},
 	"Nidoqueen": {
+		"UU Showdown Usage": {"level":100,"evs":{"hp":180,"sp":76,"sa":252},"nature":"Modest","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Stealth Rock","Ice Beam","Sludge Wave"]},
 		"ORAS UU Offensive Entry Hazard Setter": {"level":100,"evs":{"hp":180,"sp":76,"sa":252},"nature":"Modest","ability":"Sheer Force","item":"Life Orb","moves":["Earth Power","Ice Beam","Stealth Rock","Sludge Wave"]},
 		"ORAS UU Defensive Entry Hazard Setter": {"level":100,"evs":{"df":240,"hp":248,"sa":20},"nature":"Bold","ability":"Sheer Force","item":"Black Sludge","moves":["Stealth Rock","Roar","Ice Beam","Earth Power"]},
 	},
@@ -2015,7 +2171,9 @@ var SETDEX_SM = {
 		"ORAS NU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flash Fire","item":"Life Orb","moves":["Nasty Plot","Fire Blast","Psyshock","Energy Ball"]},
 	},
 	"Ninetales-Alola": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Snow Warning","item":"Light Clay","moves":["Moonblast","Aurora Veil","Freeze-Dry","Blizzard"]},
 		"OU Utility": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"ivs":{"at":0},"nature":"Timid","ability":"Snow Warning","item":"Light Clay","moves":["Aurora Veil","Freeze-Dry","Moonblast","Encore"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Snow Warning","item":"Light Clay","moves":["Blizzard","Aurora Veil","Moonblast","Freeze-Dry"]},
 		"VGC17 Hail Setter": {"level":50,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Snow Warning","item":"Focus Sash","moves":["Blizzard","Freeze-Dry","Aurora Veil","Protect"]},
 	},
 	"Ninjask": {
@@ -2029,6 +2187,7 @@ var SETDEX_SM = {
 		"ORAS LC Tailwind + 3 Attacks": {"level":5,"evs":{"sd":36,"sp":236,"sa":236},"ivs":{"hp":9},"nature":"Timid","ability":"Infiltrator","item":"Life Orb","moves":["Draco Meteor","Hurricane","Heat Wave","Tailwind"]},
 	},
 	"Noivern": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Infiltrator","item":"Choice Specs","moves":["Draco Meteor","Hurricane","U-turn","Flamethrower"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Infiltrator","item":"Choice Specs","moves":["Draco Meteor","Hurricane","Flamethrower","Switcheroo"]},
 		"ORAS UU Taunt + Roost": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Infiltrator","item":"Leftovers","moves":["Draco Meteor","Flamethrower","Taunt","Roost"]},
 	},
@@ -2063,6 +2222,7 @@ var SETDEX_SM = {
 		"LC Stealth Rock": {"level":5,"evs":{"at":236,"hp":76,"sp":196},"nature":"Jolly","ability":"Sturdy","item":"Berry Juice","moves":["Stealth Rock","Rock Blast","Earthquake","Taunt"]},
 	},
 	"Oranguru": {
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":92,"df":164,"hp":252},"nature":"Calm","ability":"Inner Focus","item":"Sitrus Berry","moves":["Instruct","Trick Room","Psychic","Protect"]},
 		"VGC17 Trick Room": {"level":50,"evs":{"sd":92,"df":140,"hp":252,"sa":20},"ivs":{"sp":0},"nature":"Sassy","ability":"Inner Focus","item":"Mental Herb","moves":["Trick Room","Psychic","Instruct","Protect"]},
 	},
 	"Oshawott": {
@@ -2106,6 +2266,7 @@ var SETDEX_SM = {
 	},
 	"Pelipper": {
 		"OU Physically Defensive": {"level":100,"evs":{"sd":64,"df":196,"hp":248},"nature":"Bold","ability":"Drizzle","item":"Damp Rock","moves":["Scald","Hurricane","U-turn","Roost"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":252,"sp":4,"sa":252},"nature":"Modest","ability":"Drizzle","item":"Damp Rock","moves":["Hurricane","Tailwind","Scald","U-turn"]},
 		"VGC17 Offensive Rain Setter": {"level":50,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Drizzle","item":"Focus Sash","moves":["Scald","Hurricane","Tailwind","Protect"]},
 		"Battle Spot Doubles Offensive Rain Support": {"level":50,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Drizzle","item":"Focus Sash","moves":["Hurricane","Scald","Tailwind","Protect"]},
 	},
@@ -2116,6 +2277,7 @@ var SETDEX_SM = {
 		"ORAS LC Sun Support": {"level":5,"evs":{"sd":36,"df":120,"sp":200,"sa":120},"nature":"Timid","ability":"Chlorophyll","item":"Eviolite","moves":["Giga Drain","Sleep Powder","Healing Wish","Hidden Power Fire"]},
 	},
 	"Phanpy": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":196,"at":116,"hp":196},"nature":"Impish","ability":"Pickup","item":"Eviolite","moves":["Earthquake","Knock Off","Ice Shard","Play Rough"]},
 		"ORAS LC Utility": {"level":5,"evs":{"sd":36,"df":196,"at":116,"hp":116,"sp":36},"nature":"Impish","ability":"Pickup","item":"Eviolite","moves":["Stealth Rock","Knock Off","Earthquake","Roar"]},
 	},
 	"Phantump": {
@@ -2165,7 +2327,9 @@ var SETDEX_SM = {
 	},
 	"Politoed": {
 		"ORAS PU Tank": {"level":100,"evs":{"df":8,"hp":248,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Leftovers","moves":["Scald","Ice Beam","Hidden Power Electric","Encore"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":164,"hp":248,"sp":96},"nature":"Calm","ability":"Drizzle","item":"Damp Rock","moves":["Encore","Toxic","Scald","Ice Beam"]},
 		"ORAS OU Support": {"level":100,"evs":{"sd":164,"hp":248,"sp":96},"nature":"Calm","ability":"Drizzle","item":"Damp Rock","moves":["Scald","Toxic","Encore","Rest"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":16,"hp":4,"sp":56,"sa":124},"nature":"Calm","ability":"Drizzle","item":"Sitrus Berry","moves":["Scald","Icy Wind","Helping Hand","Rain Dance"]},
 		"ORAS Doubles Rain Setter": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Drizzle","item":"Sitrus Berry","moves":["Scald","Icy Wind","Helping Hand","Protect"]},
 	},
 	"Poliwag": {
@@ -2177,6 +2341,7 @@ var SETDEX_SM = {
 		"ORAS UU RestTalk": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Relaxed","ability":"Water Absorb","item":"Leftovers","moves":["Rest","Sleep Talk","Scald","Circle Throw"]},
 	},
 	"Ponyta": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":76,"df":156,"at":76,"sp":196},"nature":"Jolly","ability":"Flame Body","item":"Eviolite","moves":["Morning Sun","Flare Blitz","Will-O-Wisp","Wild Charge"]},
 		"ORAS LC Utility": {"level":5,"evs":{"sd":76,"df":156,"at":76,"sp":196},"nature":"Jolly","ability":"Flame Body","item":"Eviolite","moves":["Flare Blitz","Morning Sun","Will-O-Wisp","Flame Charge"]},
 	},
 	"Poochyena": {
@@ -2192,13 +2357,16 @@ var SETDEX_SM = {
 		"OU Z-Conversion": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Adaptability","item":"Normalium Z","moves":["Thunderbolt","Ice Beam","Hidden Power Ground","Conversion"]},
 	},
 	"Porygon2": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Download","item":"Eviolite","moves":["Recover","Ice Beam","Tri Attack","Thunderbolt"]},
 		"ORAS UU Defensive": {"level":100,"evs":{"sd":136,"df":120,"hp":252},"nature":"Calm","ability":"Trace","item":"Eviolite","moves":["Recover","Tri Attack","Ice Beam","Thunder Wave"]},
 		"ORAS UU Offensive": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"ivs":{"sp":0},"nature":"Quiet","ability":"Download","item":"Eviolite","moves":["Trick Room","Recover","Thunderbolt","Ice Beam"]},
 		"ORAS OU Defensive": {"level":100,"evs":{"sd":56,"df":200,"hp":252},"nature":"Calm","ability":"Trace","item":"Eviolite","moves":["Ice Beam","Thunderbolt","Recover","Toxic"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":252,"hp":252,"sa":4},"nature":"Sassy","ability":"Download","item":"Eviolite","moves":["Recover","Ice Beam","Trick Room","Thunderbolt"]},
 		"ORAS Doubles Trick Room": {"level":100,"evs":{"sd":76,"df":160,"hp":252,"sa":20},"nature":"Sassy","ability":"Download","item":"Eviolite","moves":["Trick Room","Recover","Ice Beam","Foul Play"]},
 		"VGC17 Standard": {"level":50,"evs":{"sd":188,"df":76,"hp":244},"ivs":{"sp":0},"nature":"Sassy","ability":"Download","item":"Eviolite","moves":["Trick Room","Ice Beam","Thunderbolt","Recover"]},
 	},
 	"Primarina": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"hp":252,"sa":252},"nature":"Modest","ability":"Torrent","item":"Choice Specs","moves":["Moonblast","Hydro Pump","Energy Ball","Psychic"]},
 		"OU Choice Specs": {"level":100,"evs":{"hp":172,"sp":84,"sa":252},"nature":"Modest","ability":"Torrent","item":"Choice Specs","moves":["Hydro Pump","Moonblast","Psychic","Hidden Power Fire"]},
 	},
 	"Primeape": {
@@ -2215,6 +2383,7 @@ var SETDEX_SM = {
 		"ORAS NU Steel Trapper": {"level":100,"evs":{"hp":172,"sp":84,"sa":252},"nature":"Modest","ability":"Magnet Pull","item":"Air Balloon","moves":["Stealth Rock","Earth Power","Magnet Rise","Taunt"]},
 	},
 	"Pumpkaboo-Small": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":76,"df":36,"hp":4,"sp":148,"sa":244},"nature":"Modest","ability":"Frisk","item":"Ghostium Z","moves":["Trick-or-Treat","Shadow Ball","Fire Blast","Giga Drain"]},
 		"ORAS LC Mixed Attacker": {"level":5,"evs":{"df":36,"at":228,"sp":228,"sa":4},"ivs":{"hp":0},"nature":"Naughty","ability":"Frisk","item":"Life Orb","moves":["Bullet Seed","Fire Blast","Shadow Sneak","Rock Slide"]},
 	},
 	"Pumpkaboo-Super": {
@@ -2231,7 +2400,11 @@ var SETDEX_SM = {
 	"Pyroar": {
 		"ORAS NU Special Attacker": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Unnerve","item":"Life Orb","moves":["Fire Blast","Hyper Voice","Hidden Power Grass","Will-O-Wisp"]},
 	},
+	"Pyukumuku": {
+		"OU Showdown Usage": {"level":100,"evs":{"hp":252},"nature":"Hasty","ability":"Innards Out","item":"Rocky Helmet","moves":["Recover","Toxic","Counter","Soak"]},
+	},
 	"Quagsire": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Unaware","item":"Leftovers","moves":["Recover","Earthquake","Scald","Curse"]},
 		"OU Physical Wall": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Unaware","item":"Leftovers","moves":["Scald","Earthquake","Recover","Toxic"]},
 	},
 	"Quilladin": {
@@ -2254,6 +2427,7 @@ var SETDEX_SM = {
 		"VGC17 Offensive Support": {"level":50,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Surge Surfer","item":"Psychium Z","moves":["Fake Out","Thunderbolt","Psychic","Protect"]},
 	},
 	"Raikou": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Choice Specs","moves":["Thunderbolt","Volt Switch","Hidden Power Ice","Shadow Ball"]},
 		"ORAS OU Calm Mind": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Leftovers","moves":["Calm Mind","Thunderbolt","Hidden Power Ice","Volt Switch"]},
 		"ORAS OU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Choice Specs","moves":["Thunderbolt","Volt Switch","Hidden Power Ice","Shadow Ball"]},
 		"ORAS OU Assault Vest": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Pressure","item":"Assault Vest","moves":["Thunderbolt","Volt Switch","Hidden Power Ice","Shadow Ball"]},
@@ -2283,6 +2457,7 @@ var SETDEX_SM = {
 		"Uber Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Air Lock","item":"Choice Band","moves":["Dragon Ascent","V-create","Extreme Speed","Earthquake"]},
 	},
 	"Rayquaza-Mega": {
+		"AG Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Delta Stream","item":"Life Orb","moves":["Dragon Ascent","Extreme Speed","V-create","Earthquake"]},
 	},
 	"Regice": {
 		"ORAS PU Rock Polish": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Clear Body","item":"Life Orb","moves":["Rock Polish","Ice Beam","Thunderbolt","Focus Blast"]},
@@ -2314,6 +2489,7 @@ var SETDEX_SM = {
 		"Uber Z-Move Wallbreaker": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Modest","ability":"Turboblaze","item":"Grassium Z","moves":["Blue Flare","Draco Meteor","Solar Beam","Stone Edge"]},
 	},
 	"Reuniclus": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Magic Guard","item":"Poisonium Z","moves":["Psyshock","Recover","Calm Mind","Toxic"]},
 		"ORAS UU Calm Mind": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Magic Guard","item":"Leftovers","moves":["Calm Mind","Psyshock","Focus Blast","Recover"]},
 		"ORAS UU Trick Room": {"level":100,"evs":{"df":4,"hp":252,"sa":252},"nature":"Quiet","ability":"Magic Guard","item":"Life Orb","moves":["Trick Room","Psyshock","Focus Blast","Shadow Ball"]},
 		"ORAS OU Calm Mind": {"level":100,"evs":{"sd":56,"df":200,"hp":252},"nature":"Bold","ability":"Magic Guard","item":"Leftovers","moves":["Calm Mind","Psyshock","Focus Blast","Recover"]},
@@ -2348,6 +2524,7 @@ var SETDEX_SM = {
 		"ORAS RU Bulky Spiker": {"level":100,"evs":{"sd":88,"df":172,"hp":248},"nature":"Calm","ability":"Natural Cure","item":"Eviolite","moves":["Spikes","Synthesis","Giga Drain","Sludge Bomb"]},
 	},
 	"Roserade": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Natural Cure","item":"Black Sludge","moves":["Sludge Bomb","Spikes","Sleep Powder","Giga Drain"]},
 		"ORAS UU Offensive Hazards": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"ivs":{"hp":29},"nature":"Timid","ability":"Natural Cure","item":"Black Sludge","moves":["Spikes","Sludge Bomb","Leaf Storm","Sleep Powder"]},
 		"ORAS UU Specially Defensive": {"level":100,"evs":{"sd":252,"hp":240,"sp":16},"nature":"Calm","ability":"Natural Cure","item":"Black Sludge","moves":["Synthesis","Spikes","Giga Drain","Sleep Powder"]},
 	},
@@ -2375,6 +2552,7 @@ var SETDEX_SM = {
 		"ORAS RU SubSplit": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Life Orb","moves":["Thunderbolt","Blizzard","Pain Split","Substitute"]},
 	},
 	"Rotom-Heat": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Scarf","moves":["Overheat","Volt Switch","Will-O-Wisp","Trick"]},
 		"ORAS UU Defensive": {"level":100,"evs":{"df":52,"hp":248,"sp":208},"nature":"Timid","ability":"Levitate","item":"Leftovers","moves":["Overheat","Volt Switch","Will-O-Wisp","Pain Split"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Specs","moves":["Volt Switch","Overheat","Thunderbolt","Trick"]},
 		"ORAS UU Choice Scarf": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Scarf","moves":["Volt Switch","Overheat","Hidden Power Ice","Trick"]},
@@ -2392,6 +2570,7 @@ var SETDEX_SM = {
 	},
 	"Rotom-Wash": {
 		"OU Defensive Pivot": {"level":100,"evs":{"sd":20,"df":240,"hp":248},"nature":"Bold","ability":"Levitate","item":"Leftovers","moves":["Volt Switch","Hydro Pump","Will-O-Wisp","Pain Split"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":86,"sp":170,"sa":252},"nature":"Modest","ability":"Levitate","item":"Sitrus Berry","moves":["Hydro Pump","Protect","Thunderbolt","Volt Switch"]},
 		"Battle Spot Singles Bulky": {"level":50,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Levitate","item":"Sitrus Berry","moves":["Hydro Pump","Volt Switch","Will-O-Wisp","Thunderbolt"]},
 		"Battle Spot Singles Choice Specs": {"level":50,"evs":{"hp":252,"sp":4,"sa":252},"nature":"Modest","ability":"Levitate","item":"Choice Specs","moves":["Hydro Pump","Volt Switch","Trick","Hidden Power Ice"]},
 		"Battle Spot Singles Choice Scarf": {"level":50,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Levitate","item":"Choice Scarf","moves":["Volt Switch","Hydro Pump","Trick","Hidden Power Ice"]},
@@ -2406,6 +2585,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Prankster": {"level":100,"evs":{"sd":184,"df":72,"hp":252},"nature":"Impish","ability":"Prankster","item":"Sitrus Berry","moves":["Will-O-Wisp","Quash","Feint","Protect"]},
 	},
 	"Sableye-Mega": {
+		"OU Showdown Usage": {"level":100,"evs":{"df":252,"hp":248,"sp":8},"nature":"Impish","ability":"Magic Bounce","item":"Sablenite","moves":["Recover","Will-O-Wisp","Protect","Knock Off"]},
 		"ORAS Uber Utility": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Impish","ability":"Prankster","item":"Sablenite","moves":["Foul Play","Will-O-Wisp","Recover","Fake Out"]},
 	},
 	"Salamence": {
@@ -2414,9 +2594,13 @@ var SETDEX_SM = {
 	},
 	"Salamence-Mega": {
 		"Uber Dragon Dance": {"level":100,"evs":{"at":252,"hp":44,"sp":212},"nature":"Adamant","ability":"Intimidate","item":"Salamencite","moves":["Dragon Dance","Double-Edge","Roost","Facade"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Naive","ability":"Aerilate","item":"Salamencite","moves":["Protect","Hyper Voice","Double-Edge","Tailwind"]},
 	},
 	"Salandit": {
 		"LC Life Orb": {"level":5,"evs":{"sd":40,"df":36,"sp":220,"sa":192},"ivs":{"hp":3},"nature":"Timid","ability":"Oblivious","item":"Life Orb","moves":["Nasty Plot","Sludge Bomb","Fire Blast","Hidden Power Ground"]},
+	},
+	"Salazzle": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Corrosion","item":"Life Orb","moves":["Sludge Wave","Flamethrower","Nasty Plot","Fire Blast"]},
 	},
 	"Samurott": {
 		"ORAS NU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Torrent","item":"Lum Berry","moves":["Swords Dance","Aqua Jet","Waterfall","Megahorn"]},
@@ -2463,6 +2647,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Fast Special Attacker (aka Sucktile)": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Overgrow","item":"Sceptilite","moves":["Leaf Storm","Dragon Pulse","Focus Blast","Protect"]},
 	},
 	"Scizor": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":8,"at":252,"hp":248},"nature":"Adamant","ability":"Technician","item":"Choice Band","moves":["Bullet Punch","U-turn","Superpower","Swords Dance"]},
 		"ORAS OU Bulky Swords Dance": {"level":100,"evs":{"sd":124,"df":60,"at":16,"hp":248,"sp":60},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Swords Dance","Roost","Bullet Punch","Bug Bite"]},
 		"ORAS OU Offensive Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Technician","item":"Scizorite","moves":["Swords Dance","Bullet Punch","Bug Bite","Superpower"]},
 		"ORAS OU Pursuit": {"level":100,"evs":{"sd":176,"at":84,"hp":248},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Pursuit","Bullet Punch","U-turn","Roost"]},
@@ -2470,6 +2655,7 @@ var SETDEX_SM = {
 		"ORAS Doubles Swords Dance": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Bullet Punch","Knock Off","Swords Dance","Protect"]},
 	},
 	"Scizor-Mega": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":200,"df":16,"at":44,"hp":248},"nature":"Impish","ability":"Technician","item":"Scizorite","moves":["Bullet Punch","Roost","Swords Dance","U-turn"]},
 		"ORAS OU Bulky Swords Dance": {"level":100,"evs":{"sd":124,"df":60,"at":16,"hp":248,"sp":60},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Swords Dance","Roost","Bullet Punch","Bug Bite"]},
 		"ORAS OU Offensive Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Technician","item":"Scizorite","moves":["Swords Dance","Bullet Punch","Bug Bite","Superpower"]},
 		"ORAS OU Pursuit": {"level":100,"evs":{"sd":176,"at":84,"hp":248},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Pursuit","Bullet Punch","U-turn","Roost"]},
@@ -2477,15 +2663,18 @@ var SETDEX_SM = {
 		"ORAS Doubles Swords Dance": {"level":100,"evs":{"df":4,"at":252,"hp":252},"nature":"Adamant","ability":"Light Metal","item":"Scizorite","moves":["Bullet Punch","Knock Off","Swords Dance","Protect"]},
 	},
 	"Scolipede": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Speed Boost","item":"Leftovers","moves":["Baton Pass","Protect","Substitute","Poison Jab"]},
 		"ORAS OU Offensive": {"level":100,"evs":{"df":4,"at":252,"sp":252},"ivs":{"hp":29},"nature":"Adamant","ability":"Speed Boost","item":"Life Orb","moves":["Megahorn","Aqua Tail","Poison Jab","Protect"]},
 		"ORAS OU Spiker Lead": {"level":100,"evs":{"at":252,"sp":252},"ivs":{"sd":0,"df":0,"hp":0},"nature":"Hasty","ability":"Speed Boost","item":"Focus Sash","moves":["Spikes","Toxic Spikes","Endeavor","Megahorn"]},
 		"ORAS Uber Spikes Anti-Lead": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Speed Boost","item":"Focus Sash","moves":["Pin Missile","Toxic Spikes","Endeavor","Protect"]},
 	},
 	"Scrafty": {
 		"ORAS RU Dragon Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Shed Skin","item":"Life Orb","moves":["Dragon Dance","High Jump Kick","Knock Off","Iron Head"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Brave","ability":"Intimidate","item":"Assault Vest","moves":["Fake Out","Knock Off","Drain Punch","Ice Punch"]},
 		"ORAS Doubles Utility": {"level":100,"evs":{"df":44,"at":212,"hp":252},"nature":"Relaxed","ability":"Intimidate","item":"Sitrus Berry","moves":["Fake Out","Drain Punch","Knock Off","Quick Guard"]},
 	},
 	"Scraggy": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":36,"df":36,"at":156,"hp":36,"sp":212},"nature":"Jolly","ability":"Moxie","item":"Eviolite","moves":["Knock Off","Dragon Dance","Drain Punch","Poison Jab"]},
 		"ORAS LC Dragon Dance": {"level":5,"evs":{"sd":36,"df":36,"at":156,"hp":36,"sp":212},"nature":"Jolly","ability":"Shed Skin","item":"Eviolite","moves":["Dragon Dance","Knock Off","Drain Punch","High Jump Kick"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"at":236,"hp":36,"sp":212},"nature":"Jolly","ability":"Moxie","item":"Choice Scarf","moves":["High Jump Kick","Knock Off","Drain Punch","Poison Jab"]},
 	},
@@ -2505,11 +2694,14 @@ var SETDEX_SM = {
 	"Seismitoad": {
 		"ORAS RU Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Relaxed","ability":"Water Absorb","item":"Leftovers","moves":["Stealth Rock","Scald","Earthquake","Knock Off"]},
 		"ORAS RU Offensive Substitute": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Water Absorb","item":"Leftovers","moves":["Scald","Earth Power","Substitute","Toxic"]},
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"at":4,"hp":252},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Stealth Rock","Earth Power","Scald","Knock Off"]},
 		"ORAS UU Support": {"level":100,"evs":{"sd":56,"df":252,"hp":200},"nature":"Relaxed","ability":"Water Absorb","item":"Leftovers","moves":["Stealth Rock","Earthquake","Scald","Knock Off"]},
+		"OU Showdown Usage": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Sassy","ability":"Water Absorb","item":"Leftovers","moves":["Stealth Rock","Scald","Knock Off","Rest"]},
 		"ORAS OU Defensive": {"level":100,"evs":{"df":244,"hp":252,"sp":12},"nature":"Bold","ability":"Water Absorb","item":"Leftovers","moves":["Stealth Rock","Scald","Earthquake","Knock Off"]},
 		"ORAS OU Rain Sweeper": {"level":100,"evs":{"df":4,"hp":60,"sp":192,"sa":252},"nature":"Modest","ability":"Swift Swim","item":"Life Orb","moves":["Hydro Pump","Earth Power","Sludge Wave","Focus Blast"]},
 	},
 	"Serperior": {
+		"OU Showdown Usage": {"level":100,"evs":{"hp":200,"sp":252,"sa":56},"nature":"Timid","ability":"Contrary","item":"Leftovers","moves":["Leaf Storm","Hidden Power Fire","Substitute","Leech Seed"]},
 		"ORAS OU SubSeed": {"level":100,"evs":{"hp":56,"sp":252,"sa":200},"nature":"Timid","ability":"Contrary","item":"Leftovers","moves":["Leaf Storm","Hidden Power Fire","Substitute","Leech Seed"]},
 		"ORAS OU Special Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Contrary","item":"Leftovers","moves":["Leaf Storm","Dragon Pulse","Hidden Power Fire","Glare"]},
 		"ORAS Doubles Offensive": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Contrary","item":"Life Orb","moves":["Leaf Storm","Dragon Pulse","Hidden Power Ground","Protect"]},
@@ -2527,6 +2719,7 @@ var SETDEX_SM = {
 		"OU Cleaner": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Speed Boost","item":"Sharpedonite","moves":["Protect","Crunch","Psychic Fangs","Waterfall"]},
 	},
 	"Sharpedo-Mega": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Strong Jaw","item":"Sharpedonite","moves":["Crunch","Protect","Psychic Fangs","Waterfall"]},
 		"OU Cleaner": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Speed Boost","item":"Sharpedonite","moves":["Protect","Crunch","Psychic Fangs","Waterfall"]},
 	},
 	"Shaymin": {
@@ -2535,9 +2728,11 @@ var SETDEX_SM = {
 		"ORAS UU Leech Seed": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Natural Cure","item":"Leftovers","moves":["Leech Seed","Seed Flare","Psychic","Substitute"]},
 	},
 	"Shaymin-Sky": {
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Serene Grace","item":"Choice Scarf","moves":["Air Slash","Seed Flare","Earth Power","Healing Wish"]},
 		"ORAS Uber Life Orb": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Serene Grace","item":"Life Orb","moves":["Air Slash","Seed Flare","Hidden Power Rock","Healing Wish"]},
 		"ORAS Uber Choice Scarf": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Serene Grace","item":"Choice Scarf","moves":["Air Slash","Seed Flare","Hidden Power Ice","Healing Wish"]},
 		"ORAS Uber SubSeed": {"level":100,"evs":{"hp":44,"sp":252,"sa":212},"nature":"Timid","ability":"Serene Grace","item":"Leftovers","moves":["Substitute","Leech Seed","Air Slash","Seed Flare"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Serene Grace","item":"Focus Sash","moves":["Air Slash","Seed Flare","Protect","Earth Power"]},
 	},
 	"Shedinja": {
 		"OU Wonderwall": {"level":100,"evs":{"at":252,"sp":156},"ivs":{"sd":0,"df":0},"nature":"Lonely","ability":"Wonder Guard","item":"Focus Sash","moves":["Baton Pass","Protect","Shadow Sneak","Will-O-Wisp"]},
@@ -2621,6 +2816,7 @@ var SETDEX_SM = {
 		"ORAS NU Offensive": {"level":100,"evs":{"hp":92,"sp":164,"sa":252},"nature":"Modest","ability":"Sap Sipper","item":"Eviolite","moves":["Draco Meteor","Sludge Bomb","Muddy Water","Thunderbolt"]},
 	},
 	"Slowbro": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Regenerator","item":"Leftovers","moves":["Scald","Slack Off","Psyshock","Calm Mind"]},
 		"OU Defensive": {"level":100,"evs":{"sd":28,"df":232,"hp":248},"nature":"Bold","ability":"Regenerator","item":"Leftovers","moves":["Scald","Psyshock","Slack Off","Calm Mind"]},
 	},
 	"Slowbro-Mega": {
@@ -2639,6 +2835,7 @@ var SETDEX_SM = {
 		"ORAS OU Defensive": {"level":100,"evs":{"sd":76,"df":180,"hp":252},"nature":"Calm","ability":"Regenerator","item":"Leftovers","moves":["Scald","Psyshock","Thunder Wave","Slack Off"]},
 	},
 	"Slowpoke": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":116,"df":156,"hp":196,"sa":36},"nature":"Bold","ability":"Regenerator","item":"Eviolite","moves":["Scald","Slack Off","Thunder Wave","Fire Blast"]},
 		"ORAS LC Tank": {"level":5,"evs":{"sd":116,"df":156,"hp":116,"sa":116},"nature":"Bold","ability":"Regenerator","item":"Eviolite","moves":["Scald","Slack Off","Thunder Wave","Psychic"]},
 	},
 	"Slugma": {
@@ -2653,6 +2850,7 @@ var SETDEX_SM = {
 		"ORAS NU Lead": {"level":100,"evs":{"sd":80,"df":96,"hp":80,"sp":252},"nature":"Timid","ability":"Own Tempo","item":"Focus Sash","moves":["Sticky Web","Stealth Rock","Spore","Skill Swap"]},
 		"ORAS RU Suicide Lead": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Own Tempo","item":"Focus Sash","moves":["Spore","Stealth Rock","Sticky Web","Explosion"]},
 		"ORAS UU Suicide Lead": {"level":100,"evs":{"sd":4,"hp":252,"sp":252},"nature":"Timid","ability":"Own Tempo","item":"Focus Sash","moves":["Spore","Stealth Rock","Sticky Web","Taunt"]},
+		"Uber Showdown Usage": {"level":100,"evs":{"sd":8,"hp":248,"sp":252},"nature":"Timid","ability":"Own Tempo","item":"Focus Sash","moves":["Sticky Web","Spore","Stealth Rock","Magic Coat"]},
 		"ORAS Uber Smash Pass": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Technician","item":"Focus Sash","moves":["Shell Smash","Baton Pass","Spore","Hidden Power Steel"]},
 	},
 	"Smoochum": {
@@ -2678,6 +2876,7 @@ var SETDEX_SM = {
 		"ORAS LC Eviolite": {"level":5,"evs":{"sd":120,"df":40,"at":104,"hp":36,"sa":184},"nature":"Quiet","ability":"Snow Warning","item":"Eviolite","moves":["Blizzard","Giga Drain","Ice Shard","Hidden Power Rock"]},
 	},
 	"Snubbull": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":116,"df":196,"at":36,"hp":36,"sp":116},"nature":"Adamant","ability":"Intimidate","item":"Berry Juice","moves":["Play Rough","Thief","Earthquake","Heal Bell"]},
 		"ORAS LC Berry Juice": {"level":5,"evs":{"sd":116,"df":196,"at":36,"hp":36,"sp":116},"nature":"Adamant","ability":"Intimidate","item":"Berry Juice","moves":["Thief","Play Rough","Earthquake","Thunder Wave"]},
 		"ORAS LC Eviolite": {"level":5,"evs":{"sd":116,"df":36,"at":196,"hp":36,"sp":116},"nature":"Adamant","ability":"Intimidate","item":"Eviolite","moves":["Play Rough","Earthquake","Thunder Wave","Heal Bell"]},
 		"ORAS LC Rest + Sleep Talk": {"level":5,"evs":{"sd":196,"df":196,"at":36,"hp":36,"sp":36},"nature":"Careful","ability":"Intimidate","item":"Eviolite","moves":["Rest","Sleep Talk","Play Rough","Earthquake"]},
@@ -2726,6 +2925,7 @@ var SETDEX_SM = {
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"at":236,"hp":36,"sp":196,"sa":36},"nature":"Naive","ability":"Reckless","item":"Choice Scarf","moves":["Brave Bird","Double-Edge","U-turn","Hidden Power Grass"]},
 	},
 	"Starmie": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Analytic","item":"Life Orb","moves":["Hydro Pump","Rapid Spin","Ice Beam","Psyshock"]},
 		"ORAS OU Utility": {"level":100,"evs":{"hp":252,"sp":252,"sa":4},"nature":"Timid","ability":"Natural Cure","item":"Leftovers","moves":["Scald","Rapid Spin","Recover","Psyshock"]},
 		"ORAS OU Offensive": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"ivs":{"hp":29},"nature":"Timid","ability":"Analytic","item":"Life Orb","moves":["Rapid Spin","Hydro Pump","Psychic","Ice Beam"]},
 	},
@@ -2746,11 +2946,13 @@ var SETDEX_SM = {
 		"ORAS PU Wallbreaker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Scrappy","item":"Choice Band","moves":["Return","Facade","Superpower","Crunch"]},
 		"ORAS PU Sand Rush": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Rush","item":"Life Orb","moves":["Return","Superpower","Crunch","Facade"]},
 		"ORAS NU Sand Wallbreaker": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Rush","item":"Choice Band","moves":["Return","Crunch","Superpower","Pursuit"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Sand Rush","item":"Choice Band","moves":["Superpower","Crunch","Fire Fang","Return"]},
 	},
 	"Stunfisk": {
 		"ORAS PU Support": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Static","item":"Leftovers","moves":["Stealth Rock","Discharge","Earth Power","Toxic"]},
 	},
 	"Stunky": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":188,"df":60,"at":92,"hp":12,"sp":4,"sa":108},"nature":"Brave","ability":"Aftermath","item":"Eviolite","moves":["Sucker Punch","Pursuit","Fire Blast","Sludge Bomb"]},
 		"ORAS LC Bulky Pursuit": {"level":5,"evs":{"sd":188,"df":60,"at":92,"hp":12,"sp":4,"sa":108},"nature":"Brave","ability":"Aftermath","item":"Eviolite","moves":["Pursuit","Sucker Punch","Fire Blast","Defog"]},
 		"ORAS LC Fast Utility": {"level":5,"evs":{"df":60,"at":12,"hp":172,"sp":244},"nature":"Jolly","ability":"Aftermath","item":"Eviolite","moves":["Pursuit","Sucker Punch","Defog","Taunt"]},
 	},
@@ -2758,7 +2960,9 @@ var SETDEX_SM = {
 		"ORAS PU Suicide Lead": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sturdy","item":"Custap Berry","moves":["Stealth Rock","Stone Edge","Wood Hammer","Sucker Punch"]},
 	},
 	"Suicune": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Pressure","item":"Leftovers","moves":["Scald","Calm Mind","Rest","Sleep Talk"]},
 		"OU Substitute + Calm Mind": {"level":100,"evs":{"sd":40,"hp":252,"sp":216},"nature":"Timid","ability":"Pressure","item":"Leftovers","moves":["Substitute","Calm Mind","Scald","Protect"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":40,"df":16,"hp":252,"sp":56,"sa":144},"nature":"Bold","ability":"Pressure","item":"Sitrus Berry","moves":["Tailwind","Ice Beam","Scald","Snarl"]},
 	},
 	"Sunflora": {
 		"ORAS PU Synthesis + 3 Attacks": {"level":100,"evs":{"hp":92,"sp":164,"sa":252},"nature":"Modest","ability":"Solar Power","item":"Life Orb","moves":["Leaf Storm","Earth Power","Hidden Power Ice","Synthesis"]},
@@ -2773,6 +2977,7 @@ var SETDEX_SM = {
 		"ORAS PU Tank": {"level":100,"evs":{"sd":60,"hp":248,"sa":200},"nature":"Quiet","ability":"Sticky Hold","item":"Assault Vest","moves":["Sludge Bomb","Giga Drain","Ice Beam","Earthquake"]},
 	},
 	"Swampert": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":12,"df":248,"hp":240,"sp":8},"nature":"Relaxed","ability":"Torrent","item":"Leftovers","moves":["Stealth Rock","Earthquake","Scald","Roar"]},
 		"ORAS UU Defensive": {"level":100,"evs":{"df":252,"at":16,"hp":240},"nature":"Relaxed","ability":"Torrent","item":"Leftovers","moves":["Stealth Rock","Earthquake","Scald","Roar"]},
 		"ORAS UU Rain Sweeper": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Adamant","ability":"Damp","item":"Swampertite","moves":["Rain Dance","Waterfall","Earthquake","Ice Punch"]},
 		"ORAS UU Offensive Stealth Rock": {"level":100,"evs":{"at":252,"hp":212,"sp":44},"nature":"Adamant","ability":"Damp","item":"Swampertite","moves":["Stealth Rock","Waterfall","Earthquake","Ice Punch"]},
@@ -2804,9 +3009,11 @@ var SETDEX_SM = {
 		"ORAS PU Calm Mind": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Simple","item":"Salac Berry","moves":["Calm Mind","Stored Power","Signal Beam","Substitute"]},
 	},
 	"Sylveon": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":16,"df":236,"hp":248,"sp":8},"nature":"Calm","ability":"Pixilate","item":"Leftovers","moves":["Hyper Voice","Wish","Protect","Heal Bell"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Pixilate","item":"Choice Specs","moves":["Hyper Voice","Psyshock","Hidden Power Fire","Shadow Ball"]},
 		"ORAS UU Cleric": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Bold","ability":"Pixilate","item":"Leftovers","moves":["Hyper Voice","Heal Bell","Wish","Protect"]},
 		"ORAS OU Choice Specs": {"level":100,"evs":{"hp":240,"sp":16,"sa":252},"nature":"Modest","ability":"Pixilate","item":"Choice Specs","moves":["Hyper Voice","Psyshock","Hidden Power Fire","Baton Pass"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":38,"sp":220,"sa":252},"nature":"Modest","ability":"Pixilate","item":"Choice Specs","moves":["Hyper Voice","Shadow Ball","Psyshock","Hidden Power Ground"]},
 		"ORAS Doubles Choice Specs": {"level":100,"evs":{"df":200,"hp":56,"sa":252},"nature":"Modest","ability":"Pixilate","item":"Choice Specs","moves":["Hyper Voice","Psyshock","Hidden Power Ground","Hyper Beam"]},
 		"ORAS Doubles Calm Mind": {"level":100,"evs":{"sd":8,"df":164,"hp":248,"sa":88},"nature":"Modest","ability":"Pixilate","item":"Leftovers","moves":["Hyper Voice","Calm Mind","Substitute","Protect"]},
 	},
@@ -2815,6 +3022,7 @@ var SETDEX_SM = {
 		"LC Guts Physical Sweeper": {"level":5,"evs":{"at":236,"hp":36,"sp":236},"nature":"Jolly","ability":"Guts","item":"Flame Orb","moves":["Facade","Brave Bird","Quick Attack","U-turn"]},
 	},
 	"Talonflame": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":240,"hp":240,"sp":28},"nature":"Careful","ability":"Gale Wings","item":"Leftovers","moves":["Brave Bird","Roost","Will-O-Wisp","Taunt"]},
 		"ORAS OU Specially Defensive": {"level":100,"evs":{"sd":252,"hp":248,"sp":8},"nature":"Careful","ability":"Gale Wings","moves":["Acrobatics","Roost","Bulk Up","Will-O-Wisp"]},
 		"ORAS OU Bulky Swords Dance": {"level":100,"evs":{"at":252,"hp":248,"sp":8},"nature":"Adamant","ability":"Gale Wings","moves":["Acrobatics","Roost","Swords Dance","Will-O-Wisp"]},
 		"ORAS OU Offensive Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Gale Wings","item":"Sharp Beak","moves":["Brave Bird","Flare Blitz","Swords Dance","Roost"]},
@@ -2836,6 +3044,7 @@ var SETDEX_SM = {
 	"Tapu Bulu": {
 		"OU Choice Band": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Adamant","ability":"Grassy Surge","item":"Choice Band","moves":["Wood Hammer","Horn Leech","Superpower","Stone Edge"]},
 		"OU Leech Seed": {"level":100,"evs":{"at":252,"hp":160,"sp":96},"nature":"Adamant","ability":"Grassy Surge","item":"Leftovers","moves":["Leech Seed","Bulk Up","Horn Leech","Brick Break"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":252,"hp":40,"sp":216},"nature":"Adamant","ability":"Grassy Surge","item":"Life Orb","moves":["Wood Hammer","Protect","Stone Edge","Horn Leech"]},
 		"Battle Spot Singles Choice Band All Out Attacker": {"level":50,"evs":{"at":252,"hp":116,"sp":140},"nature":"Adamant","ability":"Grassy Surge","item":"Choice Band","moves":["Wood Hammer","Superpower","Zen Headbutt","Horn Leech"]},
 		"Battle Spot Singles Assault Vest Special Sponge": {"level":50,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Grassy Surge","item":"Assault Vest","moves":["Horn Leech","Zen Headbutt","Stone Edge","Superpower"]},
 		"Battle Spot Singles Subseed": {"level":50,"evs":{"df":4,"hp":252,"sp":252},"nature":"Jolly","ability":"Grassy Surge","item":"Leftovers","moves":["Substitute","Leech Seed","Disable","Horn Leech"]},
@@ -2843,6 +3052,7 @@ var SETDEX_SM = {
 	"Tapu Fini": {
 		"OU Defensive": {"level":100,"evs":{"sd":16,"df":192,"hp":248,"sp":52},"nature":"Calm","ability":"Misty Surge","item":"Leftovers","moves":["Taunt","Nature\u0027s Madness","Moonblast","Defog"]},
 		"OU Calm Mind": {"level":100,"evs":{"df":248,"hp":248,"sp":12},"nature":"Bold","ability":"Misty Surge","item":"Leftovers","moves":["Calm Mind","Scald","Moonblast","Taunt"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":8,"hp":248,"sa":252},"nature":"Modest","ability":"Misty Surge","item":"Leftovers","moves":["Protect","Muddy Water","Moonblast","Calm Mind"]},
 		"Battle Spot Singles Calm Mind": {"level":50,"evs":{"df":252,"hp":244,"sp":12},"nature":"Bold","ability":"Misty Surge","item":"Icium Z","moves":["Calm Mind","Surf","Moonblast","Mist"]},
 		"Battle Spot Singles Offensive": {"level":50,"evs":{"hp":244,"sp":12,"sa":252},"nature":"Modest","ability":"Misty Surge","item":"Waterium Z","moves":["Nature\u0027s Madness","Hydro Pump","Moonblast","Hidden Power Fire"]},
 	},
@@ -2850,6 +3060,7 @@ var SETDEX_SM = {
 		"OU Offensive Pivot": {"level":100,"evs":{"at":4,"sp":252,"sa":252},"nature":"Timid","ability":"Electric Surge","item":"Life Orb","moves":["Thunderbolt","Hidden Power Ice","Volt Switch","U-turn"]},
 		"OU Calm Mind": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Electric Surge","item":"Life Orb","moves":["Calm Mind","Thunderbolt","Hidden Power Ice","Roost"]},
 		"Uber Gigavolt Havoc": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Electric Surge","item":"Electrium Z","moves":["Thunder","Nature\u0027s Madness","Taunt","U-turn"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Electric Surge","item":"Life Orb","moves":["Dazzling Gleam","Protect","Thunderbolt","Volt Switch"]},
 		"Monotype Terrain Setter (Electric)": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Electric Surge","item":"Magnet","moves":["Volt Switch","Thunderbolt","Dazzling Gleam","Hidden Power Ice"]},
 		"Monotype Physical Attacker (Electric)": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Naive","ability":"Electric Surge","item":"Choice Band","moves":["Wild Charge","Brave Bird","U-turn","Volt Switch"]},
 	},
@@ -2858,6 +3069,7 @@ var SETDEX_SM = {
 		"OU Stallbreaker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Psychic Surge","item":"Twisted Spoon","moves":["Psyshock","Moonblast","Hidden Power Fire","Taunt"]},
 		"OU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Modest","ability":"Psychic Surge","item":"Choice Specs","moves":["Psychic","Moonblast","Focus Blast","Hidden Power Fire"]},
 		"Uber Offensive Support": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Psychic Surge","item":"Terrain Extender","moves":["Psychic","Moonblast","Taunt","Nature\u0027s Madness"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Psychic Surge","item":"Choice Scarf","moves":["Psychic","Moonblast","Protect","Taunt"]},
 		"Battle Spot Doubles Offensive": {"level":50,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Psychic Surge","item":"Psychium Z","moves":["Psychic","Moonblast","Thunderbolt","Protect"]},
 		"Battle Spot Doubles Choice Scarf": {"level":50,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Psychic Surge","item":"Choice Scarf","moves":["Psychic","Moonblast","Dazzling Gleam","Hidden Power Ground"]},
 	},
@@ -2873,6 +3085,7 @@ var SETDEX_SM = {
 		"ORAS PU Support": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Liquid Ooze","item":"Eviolite","moves":["Scald","Toxic Spikes","Haze","Rapid Spin"]},
 	},
 	"Tentacruel": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":240,"hp":252,"sp":16},"nature":"Bold","ability":"Liquid Ooze","item":"Black Sludge","moves":["Rapid Spin","Scald","Toxic Spikes","Haze"]},
 		"ORAS UU Utility": {"level":100,"evs":{"df":244,"hp":240,"sp":24},"nature":"Bold","ability":"Liquid Ooze","item":"Black Sludge","moves":["Rapid Spin","Scald","Toxic Spikes","Haze"]},
 		"ORAS UU Offensive": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Clear Body","item":"Black Sludge","moves":["Hydro Pump","Sludge Bomb","Ice Beam","Rapid Spin"]},
 		"ORAS OU Support": {"level":100,"evs":{"sd":28,"df":216,"hp":248,"sp":16},"nature":"Timid","ability":"Liquid Ooze","item":"Black Sludge","moves":["Scald","Rapid Spin","Acid Spray","Toxic Spikes"]},
@@ -2890,22 +3103,27 @@ var SETDEX_SM = {
 		"ORAS NU Phazer": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Careful","ability":"Guts","item":"Leftovers","moves":["Circle Throw","Rest","Sleep Talk","Bulk Up"]},
 	},
 	"Thundurus": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Life Orb","moves":["Thunderbolt","Hidden Power Ice","Thunder Wave","Nasty Plot"]},
 		"OU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Life Orb","moves":["Nasty Plot","Thunderbolt","Hidden Power Ice","Focus Blast"]},
 		"OU Mixed Attacker": {"level":100,"evs":{"at":68,"sp":252,"sa":188},"nature":"Naive","ability":"Defiant","item":"Life Orb","moves":["Thunderbolt","Hidden Power Ice","Superpower","Knock Off"]},
 		"OU Thunder Wave + 3 Attacks": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Life Orb","moves":["Thunder Wave","Thunderbolt","Hidden Power Ice","Focus Blast"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Electrium Z","moves":["Protect","Rain Dance","Focus Blast","Thunder"]},
 	},
 	"Thundurus-Therian": {
 		"OU Setup Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Volt Absorb","item":"Electrium Z","moves":["Agility","Thunderbolt","Hidden Power Ice","Nasty Plot"]},
 	},
 	"Timburr": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":236,"df":156,"at":116},"nature":"Careful","ability":"Guts","item":"Eviolite","moves":["Drain Punch","Knock Off","Mach Punch","Bulk Up"]},
 		"ORAS LC Bulky Attacker": {"level":5,"evs":{"sd":236,"df":156,"at":116},"nature":"Careful","ability":"Guts","item":"Eviolite","moves":["Drain Punch","Mach Punch","Knock Off","Bulk Up"]},
 	},
 	"Tirtouga": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":92,"at":212,"sp":180},"nature":"Jolly","ability":"Sturdy","item":"Berry Juice","moves":["Shell Smash","Aqua Jet","Stone Edge","Waterfall"]},
 		"ORAS LC Sturdy Shell Smash": {"level":5,"evs":{"df":92,"at":212,"sp":180},"nature":"Jolly","ability":"Sturdy","item":"Berry Juice","moves":["Shell Smash","Waterfall","Stone Edge","Zen Headbutt"]},
 		"ORAS LC Solid Rock Shell Smash": {"level":5,"evs":{"sd":76,"df":92,"at":132,"hp":4,"sp":180},"nature":"Adamant","ability":"Solid Rock","item":"Eviolite","moves":["Shell Smash","Waterfall","Stone Edge","Zen Headbutt"]},
 		"ORAS LC Defensive": {"level":5,"evs":{"sd":156,"df":252,"hp":84,"sa":12},"nature":"Sassy","ability":"Solid Rock","item":"Eviolite","moves":["Stealth Rock","Scald","Stone Edge","Knock Off"]},
 	},
 	"Togekiss": {
+		"UU Showdown Usage": {"level":100,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Serene Grace","item":"Leftovers","moves":["Air Slash","Roost","Defog","Nasty Plot"]},
 		"OU Stallbreaker": {"level":100,"evs":{"hp":252,"sp":252,"sa":4},"nature":"Timid","ability":"Serene Grace","item":"Leftovers","moves":["Air Slash","Roost","Nasty Plot","Heal Bell"]},
 	},
 	"Togepi": {
@@ -2918,6 +3136,7 @@ var SETDEX_SM = {
 		"ORAS UU Nasty Pass": {"level":100,"evs":{"sd":252,"hp":248,"sa":8},"ivs":{"sp":0},"nature":"Sassy","ability":"Super Luck","item":"Eviolite","moves":["Nasty Plot","Baton Pass","Roost","Dazzling Gleam"]},
 	},
 	"Torchic": {
+		"LC Showdown Usage": {"level":5,"evs":{"sd":36,"df":36,"sp":236,"sa":200},"nature":"Modest","ability":"Speed Boost","item":"Eviolite","moves":["Baton Pass","Protect","Swords Dance","Fire Blast"]},
 		"ORAS LC Baton Pass": {"level":5,"evs":{"sd":36,"df":196,"at":36,"sp":236},"nature":"Impish","ability":"Speed Boost","item":"Eviolite","moves":["Protect","Curse","Substitute","Baton Pass"]},
 		"ORAS LC Life Orb": {"level":5,"evs":{"sd":36,"df":36,"sp":236,"sa":200},"ivs":{"hp":0},"nature":"Modest","ability":"Speed Boost","item":"Life Orb","moves":["Protect","Fire Blast","Hidden Power Grass","Baton Pass"]},
 	},
@@ -2927,6 +3146,7 @@ var SETDEX_SM = {
 		"VGC17 Eruption": {"level":50,"evs":{"df":4,"hp":252,"sa":252},"ivs":{"at":0,"sp":0},"nature":"Quiet","ability":"Drought","item":"Charcoal","moves":["Eruption","Heat Wave","Solar Beam","Protect"]},
 	},
 	"Tornadus": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Choice Specs","moves":["U-turn","Hurricane","Focus Blast","Tailwind"]},
 		"ORAS UU Special Attacker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Life Orb","moves":["Hurricane","Focus Blast","Grass Knot","Tailwind"]},
 		"ORAS UU Bulk Up": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Prankster","item":"Chesto Berry","moves":["Bulk Up","Acrobatics","Rest","Knock Off"]},
 		"ORAS UU Defiant Attacker": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Defiant","moves":["Acrobatics","Knock Off","Superpower","U-turn"]},
@@ -2951,6 +3171,7 @@ var SETDEX_SM = {
 		"OU Physically Defensive": {"level":100,"evs":{"sd":24,"df":232,"hp":252},"nature":"Bold","ability":"Regenerator","item":"Black Sludge","moves":["Scald","Recover","Toxic","Haze"]},
 	},
 	"Toxicroak": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Dry Skin","item":"Life Orb","moves":["Drain Punch","Swords Dance","Gunk Shot","Sucker Punch"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Dry Skin","item":"Life Orb","moves":["Swords Dance","Gunk Shot","Drain Punch","Sucker Punch"]},
 		"ORAS UU Nasty Plot": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Dry Skin","item":"Life Orb","moves":["Nasty Plot","Sludge Bomb","Vacuum Wave","Dark Pulse"]},
 		"ORAS UU Bulky Croak": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Dry Skin","item":"Black Sludge","moves":["Swords Dance","Drain Punch","Gunk Shot","Sucker Punch"]},
@@ -2972,6 +3193,9 @@ var SETDEX_SM = {
 	"Trubbish": {
 		"ORAS LC Spikes": {"level":5,"evs":{"sd":20,"df":100,"at":36,"hp":116,"sp":236},"nature":"Jolly","ability":"Sticky Hold","item":"Berry Juice","moves":["Spikes","Recycle","Gunk Shot","Drain Punch"]},
 	},
+	"Tsareena": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Queenly Majesty","item":"Leftovers","moves":["Trop Kick","Rapid Spin","U-turn","Synthesis"]},
+	},
 	"Turtwig": {
 		"ORAS LC Stealth Rock": {"level":5,"evs":{"sd":236,"df":244,"sp":28},"nature":"Careful","ability":"Overgrow","item":"Eviolite","moves":["Stealth Rock","Synthesis","Bullet Seed","Superpower"]},
 	},
@@ -2986,6 +3210,7 @@ var SETDEX_SM = {
 		"OU Choice Scarf": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Sand Stream","item":"Choice Scarf","moves":["Stone Edge","Pursuit","Crunch","Superpower"]},
 		"Uber Entry Hazard Support": {"level":100,"evs":{"sd":252,"df":8,"hp":248},"nature":"Careful","ability":"Sand Stream","item":"Chople Berry","moves":["Stealth Rock","Pursuit","Rock Slide","Toxic"]},
 		"Uber Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Sand Stream","item":"Choice Band","moves":["Pursuit","Stone Edge","Crunch","Low Kick"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"hp":252},"nature":"Adamant","ability":"Sand Stream","item":"Assault Vest","moves":["Rock Slide","Crunch","Protect","Ice Punch"]},
 	},
 	"Tyranitar-Mega": {
 	},
@@ -3001,6 +3226,7 @@ var SETDEX_SM = {
 		"ORAS LC Stealth Rock Phazer": {"level":5,"evs":{"sd":76,"df":140,"at":204,"hp":52},"ivs":{"hp":23},"nature":"Jolly","ability":"Sturdy","item":"Berry Juice","moves":["Stealth Rock","Dragon Tail","Stone Edge","Earthquake"]},
 	},
 	"Umbreon": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Synchronize","item":"Leftovers","moves":["Foul Play","Wish","Protect","Heal Bell"]},
 		"ORAS UU Cleric / Wish Pass": {"level":100,"evs":{"sd":252,"df":4,"hp":252},"nature":"Calm","ability":"Synchronize","item":"Leftovers","moves":["Wish","Protect","Heal Bell","Foul Play"]},
 	},
 	"Unfezant": {
@@ -3040,6 +3266,7 @@ var SETDEX_SM = {
 	"Venusaur": {
 		"OU Defensive Tank": {"level":100,"evs":{"sd":80,"df":180,"hp":232,"sp":16},"nature":"Bold","ability":"Chlorophyll","item":"Venusaurite","moves":["Giga Drain","Sludge Bomb","Synthesis","Hidden Power Fire"]},
 		"OU Offensive Tank": {"level":100,"evs":{"sd":80,"hp":232,"sp":16,"sa":180},"nature":"Modest","ability":"Chlorophyll","item":"Venusaurite","moves":["Giga Drain","Sludge Bomb","Synthesis","Hidden Power Fire"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":60,"sp":196,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Life Orb","moves":["Sludge Bomb","Protect","Sleep Powder","Giga Drain"]},
 		"Battle Spot Singles Bulky Offense": {"level":50,"evs":{"hp":252,"sp":4,"sa":252},"nature":"Modest","ability":"Chlorophyll","item":"Venusaurite","moves":["Sludge Bomb","Synthesis","Giga Drain","Hidden Power Fire"]},
 		"Battle Spot Singles Defensive": {"level":50,"evs":{"df":252,"hp":252,"sp":4},"nature":"Bold","ability":"Chlorophyll","item":"Venusaurite","moves":["Sludge Bomb","Synthesis","Leech Seed","Giga Drain"]},
 	},
@@ -3056,6 +3283,7 @@ var SETDEX_SM = {
 		"ORAS PU Defog": {"level":100,"evs":{"sd":8,"df":252,"hp":248},"nature":"Impish","ability":"Levitate","item":"Eviolite","moves":["Defog","U-turn","Roost","Earthquake"]},
 	},
 	"Victini": {
+		"OU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Victory Star","item":"Choice Scarf","moves":["V-create","Bolt Strike","U-turn","Trick"]},
 		"ORAS OU MixTini": {"level":100,"evs":{"at":96,"sp":252,"sa":160},"nature":"Naive","ability":"Victory Star","item":"Life Orb","moves":["V-create","Bolt Strike","Glaciate","Energy Ball"]},
 		"ORAS OU Choice Band": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Victory Star","item":"Choice Band","moves":["V-create","Bolt Strike","U-turn","Trick"]},
 		"ORAS Doubles Choice Scarf": {"level":100,"evs":{"at":252,"hp":36,"sp":220},"nature":"Jolly","ability":"Victory Star","item":"Choice Scarf","moves":["V-create","Bolt Strike","U-turn","Final Gambit"]},
@@ -3073,6 +3301,7 @@ var SETDEX_SM = {
 	"Virizion": {
 		"ORAS RU Swords Dance": {"level":100,"evs":{"df":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Lum Berry","moves":["Swords Dance","Close Combat","Leaf Blade","Stone Edge"]},
 		"ORAS RU Calm Mind": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Justified","item":"Life Orb","moves":["Calm Mind","Giga Drain","Focus Blast","Hidden Power Ice"]},
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Fightinium Z","moves":["Leaf Blade","Close Combat","Swords Dance","Substitute"]},
 		"ORAS UU Swords Dance": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Justified","item":"Lum Berry","moves":["Swords Dance","Leaf Blade","Close Combat","Stone Edge"]},
 		"ORAS Doubles Physical Attacker": {"level":100,"evs":{"at":252,"hp":4,"sp":252},"nature":"Jolly","ability":"Justified","item":"Life Orb","moves":["Leaf Blade","Close Combat","Stone Edge","Protect"]},
 	},
@@ -3086,10 +3315,13 @@ var SETDEX_SM = {
 		"ORAS PU Weather Supporter": {"level":100,"evs":{"df":252,"at":4,"hp":252},"ivs":{"sp":0},"nature":"Relaxed","ability":"Prankster","item":"Heat Rock","moves":["Sunny Day","U-turn","Encore","Thunder Wave"]},
 	},
 	"Volcanion": {
+		"UU Showdown Usage": {"level":100,"evs":{"at":36,"sp":220,"sa":252},"nature":"Rash","ability":"Water Absorb","item":"Shuca Berry","moves":["Steam Eruption","Fire Blast","Hidden Power Electric","Superpower"]},
 		"OU All-out Attacker": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Choice Specs","moves":["Steam Eruption","Fire Blast","Sludge Bomb","Hidden Power Electric"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":4,"sp":252,"sa":252},"nature":"Modest","ability":"Water Absorb","item":"Leftovers","moves":["Steam Eruption","Heat Wave","Protect","Substitute"]},
 	},
 	"Volcarona": {
 		"OU Quiver Dance Sweeper": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flame Body","item":"Firium Z","moves":["Quiver Dance","Fire Blast","Giga Drain","Hidden Power Ground"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Flame Body","item":"Firium Z","moves":["Quiver Dance","Protect","Heat Wave","Giga Drain"]},
 	},
 	"Voltorb": {
 		"ORAS LC Lead": {"level":5,"evs":{"df":36,"hp":36,"sp":196,"sa":236},"nature":"Timid","ability":"Static","item":"Damp Rock","moves":["Rain Dance","Thunder","Volt Switch","Taunt"]},
@@ -3103,6 +3335,7 @@ var SETDEX_SM = {
 		"LC Defensive": {"level":5,"evs":{"sd":76,"df":236,"at":76,"hp":116},"nature":"Impish","ability":"Overcoat","item":"Eviolite","moves":["Roost","Knock Off","Brave Bird","Defog"]},
 	},
 	"Vulpix": {
+		"LC Showdown Usage": {"level":5,"evs":{"df":36,"sp":236,"sa":196},"nature":"Timid","ability":"Drought","item":"Heat Rock","moves":["Energy Ball","Fire Blast","Will-O-Wisp","Quick Attack"]},
 		"ORAS LC Sun Support": {"level":5,"evs":{"hp":52,"sp":240,"sa":196},"nature":"Timid","ability":"Drought","item":"Heat Rock","moves":["Fire Blast","Energy Ball","Will-O-Wisp","Quick Attack"]},
 		"ORAS LC Life Orb": {"level":5,"evs":{"df":40,"sp":240,"sa":196},"ivs":{"sd":30,"df":30,"hp":23,"sp":30},"nature":"Timid","ability":"Drought","item":"Life Orb","moves":["Fire Blast","Energy Ball","Hidden Power Rock","Overheat"]},
 		"ORAS LC Choice Scarf": {"level":5,"evs":{"hp":52,"sp":240,"sa":196},"nature":"Modest","ability":"Drought","item":"Choice Scarf","moves":["Fire Blast","Energy Ball","Hidden Power Rock","Overheat"]},
@@ -3138,6 +3371,7 @@ var SETDEX_SM = {
 		"ORAS UU Physically Defensive": {"level":100,"evs":{"df":252,"hp":252,"sa":4},"nature":"Bold","ability":"Levitate","item":"Black Sludge","moves":["Toxic Spikes","Sludge Bomb","Will-O-Wisp","Pain Split"]},
 	},
 	"Whimsicott": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Pixie Plate","moves":["Moonblast","Encore","U-turn","Energy Ball"]},
 		"ORAS UU Applaud &amp; Attack (Offensive)": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Prankster","item":"Leftovers","moves":["Moonblast","Giga Drain","Encore","U-turn"]},
 		"ORAS UU Support": {"level":100,"evs":{"df":252,"hp":248,"sp":8},"nature":"Bold","ability":"Prankster","item":"Leftovers","moves":["Encore","Stun Spore","Moonblast","U-turn"]},
 		"ORAS UU Choice Specs": {"level":100,"evs":{"df":4,"sp":252,"sa":252},"nature":"Timid","ability":"Infiltrator","item":"Choice Specs","moves":["Moonblast","Energy Ball","Switcheroo","U-turn"]},
@@ -3178,6 +3412,7 @@ var SETDEX_SM = {
 		"ORAS PU Utility": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Overcoat","item":"Leftovers","moves":["Stealth Rock","Toxic","Protect","Iron Head"]},
 	},
 	"Wynaut": {
+		"LC Showdown Usage": {"level":5,"evs":{"hp":236,"sp":252},"nature":"Timid","ability":"Shadow Tag","item":"Berry Juice","moves":["Counter","Encore","Mirror Coat","Destiny Bond"]},
 		"ORAS LC Standard": {"level":5,"evs":{"sd":132,"df":132,"hp":236},"nature":"Bold","ability":"Shadow Tag","item":"Berry Juice","moves":["Encore","Counter","Mirror Coat","Safeguard"]},
 	},
 	"Xatu": {
@@ -3220,6 +3455,7 @@ var SETDEX_SM = {
 	},
 	"Zapdos": {
 		"OU Defensive": {"level":100,"evs":{"df":244,"hp":248,"sp":16},"nature":"Bold","ability":"Pressure","item":"Leftovers","moves":["Discharge","Roost","Heat Wave","Defog"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"hp":84,"sp":172,"sa":252},"nature":"Modest","ability":"Static","item":"Sitrus Berry","moves":["Tailwind","Hidden Power Ice","Thunderbolt","Roost"]},
 		"Monotype SubToxic (Flying)": {"level":100,"evs":{"sd":180,"hp":252,"sp":76},"nature":"Timid","ability":"Pressure","item":"Leftovers","moves":["Discharge","Roost","Toxic","Substitute"]},
 		"Monotype Defog (Flying)": {"level":100,"evs":{"sd":192,"hp":252,"sp":64},"nature":"Calm","ability":"Pressure","item":"Leftovers","moves":["Volt Switch","Roost","Defog","Heat Wave"]},
 	},
@@ -3251,8 +3487,10 @@ var SETDEX_SM = {
 	"Zygarde": {
 		"OU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Aura Break","item":"Choice Band","moves":["Thousand Arrows","Outrage","Extreme Speed","Toxic"]},
 		"Uber Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Power Construct","item":"Leftovers","moves":["Rest","Thousand Arrows","Dragon Tail","Sleep Talk"]},
+		"DOU Showdown Usage": {"level":100,"evs":{"at":252,"hp":104,"sp":152},"nature":"Adamant","ability":"Aura Break","item":"Leftovers","moves":["Thousand Arrows","Protect","Dragon Dance","Substitute"]},
 	},
 	"Zygarde-10%": {
+		"UU Showdown Usage": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Aura Break","item":"Choice Band","moves":["Thousand Arrows","Extreme Speed","Outrage","Sleep Talk"]},
 		"OU Choice Band": {"level":100,"evs":{"sd":4,"at":252,"sp":252},"nature":"Jolly","ability":"Aura Break","item":"Choice Band","moves":["Thousand Arrows","Outrage","Extreme Speed","Toxic"]},
 		"Uber Physically Defensive": {"level":100,"evs":{"sd":4,"df":252,"hp":252},"nature":"Impish","ability":"Power Construct","item":"Leftovers","moves":["Rest","Thousand Arrows","Dragon Tail","Sleep Talk"]},
 	},


### PR DESCRIPTION
Add usage-based sets for Pokemon in tiers where they have decent usage but no Smogon analysis. This is mainly for SM
where most analyses are still in progress, but it also fills in some gaps in old-gen lower tiers that lack full sets of
analyses and have usage stats available from the RoA Rotational ladder.