### PR TITLE
Switch bit weights between Special and Speed stats

### DIFF
--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -84,9 +84,9 @@ $(".sl .dvs").keyup(function () {
 
 function getHPDVs(poke) {
 	return (~~poke.find(".at .dvs").val() % 2) * 8 +
-	(~~poke.find(".df .dvs").val() % 2) * 4 +
-	(~~poke.find(".sp .dvs").val() % 2) * 2 +
-	(~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
+(~~poke.find(".df .dvs").val() % 2) * 4 +
+(~~poke.find(".sp .dvs").val() % 2) * 2 +
+(~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
 }
 
 function calcStats(poke) {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -84,9 +84,9 @@ $(".sl .dvs").keyup(function () {
 
 function getHPDVs(poke) {
 	return (~~poke.find(".at .dvs").val() % 2) * 8 +
-            (~~poke.find(".df .dvs").val() % 2) * 4 +
-				(~~poke.find(".sp .dvs").val() % 2) * 2 +
-            (~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
+   (~~poke.find(".df .dvs").val() % 2) * 4 +
+	(~~poke.find(".sp .dvs").val() % 2) * 2 +
+   (~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
 }
 
 function calcStats(poke) {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -84,9 +84,9 @@ $(".sl .dvs").keyup(function () {
 
 function getHPDVs(poke) {
 	return (~~poke.find(".at .dvs").val() % 2) * 8 +
-   (~~poke.find(".df .dvs").val() % 2) * 4 +
-	(~~poke.find(".sp .dvs").val() % 2) * 2 +
-   (~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
+		(~~poke.find(".df .dvs").val() % 2) * 4 +
+		(~~poke.find(".sp .dvs").val() % 2) * 2 +
+		(~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
 }
 
 function calcStats(poke) {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -85,8 +85,8 @@ $(".sl .dvs").keyup(function () {
 function getHPDVs(poke) {
 	return (~~poke.find(".at .dvs").val() % 2) * 8 +
             (~~poke.find(".df .dvs").val() % 2) * 4 +
-            (~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2) * 2 +
-            (~~poke.find(".sp .dvs").val() % 2);
+				(~~poke.find(".sp .dvs").val() % 2) * 2 +
+            (~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
 }
 
 function calcStats(poke) {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -84,9 +84,9 @@ $(".sl .dvs").keyup(function () {
 
 function getHPDVs(poke) {
 	return (~~poke.find(".at .dvs").val() % 2) * 8 +
-		(~~poke.find(".df .dvs").val() % 2) * 4 +
-		(~~poke.find(".sp .dvs").val() % 2) * 2 +
-		(~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
+	(~~poke.find(".df .dvs").val() % 2) * 4 +
+	(~~poke.find(".sp .dvs").val() % 2) * 2 +
+	(~~poke.find(gen === 1 ? ".sl .dvs" : ".sa .dvs").val() % 2);
 }
 
 function calcStats(poke) {


### PR DESCRIPTION
Closes issue #182.. I guess.

In short : instead of considering 2 bits for Special and one for Speed, the Speed DVs affect 2 units of HP DVs, while the Special ones do not affect but one.