### PR TITLE
Add damage multiplier for draining moves

### DIFF
--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -105,7 +105,7 @@ var MOVES_RBY = {
         type: 'Psychic',
         category: 'Special',
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Drill Peck': {
         bp: 80,
@@ -227,7 +227,7 @@ var MOVES_RBY = {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Leech Seed': {
         bp: 0,
@@ -245,7 +245,7 @@ var MOVES_RBY = {
         bp: 40,
         type: 'Grass',
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Mirror Move': {
         bp: 0,
@@ -576,7 +576,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
         type: 'Grass',
         category: 'Special',
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Gust': { type: 'Flying' },
     'Headbutt': {
@@ -1415,7 +1415,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
         makesContact: true,
         isPunch: true,
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Earth Power': {
         bp: 90,
@@ -2058,7 +2058,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
     },
     'Hurricane': {
         bp: 120,
@@ -2363,7 +2363,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         category: 'Special',
         makesContact: true,
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.75
     },
     'Energy Ball': { bp: 90 },
     'Facade': { ignoresBurn: true },
@@ -2481,7 +2481,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Flying',
         category: 'Special',
         givesHealth: true,
-	 percentHealed: 0.75
+		percentHealed: 0.75
     },
     'Origin Pulse': {
         bp: 110,
@@ -2496,7 +2496,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Electric',
         category: 'Special',
         givesHealth: true,
-	 percentHealed: 0.5
+		percentHealed: 0.5
      },
     'Phantom Force': {
         bp: 90,

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -104,7 +104,8 @@ var MOVES_RBY = {
         bp: 100,
         type: 'Psychic',
         category: 'Special',
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Drill Peck': {
         bp: 80,
@@ -225,7 +226,8 @@ var MOVES_RBY = {
         type: 'Bug',
         category: 'Physical',
         makesContact: true,
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Leech Seed': {
         bp: 0,
@@ -242,7 +244,8 @@ var MOVES_RBY = {
     'Mega Drain': {
         bp: 40,
         type: 'Grass',
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Mirror Move': {
         bp: 0,
@@ -572,7 +575,8 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
         bp: 60,
         type: 'Grass',
         category: 'Special',
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Gust': { type: 'Flying' },
     'Headbutt': {
@@ -1410,7 +1414,8 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
         category: 'Physical',
         makesContact: true,
         isPunch: true,
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Earth Power': {
         bp: 90,
@@ -2052,7 +2057,8 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         type: 'Grass',
         category: 'Physical',
         makesContact: true,
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Hurricane': {
         bp: 120,
@@ -2356,7 +2362,8 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Fairy',
         category: 'Special',
         makesContact: true,
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.5
     },
     'Energy Ball': { bp: 90 },
     'Facade': { ignoresBurn: true },
@@ -2473,7 +2480,8 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         bp: 80,
         type: 'Flying',
         category: 'Special',
-        givesHealth: true
+        givesHealth: true,
+		percentHealed : 0.75
     },
     'Origin Pulse': {
         bp: 110,
@@ -2483,11 +2491,12 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         isPulse: true
     },
     'Overheat': { bp: 130 },
-    'Parabolic Charge': { 
+    'Parabolic Charge' : { 
         bp: 50,
         type : 'Electric',
         category: 'Special',
-        givesHealth : true
+        givesHealth : true,
+		percentHealed : 0.5
      },
     'Phantom Force': {
         bp: 90,
@@ -3038,7 +3047,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Outrage': { zp: 190 },
     'Overheat': { zp: 195 },
     'Paleo Wave': { zp: 160 },
-    'Parabolic Charge': { bp: 65, zp:120 },
+    'Parabolic Charge' : { bp: 65, zp:120 },
     'Payback': { zp: 100 },
     'Petal Dance': { zp: 190 },
     'Phantom Force': { zp: 175 },

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -2491,7 +2491,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         isPulse: true
     },
     'Overheat': { bp: 130 },
-    'Parabolic Charge' : { 
+    'Parabolic Charge': { 
         bp: 50,
         type: 'Electric',
         category: 'Special',

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -105,7 +105,7 @@ var MOVES_RBY = {
         type: 'Psychic',
         category: 'Special',
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Drill Peck': {
         bp: 80,
@@ -227,7 +227,7 @@ var MOVES_RBY = {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Leech Seed': {
         bp: 0,
@@ -245,7 +245,7 @@ var MOVES_RBY = {
         bp: 40,
         type: 'Grass',
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Mirror Move': {
         bp: 0,
@@ -576,7 +576,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
         type: 'Grass',
         category: 'Special',
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Gust': { type: 'Flying' },
     'Headbutt': {
@@ -1415,7 +1415,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
         makesContact: true,
         isPunch: true,
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Earth Power': {
         bp: 90,
@@ -2058,7 +2058,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Hurricane': {
         bp: 120,
@@ -2363,7 +2363,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         category: 'Special',
         makesContact: true,
         givesHealth: true,
-		percentHealed : 0.5
+	percentHealed: 0.5
     },
     'Energy Ball': { bp: 90 },
     'Facade': { ignoresBurn: true },
@@ -2481,7 +2481,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Flying',
         category: 'Special',
         givesHealth: true,
-		percentHealed : 0.75
+	percentHealed: 0.75
     },
     'Origin Pulse': {
         bp: 110,
@@ -2493,10 +2493,10 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
     'Overheat': { bp: 130 },
     'Parabolic Charge' : { 
         bp: 50,
-        type : 'Electric',
+        type: 'Electric',
         category: 'Special',
-        givesHealth : true,
-		percentHealed : 0.5
+        givesHealth: true,
+	percentHealed: 0.5
      },
     'Phantom Force': {
         bp: 90,
@@ -3047,7 +3047,7 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     'Outrage': { zp: 190 },
     'Overheat': { zp: 195 },
     'Paleo Wave': { zp: 160 },
-    'Parabolic Charge' : { bp: 65, zp:120 },
+    'Parabolic Charge': { bp: 65, zp:120 },
     'Payback': { zp: 100 },
     'Petal Dance': { zp: 190 },
     'Phantom Force': { zp: 175 },

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -105,7 +105,7 @@ var MOVES_RBY = {
         type: 'Psychic',
         category: 'Special',
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Drill Peck': {
         bp: 80,
@@ -227,7 +227,7 @@ var MOVES_RBY = {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Leech Seed': {
         bp: 0,
@@ -245,7 +245,7 @@ var MOVES_RBY = {
         bp: 40,
         type: 'Grass',
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Mirror Move': {
         bp: 0,
@@ -576,7 +576,7 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
         type: 'Grass',
         category: 'Special',
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Gust': { type: 'Flying' },
     'Headbutt': {
@@ -1415,7 +1415,7 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
         makesContact: true,
         isPunch: true,
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Earth Power': {
         bp: 90,
@@ -2058,7 +2058,7 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         category: 'Physical',
         makesContact: true,
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Hurricane': {
         bp: 120,
@@ -2363,7 +2363,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         category: 'Special',
         makesContact: true,
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
     },
     'Energy Ball': { bp: 90 },
     'Facade': { ignoresBurn: true },
@@ -2481,7 +2481,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Flying',
         category: 'Special',
         givesHealth: true,
-	percentHealed: 0.75
+	 percentHealed: 0.75
     },
     'Origin Pulse': {
         bp: 110,
@@ -2496,7 +2496,7 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
         type: 'Electric',
         category: 'Special',
         givesHealth: true,
-	percentHealed: 0.5
+	 percentHealed: 0.5
      },
     'Phantom Force': {
         bp: 90,

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -40,23 +40,36 @@ function calculate() {
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p1.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p1, p2, field.getSide(1), p1.moves[i].hits, p1.ability === 'Bad Dreams');
+        var recoveryText = '';
+        if (p1.moves[i].givesHealth) {
+            var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
+            var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
+            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+        }
+		
         $(resultLocations[0][i].move + " + label").text(p1.moves[i].name.replace("Hidden Power", "HP"));
-        $(resultLocations[0][i].damage).text(minDisplay + " - " + maxDisplay + notation);
+        $(resultLocations[0][i].damage).text(minDisplay + " - " + maxDisplay + notation + recoveryText);
         if (maxDamage > highestDamage) {
             highestDamage = maxDamage;
             bestResult = $(resultLocations[0][i].move);
         }
         
         result = damageResults[1][i];
+		recoveryText = '';
         minDamage = result.damage[0] * p2.moves[i].hits;
         maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
         minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);
         maxDisplay = notation === '%' ? Math.floor(maxDamage * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * 48 / p1.maxHP);
+		if (p2.moves[i].givesHealth) {
+            var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
+            var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
+            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+		}
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p2.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p2, p1, field.getSide(0), p2.moves[i].hits, p2.ability === 'Bad Dreams');
         $(resultLocations[1][i].move + " + label").text(p2.moves[i].name.replace("Hidden Power", "HP"));
-        $(resultLocations[1][i].damage).text(minDisplay + " - " + maxDisplay + notation);
+        $(resultLocations[1][i].damage).text(minDisplay + " - " + maxDisplay + notation + recoveryText);
         if (maxDamage > highestDamage) {
             highestDamage = maxDamage;
             bestResult = $(resultLocations[1][i].move);

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -55,12 +55,12 @@ function calculate() {
         }
         
         result = damageResults[1][i];
-	recoveryText = '';
+	 recoveryText = '';
         minDamage = result.damage[0] * p2.moves[i].hits;
         maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
         minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);
         maxDisplay = notation === '%' ? Math.floor(maxDamage * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * 48 / p1.maxHP);
-	if (p2.moves[i].givesHealth) {
+	 if (p2.moves[i].givesHealth) {
             var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -40,31 +40,31 @@ function calculate() {
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p1.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p1, p2, field.getSide(1), p1.moves[i].hits, p1.ability === 'Bad Dreams');
-        var recoveryText = '';
-        if (p1.moves[i].givesHealth) {
-            var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
-            var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
-            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
-        }
+		var recoveryText = '';
+		if (p1.moves[i].givesHealth) {
+			var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
+			var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
+			recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+		}
 		
         $(resultLocations[0][i].move + " + label").text(p1.moves[i].name.replace("Hidden Power", "HP"));
         $(resultLocations[0][i].damage).text(minDisplay + " - " + maxDisplay + notation + recoveryText);
         if (maxDamage > highestDamage) {
             highestDamage = maxDamage;
             bestResult = $(resultLocations[0][i].move);
-        }
+		}
         
         result = damageResults[1][i];
-	 recoveryText = '';
-        minDamage = result.damage[0] * p2.moves[i].hits;
-        maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
-        minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);
+		recoveryText = '';
+		minDamage = result.damage[0] * p2.moves[i].hits;
+		maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
+		minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);
         maxDisplay = notation === '%' ? Math.floor(maxDamage * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * 48 / p1.maxHP);
-	 if (p2.moves[i].givesHealth) {
-            var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
-            var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
-            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
-	 }
+		if (p2.moves[i].givesHealth) {
+			var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
+			var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
+			recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+		}
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p2.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p2, p1, field.getSide(0), p2.moves[i].hits, p2.ability === 'Bad Dreams');

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -55,7 +55,7 @@ function calculate() {
         }
         
         result = damageResults[1][i];
-		recoveryText = '';
+	recoveryText = '';
         minDamage = result.damage[0] * p2.moves[i].hits;
         maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
         minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -60,11 +60,11 @@ function calculate() {
         maxDamage = result.damage[result.damage.length-1] * p2.moves[i].hits;
         minDisplay = notation === '%' ? Math.floor(minDamage * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * 48 / p1.maxHP);
         maxDisplay = notation === '%' ? Math.floor(maxDamage * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * 48 / p1.maxHP);
-		if (p2.moves[i].givesHealth) {
+	if (p2.moves[i].givesHealth) {
             var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
-		}
+	}
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p2.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p2, p1, field.getSide(0), p2.moves[i].hits, p2.ability === 'Bad Dreams');

--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -64,7 +64,7 @@ function calculate() {
             var minHealthRecovered = notation === '%' ? Math.floor(minDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p1.maxHP) / 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
-	}
+	 }
         result.damageText = minDamage + "-" + maxDamage + " (" + minDisplay + " - " + maxDisplay + notation + ")";
         result.koChanceText = p2.moves[i].bp === 0 ? 'nice move'
                 : getKOChanceText(result.damage, p2, p1, field.getSide(0), p2.moves[i].hits, p2.ability === 'Bad Dreams');


### PR DESCRIPTION
For ToDo list, number 6. All moves make their user recover 50% of the damage dealt, except Oblivion Wing that heals 75% of the damage.