### PR TITLE
Add terrain options to one-vs-all

### DIFF
--- a/calc_bc.html
+++ b/calc_bc.html
@@ -74,8 +74,8 @@
                     <div class="info-group">
                         <div>
                             <label>Type</label>
-                            <select class="type1"></select>
-                            <select class="type2"></select>
+                            <select class="type1 terrain-trigger"></select>
+                            <select class="type2 terrain-trigger"></select>
                         </div>
                         <div>
                             <label>Level</label>
@@ -362,11 +362,11 @@
                         </div>
                         <div class="gen-specific g3 g4 g5 g6 g7">
                             <label>Ability</label>
-                            <select class="ability"></select>
+                            <select class="ability terrain-trigger"></select>
                         </div>
                         <div class="gen-specific g2 g3 g4 g5 g6 g7">
                             <label>Item</label>
-                            <select class="item"></select>
+                            <select class="item terrain-trigger"></select>
                         </div>
                         <div>
                             <label>Status</label>
@@ -494,6 +494,15 @@
                         <input class="btn-input" type="radio" name="format" value="Doubles" id="doubles-format" />
                         <label class="btn btn-right" for="doubles-format">Doubles</label>
                     </div>
+                    <div class="gen-specific g6 g7" title="Select the current terrain.">
+                        <input class="btn-input terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Electric" id="electric" /><label class="btn btn-xxxwide btn-left" for="electric">Electric Terrain</label>
+                        <input class="btn-input terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Grassy" id="grassy" /><label class="btn btn-xxxwide btn-mid" for="grassy">Grassy Terrain</label>
+                        <input class="btn-input terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Misty" id="misty" /><label class="btn btn-xxxwide btn-right" for="misty">Misty Terrain</label>
+                    </div>
+                    <div class="gen-specific g7" title="Select the current terrain.">
+                        <input class="btn-input terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-xxxwide btn-mid" for="psychic">Psychic Terrain</label>
+                    </div>
+                    <hr class="gen-specific g6 g7" />
                     <div class="gen-specific g3 g4 g5 g6 g7" style="width: 22.2em; margin: 5px auto;" title="Select the current weather condition.">
                         <input class="btn-input" type="radio" name="weather" value="" id="clear" checked="checked" />
                         <label class="btn btn-small btn-left" for="clear">None</label>

--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -700,6 +700,69 @@ function getSelectOptions(arr, sort) {
     return r;
 }
 
+function isGrounded(pokeInfo) {
+    return $("#gravity").prop("checked") || (
+        pokeInfo.find(".type1").val() !== "Flying" &&
+        pokeInfo.find(".type2").val() !== "Flying" &&
+        pokeInfo.find(".ability").val() !== "Levitate" &&
+        pokeInfo.find(".item").val() !== "Air Balloon"
+    );
+}
+
+function getTerrainEffects() {
+    var className = $(this).prop("className");
+    className = className.substring(0, className.indexOf(" "));
+    switch (className) {
+        case "type1":
+        case "type2":
+        case "item":
+            var id = $(this).closest(".poke-info").prop("id");
+            var terrainValue = $("input:checkbox[name='terrain']:checked").val();
+            if (terrainValue === "Electric") {
+                $("#" + id).find("[value='Asleep']").prop("disabled", isGrounded($("#" + id)));
+            } else if (terrainValue === "Misty") {
+                $("#" + id).find(".status").prop("disabled", isGrounded($("#" + id)));
+            }
+            break;
+        case "ability":
+            // with autoset, ability change may cause terrain change, need to consider both sides
+            var terrainValue = $("input:checkbox[name='terrain']:checked").val();
+            if (terrainValue === "Electric") {
+                $("#p1").find(".status").prop("disabled", false);
+                $("#p2").find(".status").prop("disabled", false);
+                $("#p1").find("[value='Asleep']").prop("disabled", isGrounded($("#p1")));
+                $("#p2").find("[value='Asleep']").prop("disabled", isGrounded($("#p2")));
+            } else if (terrainValue === "Misty") {
+                $("#p1").find(".status").prop("disabled", isGrounded($("#p1")));
+                $("#p2").find(".status").prop("disabled", isGrounded($("#p2")));
+            } else {
+                $("#p1").find("[value='Asleep']").prop("disabled", false);
+                $("#p1").find(".status").prop("disabled", false);
+                $("#p2").find("[value='Asleep']").prop("disabled", false);
+                $("#p2").find(".status").prop("disabled", false);
+            }
+            break;
+        default:
+            $("input:checkbox[name='terrain']").not(this).prop("checked", false);
+            if ($(this).prop("checked") && $(this).val() === "Electric") {
+                // need to enable status because it may be disabled by Misty Terrain before.
+                $("#p1").find(".status").prop("disabled", false);
+                $("#p2").find(".status").prop("disabled", false);
+                $("#p1").find("[value='Asleep']").prop("disabled", isGrounded($("#p1")));
+                $("#p2").find("[value='Asleep']").prop("disabled", isGrounded($("#p2")));
+            } else if ($(this).prop("checked") && $(this).val() === "Misty") {
+                $("#p1").find(".status").prop("disabled", isGrounded($("#p1")));
+                $("#p2").find(".status").prop("disabled", isGrounded($("#p2")));
+            } else {
+                $("#p1").find("[value='Asleep']").prop("disabled", false);
+                $("#p1").find(".status").prop("disabled", false);
+                $("#p2").find("[value='Asleep']").prop("disabled", false);
+                $("#p2").find(".status").prop("disabled", false);
+            }
+            break;
+    }
+}
+
 $(document).ready(function() {
     $("#gen7").prop("checked", true);
     $("#gen7").change();
@@ -736,4 +799,6 @@ $(document).ready(function() {
     });
     $(".set-selector").val(getSetOptions()[gen < 4 ? 3 : 1].id);
     $(".set-selector").change();
+
+    $(".terrain-trigger").bind("change keyup", getTerrainEffects);
 });

--- a/js/calc_ab.js
+++ b/js/calc_ab.js
@@ -10,69 +10,6 @@ $("#p2 .item").bind("keyup change", function() {
 lastManualStatus["#p2"] = "Healthy";
 lastAutoStatus["#p1"] = "Healthy";
 
-function getTerrainEffects() {
-    var className = $(this).prop("className");
-    className = className.substring(0, className.indexOf(" "));
-    switch (className) {
-        case "type1":
-        case "type2":
-        case "item":
-            var id = $(this).closest(".poke-info").prop("id");
-            var terrainValue = $("input:checkbox[name='terrain']:checked").val();
-            if (terrainValue === "Electric") {
-                $("#" + id).find("[value='Asleep']").prop("disabled", isGrounded($("#" + id)));
-            } else if (terrainValue === "Misty") {
-                $("#" + id).find(".status").prop("disabled", isGrounded($("#" + id)));
-            }
-            break;
-        case "ability":
-            // with autoset, ability change may cause terrain change, need to consider both sides
-            var terrainValue = $("input:checkbox[name='terrain']:checked").val();
-            if (terrainValue === "Electric") {
-                $("#p1").find(".status").prop("disabled", false);
-                $("#p2").find(".status").prop("disabled", false);
-                $("#p1").find("[value='Asleep']").prop("disabled", isGrounded($("#p1")));
-                $("#p2").find("[value='Asleep']").prop("disabled", isGrounded($("#p2")));
-            } else if (terrainValue === "Misty") {
-                $("#p1").find(".status").prop("disabled", isGrounded($("#p1")));
-                $("#p2").find(".status").prop("disabled", isGrounded($("#p2")));
-            } else {
-                $("#p1").find("[value='Asleep']").prop("disabled", false);
-                $("#p1").find(".status").prop("disabled", false);
-                $("#p2").find("[value='Asleep']").prop("disabled", false);
-                $("#p2").find(".status").prop("disabled", false);
-            }
-            break;
-        default:
-            $("input:checkbox[name='terrain']").not(this).prop("checked", false);
-            if ($(this).prop("checked") && $(this).val() === "Electric") {
-                // need to enable status because it may be disabled by Misty Terrain before.
-                $("#p1").find(".status").prop("disabled", false);
-                $("#p2").find(".status").prop("disabled", false);
-                $("#p1").find("[value='Asleep']").prop("disabled", isGrounded($("#p1")));
-                $("#p2").find("[value='Asleep']").prop("disabled", isGrounded($("#p2")));
-            } else if ($(this).prop("checked") && $(this).val() === "Misty") {
-                $("#p1").find(".status").prop("disabled", isGrounded($("#p1")));
-                $("#p2").find(".status").prop("disabled", isGrounded($("#p2")));
-            } else {
-                $("#p1").find("[value='Asleep']").prop("disabled", false);
-                $("#p1").find(".status").prop("disabled", false);
-                $("#p2").find("[value='Asleep']").prop("disabled", false);
-                $("#p2").find(".status").prop("disabled", false);
-            }
-            break;
-    }
-}
-
-function isGrounded(pokeInfo) {
-    return $("#gravity").prop("checked") || (
-        pokeInfo.find(".type1").val() !== "Flying"
-        && pokeInfo.find(".type2").val() !== "Flying"
-        && pokeInfo.find(".ability").val() !== "Levitate"
-        && pokeInfo.find(".item").val() !== "Air Balloon"
-    );
-}
-
 var resultLocations = [[],[]];
 for (var i = 0; i < 4; i++) {
     resultLocations[0].push({
@@ -183,7 +120,6 @@ $(".notation").change(function () {
 });
 
 $(document).ready(function() {
-    $(".terrain-trigger").bind("change keyup", getTerrainEffects);
     $(".calc-trigger").bind("change keyup", function() {
         setTimeout(calculate, 0);
     });


### PR DESCRIPTION
Add terrain options to one-vs-all/all-vs-one. Changes in detail:

1. Add terrain buttons to `calc_bc.html`
2. Add `terrain-trigger` class to type/ability/item elements in `calc_bc.html`
3. Move function `isGrounded`, `getTerrainEffects` to `ap_calc.js`, so they can be used both in one-vs-one and one-vs-all

Tested
