### PR TITLE
Notify user if no format selected for 1vsAll calculation

### DIFF
--- a/js/calc_bc.js
+++ b/js/calc_bc.js
@@ -219,6 +219,14 @@ function placeBsBtn() {
     var honkalculator = "<button style='position:absolute' class='bs-btn bs-btn-default'>Honkalculate</button>";
     $("#holder-2_wrapper").prepend(honkalculator);
     $(".bs-btn").click(function() {
+        var formats = getSelectedTiers();
+        if (!formats.length) {
+            $(".bs-btn").popover({
+                content: "No format selected",
+                placement: "right"
+            }).popover('show');
+            setTimeout(function(){ $(".bs-btn").popover('destroy') }, 1350);
+        }
         table.clear();
         calculate();
     });


### PR DESCRIPTION
No format being selected is the default, and there is zero feedback to the user if they click "Honkalculate" in that situiation. Perhaps they even assume that "no format selected" = "use sets from all formats".
So, here's a popover (like those that appear when the level is changed) for that.