### PR TITLE
Fix visual disorder

### DIFF
--- a/js/index_controls.js
+++ b/js/index_controls.js
@@ -46,7 +46,7 @@ function calculate() {
                 10 : Math.floor(minDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
             var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p1.moves[i].percentHealed * 1000 / p1.maxHP) / 
                 10 : Math.floor(maxDamage * p1.moves[i].percentHealed * 48 / p1.maxHP);
-            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+            recoveryText = ' (' + minHealthRecovered + ' - ' + maxHealthRecovered + notation + ' recovered)';
         }
         $(resultLocations[0][i].move + " + label").text(p1.moves[i].name.replace("Hidden Power", "HP"));
         $(resultLocations[0][i].damage).text(minDisplay + " - " + maxDisplay + notation + recoveryText);
@@ -69,7 +69,7 @@ function calculate() {
                 10 : Math.floor(minDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
             var maxHealthRecovered = notation === '%' ? Math.floor(maxDamage * p2.moves[i].percentHealed * 1000 / p2.maxHP) / 
                 10 : Math.floor(maxDamage * p2.moves[i].percentHealed * 48 / p2.maxHP);
-            recoveryText = ' (recovers between ' + minHealthRecovered + notation + ' and ' + maxHealthRecovered + notation + ')';
+            recoveryText = ' (' + minHealthRecovered + ' - ' + maxHealthRecovered + notation + ' recovered)';
         }
         $(resultLocations[1][i].move + " + label").text(p2.moves[i].name.replace("Hidden Power", "HP"));
         $(resultLocations[1][i].damage).text(minDisplay + " - " + maxDisplay + notation + recoveryText);


### PR DESCRIPTION
Draining HP at x4 effectiveness will make the main description text go wild to the right while the percentage of the related move goes for an additional line, ruining the view. This fix reduces `recoveryText`'s length so even if the percentage went really high, nothing would be messed up.

To understand what the issue is about, try Giga Draining with Abomasnow on a Swampert for example.

EDIT : and no, no formatting issue.