### PR TITLE
Fix no Pokemon is selected when change to ADV

### DIFF
--- a/js/ap_calc.js
+++ b/js/ap_calc.js
@@ -626,7 +626,7 @@ $(".gen").change(function () {
     var itemOptions = getSelectOptions(items, true);
     $("select.item").find("option").remove().end().append("<option value=\"\">(none)</option>" + itemOptions);
     
-    $(".set-selector").val(getSetOptions()[gen < 4 ? 3 : 1].id);
+    $(".set-selector").val(getSetOptions()[gen < 3 ? 3 : 1].id);
     $(".set-selector").change();
 });
 
@@ -794,7 +794,7 @@ $(document).ready(function() {
             });
         },
         initSelection: function(element, callback) {
-            var data = getSetOptions()[gen < 4 ? 3 : 1];
+            var data = getSetOptions()[gen < 3 ? 3 : 1];
             callback(data);
         }
     });
@@ -805,7 +805,7 @@ $(document).ready(function() {
             return text.toUpperCase().indexOf(term.toUpperCase()) === 0 || text.toUpperCase().indexOf(" " + term.toUpperCase()) >= 0;
         }
     });
-    $(".set-selector").val(getSetOptions()[gen < 4 ? 3 : 1].id);
+    $(".set-selector").val(getSetOptions()[gen < 3 ? 3 : 1].id);
     $(".set-selector").change();
 
     $(".terrain-trigger").bind("change keyup", getTerrainEffects);


### PR DESCRIPTION
Previously the items in ADV set options was like this, so it was proper to choose the 3rd item by default when we change to ADV;

```
0  Abra
1    Blank Set
2  Aerodactyl
3    UU Showdown Usage
...
```

Now after setdex update the ADV set options is like this, the 3rd item is no longer a valid set, so weird behavoir occurs when we change to ADV. The 1st or 4th item should be chosen by default. I currently choose the 1st item.

```
0  Abra
1    NU Showdown Usage
2    Blank Set
3  Aerodactyl
4    UU Showdown Usage
...
```