### PR TITLE
TODO List task No.4

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -112,7 +112,10 @@
         <fieldset class="poke-info" id="p1">
             <legend align="center">Pok&eacute;mon 1</legend>
             <input type="text" class="set-selector calc-trigger" />
-			<button id="clearSets" style="display:none">Clear Custom Sets</button>
+            <span id="importedSetsOptions" style="width:auto; display:none">
+                <input type="checkbox" id="importedSets" /> Only show imported sets <br />
+                <button id="clearSets">Clear Custom Sets</button>
+            </span>
             <div class="info-group">
                 <div>
                     <label>Type</label>

--- a/js/moveset_import.js
+++ b/js/moveset_import.js
@@ -300,8 +300,7 @@ $("#importedSets").click(function () {
 	var showCustomSets = $(this).prop("checked");
 	if (showCustomSets) {
 		loadCustomList();
-	}
-	else {
+	} else {
 		loadDefaultList();
 	}
 });
@@ -314,8 +313,7 @@ $(document).ready(function () {
 		customSets = JSON.parse(localStorage.customsets);
 		updateDex(customSets);		
 		$("#importedSetsOptions").css("display","inline");
-	}
-	else {
+	} else {
 		loadDefaultList();
 	}
 });

--- a/js/moveset_import.js
+++ b/js/moveset_import.js
@@ -289,16 +289,33 @@ function checkExeptions(poke) {
 
 }
 
-$("#clearSets").click(function(){
+$("#clearSets").click(function () {
 	localStorage.removeItem("customsets");
 	alert("Custom Sets successfully cleared. Please refresh the page.");
-	$("#clearSets").css("display","none");
+	$("#importedSetsOptions").css("display","none");
+	loadDefaultList();
 });
+
+$("#importedSets").click(function () {
+	var showCustomSets = $(this).prop("checked");
+	if (showCustomSets) {
+		loadCustomList();
+	}
+	else {
+		loadDefaultList();
+	}
+});
+
+var customSets;
 
 $(document).ready(function () {
 	placeBsBtn();
 	if (localStorage.customsets) {
-		updateDex(JSON.parse(localStorage.customsets));
-		$("#clearSets").css("display","inline");
+		customSets = JSON.parse(localStorage.customsets);
+		updateDex(customSets);		
+		$("#importedSetsOptions").css("display","inline");
+	}
+	else {
+		loadDefaultList();
 	}
 });

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -685,6 +685,8 @@ $(".gen").change(function () {
 		calcStat = CALC_STAT_ADV;
 	}
 	clearField();
+	$("#importedSets").prop("checked", false);
+	loadDefaultList();
 	$(".gen-specific.g" + gen).show();
 	$(".gen-specific").not(".g" + gen).hide();
 	var typeOptions = getSelectOptions(Object.keys(typeChart));
@@ -735,8 +737,8 @@ function clearField() {
 	$("input:checkbox[name='terrain']").prop("checked", false);
 }
 
-function getSetOptions() {
-	var pokeNames = Object.keys(pokedex);
+function getSetOptions(sets = pokedex) {
+	var pokeNames = Object.keys(sets);
 	pokeNames.sort();
 	var setOptions = [];
 	var idNum = 0;
@@ -873,12 +875,7 @@ function getTerrainEffects() {
 	}
 }
 
-$(document).ready(function () {
-	$("#gen7").prop("checked", true);
-	$("#gen7").change();
-	$("#percentage").prop("checked", true);
-	$("#percentage").change();
-
+function loadDefaultList() {
 	$(".set-selector").select2({
 		formatResult: function (object) {
 			return object.set ? ("&nbsp;&nbsp;&nbsp;" + object.set) : ("<b>" + object.text + "</b>");
@@ -901,6 +898,39 @@ $(document).ready(function () {
 			callback(data);
 		}
 	});
+}
+
+function loadCustomList() {
+	var customSetsOptions = getSetOptions(customSets);
+	$("#p1 .set-selector").select2({
+			formatResult: function(set){
+				return set.pokemon;
+			},
+			query: function(query){
+				var pageSize = 20;
+				var results = _.filter(getSetOptions(), function(option){
+					if (option.set === "Custom Set") {
+						return option.pokemon;
+					}
+				});
+				query.callback({
+					results: results,
+					more: results.length >= query.page * pageSize
+				});
+			},
+			initSelection: function(element, callback){
+				var data = "";
+				callback(data);
+			}
+		});
+}
+
+$(document).ready(function () {
+	$("#gen7").prop("checked", true);
+	$("#gen7").change();
+	$("#percentage").prop("checked", true);
+	$("#percentage").change();
+	loadDefaultList();
 	$(".move-selector").select2({
 		dropdownAutoWidth: true,
 		matcher: function (term, text) {

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -894,7 +894,7 @@ function loadDefaultList() {
 			});
 		},
 		initSelection: function (element, callback) {
-			var data = getSetOptions()[gen < 3 ? 3 : 1];
+			var data = "";
 			callback(data);
 		}
 	});


### PR DESCRIPTION
At last it has arrived!

## Demo screenshots
Given this custom set :
```
Reshiram @ Draco Plate
Modest Nature
- Fusion Flare
- Energy Ball
- Thunderbolt
- Ice Beam
```
This is what happens to the page upon successful importing (notice the new checkbox) : 

![imported sets](https://user-images.githubusercontent.com/32229257/34261607-4f0a83cc-e672-11e7-9fb5-0180fe6b6c38.PNG)

Till now, nothing fancy. But when you check the box and you wanna select a Pokémon from there.... (the white Kyurem was already there)

![dropdown](https://user-images.githubusercontent.com/32229257/34261675-9d3f0676-e672-11e7-9eae-f98ec8399a22.PNG)

Our Reshiram appears.

Now the reason why a blank select value shows up first is explained in both `shared_controls`' commits.

But then, the most interesting part, when you finally click a custom set : 

![reshiram](https://user-images.githubusercontent.com/32229257/34262811-1e101b84-e676-11e7-931b-69381c503f09.PNG)

_Tadaaa_

Now as a side note, I'm not quite sure if anyone agrees with the select default value being blanked for default sets. But I just hope everything goes well. 🤷‍♂️ 