### PR TITLE
Implement protect check

### DIFF
--- a/calc_bc.html
+++ b/calc_bc.html
@@ -594,6 +594,16 @@
                             <label class="btn btn-xwide btn-right" for="lightScreenR">Light Screen</label>
                         </div>
                     </div>
+                    <div class="btn-group gen-specific g2 g3 g4 g5 g6 g7">
+                        <div class="left" title="Is this Pok&eacute;mon protected?">
+                            <input class="btn-input" type="checkbox" id="protectL" />
+                            <label class="btn btn-wide" for="protectL">Protect</label>
+                        </div>
+                        <div class="right" title="Is this Pok&eacute;mon protected?">
+                            <input class="btn-input" type="checkbox" id="protectR" />
+                            <label class="btn btn-wide" for="protectR">Protect</label>
+                        </div>
+                    </div>
                     <div class="btn-group">
                         <div class="left" title="Has this Pok&eacute;mon been affected by Leech Seed?">
                             <input class="btn-input" type="checkbox" id="leechSeedL" />

--- a/index.html
+++ b/index.html
@@ -630,6 +630,16 @@
                         <label class="btn btn-xwide btn-right" for="lightScreenR">Light Screen</label>
                     </div>
                 </div>
+                <div class="btn-group gen-specific g2 g3 g4 g5 g6 g7">
+                    <div class="left" title="Is this Pok&eacute;mon protected?">
+                        <input class="btn-input calc-trigger" type="checkbox" id="protectL" />
+                        <label class="btn btn-wide" for="protectL">Protect</label>
+                    </div>
+                    <div class="right" title="Is this Pok&eacute;mon protected?">
+                        <input class="btn-input calc-trigger" type="checkbox" id="protectR" />
+                        <label class="btn btn-wide" for="protectR">Protect</label>
+                    </div>
+                </div>
                 <div class="btn-group">
                     <div class="left" title="Has this Pok&eacute;mon been affected by Leech Seed?">
                         <input class="btn-input calc-trigger" type="checkbox" id="leechSeedL" />

--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -445,7 +445,6 @@ function getMoveDetails(moveInfo, item) {
             bp: moves[zMoveName].bp === 1 ? defaultDetails.zp : moves[zMoveName].bp,
             category: defaultDetails.category,
             isCrit: moveInfo.find(".move-crit").prop("checked"),
-            isZ: true,
             hits: 1
         });
     } else {
@@ -490,6 +489,7 @@ function Field() {
     var terrain = ($("input:checkbox[name='terrain']:checked").val()) ? $("input:checkbox[name='terrain']:checked").val() : "";
     var isReflect = [$("#reflectL").prop("checked"), $("#reflectR").prop("checked")];
     var isLightScreen = [$("#lightScreenL").prop("checked"), $("#lightScreenR").prop("checked")];
+    var isProtected = [$("#protectL").prop("checked"), $("#protectR").prop("checked")];
     var isSeeded = [$("#leechSeedL").prop("checked"), $("#leechSeedR").prop("checked")];
     var isForesight = [$("#foresightL").prop("checked"), $("#foresightR").prop("checked")];
     var isHelpingHand = [$("#helpingHandR").prop("checked"), $("#helpingHandL").prop("checked")]; // affects attacks against opposite side
@@ -503,11 +503,11 @@ function Field() {
         weather = "";
     };
     this.getSide = function(i) {
-        return new Side(format, terrain, weather, isGravity, isSR[i], spikes[i], isReflect[i], isLightScreen[i], isSeeded[1-i], isSeeded[i], isForesight[i], isHelpingHand[i], isFriendGuard[i], isAuroraVeil[i]);
+        return new Side(format, terrain, weather, isGravity, isSR[i], spikes[i], isReflect[i], isLightScreen[i], isProtected[i], isSeeded[1-i], isSeeded[i], isForesight[i], isHelpingHand[i], isFriendGuard[i], isAuroraVeil[i]);
     };
 }
 
-function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLightScreen, isAttackerSeeded, isDefenderSeeded, isForesight, isHelpingHand, isFriendGuard, isAuroraVeil) {
+function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLightScreen, isProtected, isAttackerSeeded, isDefenderSeeded, isForesight, isHelpingHand, isFriendGuard, isAuroraVeil) {
     this.format = format;
     this.terrain = terrain;
     this.weather = weather;
@@ -516,6 +516,7 @@ function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLi
     this.spikes = spikes;
     this.isReflect = isReflect;
     this.isLightScreen = isLightScreen;
+    this.isProtected = isProtected;
     this.isAttackerSeeded = isAttackerSeeded;
     this.isDefenderSeeded = isDefenderSeeded;
     this.isForesight = isForesight;
@@ -643,6 +644,8 @@ function clearField() {
     $("#reflectR").prop("checked", false);
     $("#lightScreenL").prop("checked", false);
     $("#lightScreenR").prop("checked", false);
+    $("#protectL").prop("checked", false);
+    $("#protectR").prop("checked", false);
     $("#leechSeedL").prop("checked", false);
     $("#leechSeedR").prop("checked", false);
     $("#foresightL").prop("checked", false);

--- a/js/damage.js
+++ b/js/damage.js
@@ -67,7 +67,12 @@ function getDamageResult(attacker, defender, move, field) {
     if (move.bp === 0) {
         return {"damage":[0], "description":buildDescription(description)};
     }
-    
+
+    if (field.isProtected && !move.bypassesProtect && !move.isZ) {
+        description.isProtected = true;
+        return {"damage":[0], "description":buildDescription(description)};
+    }
+
     var defAbility = defender.ability;
     if (["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) !== -1) {
         defAbility = "";
@@ -643,6 +648,10 @@ function getDamageResult(attacker, defender, move, field) {
             attacker.ability !== "Unnerve") {
         finalMods.push(0x800);
         description.defenderItem = defender.item;
+    }
+    if (field.isProtected && move.isZ) {
+        finalMods.push(0x400);
+        description.isProtected = true;
     }
     var finalMod = chainMods(finalMods);
     

--- a/js/damage_dpp.js
+++ b/js/damage_dpp.js
@@ -51,6 +51,11 @@ function CALCULATE_DAMAGE_DPP(attacker, defender, move, field) {
     if (move.bp === 0) {
         return {"damage":[0], "description":buildDescription(description)};
     }
+
+    if (field.isProtected && !move.bypassesProtect) {
+        description.isProtected = true;
+        return {"damage":[0], "description":buildDescription(description)};
+    }
     
     var defAbility = defender.ability;
     if (attacker.ability === "Mold Breaker") {

--- a/js/damage_gsc.js
+++ b/js/damage_gsc.js
@@ -40,7 +40,12 @@ function CALCULATE_DAMAGE_GSC(attacker, defender, move, field) {
     if (move.bp === 0) {
         return {"damage":[0], "description":buildDescription(description)};
     }
-    
+
+    if (field.isProtected) {
+        description.isProtected = true;
+        return {"damage":[0], "description":buildDescription(description)};
+    }
+
     var typeEffect1 = getMoveEffectiveness(move, defender.type1, field.isForesight);
     var typeEffect2 = defender.type2 ? getMoveEffectiveness(move, defender.type2, field.isForesight) : 1;
     var typeEffectiveness = typeEffect1 * typeEffect2;

--- a/js/damage_rby.js
+++ b/js/damage_rby.js
@@ -154,6 +154,9 @@ function buildDescription(description) {
     }
     output = appendIfSet(output, description.defenderItem);
     output = appendIfSet(output, description.defenderAbility);
+    if (description.isProtected) {
+        output += "protected ";
+    }
     output += description.defenderName;
     if (description.weather && description.terrain) {
         

--- a/js/damage_rse.js
+++ b/js/damage_rse.js
@@ -40,7 +40,12 @@ function CALCULATE_DAMAGE_ADV(attacker, defender, move, field) {
     if (move.bp === 0) {
         return {"damage":[0], "description":buildDescription(description)};
     }
-    
+
+    if (field.isProtected) {
+        description.isProtected = true;
+        return {"damage":[0], "description":buildDescription(description)};
+    }
+
     if (move.name === "Weather Ball") {
         move.type = field.weather === "Sun" ? "Fire"
                 : field.weather === "Rain" ? "Water"

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -1390,6 +1390,12 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
         hasSecondaryEffect: true,
         isBullet: true
     },
+    'Feint': {
+        bp: 50,
+        type: 'Normal',
+        category: 'Physical',
+        bypassesProtect: true
+    },
     'Fire Fang': {
         bp: 65,
         type: 'Fire',
@@ -1898,12 +1904,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         hasSecondaryEffect: true,
         isSpread: true
     },
-    'Feint': {
-        bp: 30,
-        type: 'Normal',
-        category: 'Physical',
-        bypassesProtect: true
-    },
+    'Feint': { bp: 30 },
     'Fiery Dance': {
         bp: 80,
         type: 'Fire',
@@ -2507,12 +2508,14 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     '10,000,000 Volt Thunderbolt': {
         bp: 195,
         type: 'Electric',
-        category: 'Special'
+        category: 'Special',
+        isZ: true
     },
     'Acid Downpour': {
         bp: 1,
         type: 'Poison',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Acid Spray': { zp: 100 },
     'Accelerock': {
@@ -2531,7 +2534,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'All-Out Pummeling': {
         bp: 1,
         type: 'Fighting',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Anchor Shot': {
         bp: 80,
@@ -2560,7 +2564,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Black Hole Eclipse': {
         bp: 1,
         type: 'Dark',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Blast Burn': { zp: 200 },
     'Blaze Kick': { zp: 160 },
@@ -2568,14 +2573,16 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Bloom Doom': {
         bp: 1,
         type: 'Grass',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Blue Flare': { zp: 195 },
     'Brave Bird': { zp: 190 },
     'Breakneck Blitz': {
         bp: 1,
         type: 'Normal',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Brine': { zp: 120 },
     'Body Slam': { zp: 160 },
@@ -2608,7 +2615,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Catastropika': {
         bp: 210,
         type: 'Electric',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Charge Beam': { zp: 100 },
     'Chatter': { zp: 120 },
@@ -2627,7 +2635,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Continental Crush': {
         bp: 1,
         type: 'Rock',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Core Enforcer': {
         bp: 100,
@@ -2639,7 +2648,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Corkscrew Crash': {
         bp: 1,
         type: 'Steel',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Covet': { zp: 120 },
     'Crabhammer': { zp: 180 },
@@ -2670,7 +2680,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Devastating Drake': {
         bp: 1,
         type: 'Dragon',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Doom Desire': { zp: 200 },
     'Double-Edge': { zp: 190 },
@@ -2756,14 +2767,16 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Genesis Supernova': {
         bp: 185,
         type: 'Psychic',
-        category: 'Special'
+        category: 'Special',
+        isZ: true
     },
     'Giga Drain': { zp: 140 },
     'Giga Impact': { zp: 200 },
     'Gigavolt Havoc': {
         bp: 1,
         type: 'Electric',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Glaciate': { zp: 120 },
     'Grass Knot': { zp: 160 },
@@ -2807,7 +2820,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Hydro Vortex': {
         bp: 1,
         type: 'Water',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Hyper Beam': { zp: 200 },
     'Hyper Voice': { zp: 175 },
@@ -2834,7 +2848,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Inferno Overdrive': {
         bp: 1,
         type: 'Fire',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Iron Head': { zp: 160 },
     'Iron Tail': { zp: 180 },
@@ -2882,7 +2897,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
         bp: 180,
         type: 'Dark',
         category: 'Physical',
-        makesContact: true
+        makesContact: true,
+        isZ: true
     },
     'Megahorn': { zp: 190 },
     'Meteor Mash': { zp: 175 },
@@ -2910,7 +2926,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Never-Ending Nightmare': {
         bp: 1,
         type: 'Ghost',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Night Daze': { zp: 160 },
     'Night Shade': { zp: 100 },
@@ -2920,7 +2937,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Oceanic Operetta': {
         bp: 195,
         type: 'Water',
-        category: 'Special'
+        category: 'Special',
+        isZ: true
     },
     'Ominous Wind': { zp: 120 },
     'Origin Pulse': { zp: 185 },
@@ -2975,7 +2993,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Pulverizing Pancake': {
         bp: 210,
         type: 'Normal',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Punishment': { zp: 160 },
     'Pursuit': { zp: 100 },
@@ -3008,7 +3027,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Savage Spin-Out': {
         bp: 1,
         type: 'Bug',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Scald': { zp: 160 },
     'Searing Shot': { zp: 180 },
@@ -3024,7 +3044,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Shattered Psyche': {
         bp: 1,
         type: 'Psychic',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Shadow Ball': { zp: 160 },
     'Shadow Bone': {
@@ -3049,7 +3070,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Sinister Arrow Raid': {
         bp: 180,
         type: 'Ghost',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Skull Bash': { zp: 195 },
     'Sky Attack': { zp: 200 },
@@ -3077,7 +3099,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Soul-Stealing 7-Star Strike': {
         bp: 195,
         type: 'Ghost',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Spacial Rend': { zp: 180 },
     'Spark': { zp: 120 },
@@ -3108,7 +3131,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Stoked Sparksurfer': {
         bp: 175,
         type: 'Electric',
-        category: 'Special'
+        category: 'Special',
+        isZ: true
     },
     'Stomping Tantrum': {
         bp: 75,
@@ -3124,7 +3148,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Subzero Slammer': {
         bp: 1,
         type: 'Ice',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Sucker Punch': { bp: 70, zp: 140 },
     'Sunsteel Strike': {
@@ -3139,7 +3164,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Supersonic Skystrike': {
         bp: 1,
         type: 'Flying',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Surf': { zp: 175 },
     'Swift': { zp: 120 },
@@ -3150,7 +3176,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Tectonic Rage': {
         bp: 1,
         type: 'Ground',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     'Thief': { zp: 120 },
     'Thousand Arrows': { zp: 180 },
@@ -3179,7 +3206,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Twinkle Tackle': {
         bp: 1,
         type: 'Fairy',
-        category: 'Physical'
+        category: 'Physical',
+        isZ: true
     },
     "U-turn": { zp: 140 },
     'Uproar': { zp: 175 },


### PR DESCRIPTION
Add "Protect" option, if checked, moves without `bypassesProtect` property with do no damage, and z-moves will get their damage reduced
Implement `isZ` as an own property of z-moves instead of adding it dynamically, so even if the user type the z-move themselves, it still works
Move Feint to gen 4 when it was introduced, and change its power in gen 5