### PR TITLE
Fluffy damage calculation fixes

### DIFF
--- a/js/damage.js
+++ b/js/damage.js
@@ -322,10 +322,10 @@ function getDamageResult(attacker, defender, move, field) {
     } else if (defAbility === "Dry Skin" && move.type === "Fire") {
         bpMods.push(0x1400);
         description.defenderAbility = defAbility;
-    } else if (defAbility === "Fluffy" && move.makesContact && move.type === "Fire") {
+    } else if (defAbility === "Fluffy" && (!move.makesContact || attacker.ability === "Long Reach") && move.type === "Fire") {
         bpMods.push(0x2000); 
         description.defenderAbility = defAbility;
-    } else if (defAbility === "Fluffy" && move.makesContact && attacker.ability !== "Long Reach") {
+    } else if (defAbility === "Fluffy" && move.makesContact && attacker.ability !== "Long Reach" && move.type !== "Fire") {
         bpMods.push(0x800);
         description.defenderAbility = defAbility;
     }


### PR DESCRIPTION
Damage calculator was calculating damage for Fluffy incorrectly. Correct calculation is that damage doubles for Fire-type moves that don't make contact and halves for moves that make contact that aren't Fire type. Reported here: https://www.smogon.com/forums/posts/7310857