### PR TITLE
TODO List, task No.5

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -476,6 +476,13 @@
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
                 </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
+                </select>
             </div>
             <div class="move2">
                 <select class="move-selector calc-trigger small-select"></select>
@@ -494,6 +501,13 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
                 </select>
             </div>
             <div class="move3">
@@ -514,6 +528,13 @@
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
                 </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
+                </select>
             </div>
             <div class="move4">
                 <select class="move-selector calc-trigger small-select"></select>
@@ -532,6 +553,13 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
                 </select>
             </div>
         </fieldset>
@@ -1107,6 +1135,13 @@
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
                 </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
+                </select>
             </div>
             <div class="move2">
                 <select class="move-selector calc-trigger small-select"></select>
@@ -1125,6 +1160,13 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
                 </select>
             </div>
             <div class="move3">
@@ -1145,6 +1187,13 @@
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
                 </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
+                </select>
             </div>
             <div class="move4">
                 <select class="move-selector calc-trigger small-select"></select>
@@ -1163,6 +1212,13 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                </select>
+                <select class="stat-drops calc-trigger hide">
+                    <option value="1">Once</option>
+                    <option value="2">Twice</option>
+                    <option value="3">3 times</option>
+                    <option value="4">4 times</option>
+                    <option value="5">5 times</option>
                 </select>
             </div>
         </fieldset>

--- a/js/damage.js
+++ b/js/damage.js
@@ -712,7 +712,7 @@ function getDamageResult(attacker, defender, move, field) {
 				}
 				return affectedAmount;
 			});
-			attacker.boosts[attackStat] += boostDrop;
+			attacker.boosts[attackStat] = boostDrop;
 			if (hasWhiteHerb && boostDrop < 0 && !usedWhiteHerb) {
 				attacker.boosts[attackStat] -= boostDrop;
 				usedWhiteHerb = true;

--- a/js/damage.js
+++ b/js/damage.js
@@ -302,6 +302,7 @@ function getDamageResult(attacker, defender, move, field) {
 		break;
 	case "Nature Power":
 		basePower = (field.terrain === "Electric" || field.terrain === "Grassy" || field.terrain === "Psychic") ? 90 : (field.terrain === "Misty") ? 95 : 80;
+		//console.log("A " + field.terrain + " terrain " + move.type + move.name + " with " + move.bp + " base power " + " agaisnt a(n) " + defender.name + " that has " + defender.type1 + " " + defender.type2 + " typing");
 		break;
 	case "Water Shuriken":
 		basePower = (attacker.name === "Greninja-Ash") ? 20 : 15;
@@ -548,7 +549,7 @@ function getDamageResult(attacker, defender, move, field) {
 		description.defenderAbility = defAbility;
 	}
 
-	if (gen < 7 && (!hitsPhysical && ["Latios","Latias"].indexOf(defender.name) !== -1) || defender.item === "Eviolite" || (!hitsPhysical && defender.item === "Assault Vest")) {
+	if (gen < 7 && (!hitsPhysical && ["Latios","Latias"].indexOf(defender.name) !== -1 && defender.item === "Soul Dew") || defender.item === "Eviolite" || (!hitsPhysical && defender.item === "Assault Vest")) {
 		dfMods.push(0x1800);
 		description.defenderItem = defender.item;
 	}
@@ -702,7 +703,7 @@ function getDamageResult(attacker, defender, move, field) {
 		}
 		var hasWhiteHerb = attacker.item === "White Herb";
 		var usedWhiteHerb = false;
-		for (var times = 0; times < move.usedTimes; times++){
+		for (var times = 0; times < move.usedTimes; times++) {
 			var oldAttack = attack;
 			var newAttack = getModifiedStat(attacker.rawStats[attackStat], attacker.boosts[attackStat]);
 			damage = damage.map(function(affectedAmount) {

--- a/js/damage.js
+++ b/js/damage.js
@@ -697,9 +697,9 @@ function getDamageResult(attacker, defender, move, field) {
 			description.moveTurns = 'over ' + move.usedTimes + ' turns';
 		}
 		var droppedStats = move.dropsStats;
-		var boostDrop = Math.max(-6, attacker.boosts[attackStat] - (droppedStats * (move.usedTimes-1)));
+		var boostDrop = Math.max(-6, attacker.boosts[attackStat] - (droppedStats * move.usedTimes));
 		if (attacker.ability === "Contrary") {
-			boostDrop = Math.min(6, attacker.boosts[attackStat] + (droppedStats * (move.usedTimes-1)));
+			boostDrop = Math.min(6, attacker.boosts[attackStat] + (droppedStats * move.usedTimes));
 		}
 		var hasWhiteHerb = attacker.item === "White Herb";
 		var usedWhiteHerb = false;
@@ -714,7 +714,8 @@ function getDamageResult(attacker, defender, move, field) {
 			});
 			attacker.boosts[attackStat] = boostDrop;
 			if (hasWhiteHerb && boostDrop < 0 && !usedWhiteHerb) {
-				attacker.boosts[attackStat] -= boostDrop;
+				boostDrop += move.dropsStats;
+				attacker.boosts[attackStat] = boostDrop;
 				usedWhiteHerb = true;
 				description.attackerItem = attacker.item;
 			}

--- a/js/damage.js
+++ b/js/damage.js
@@ -548,7 +548,7 @@ function getDamageResult(attacker, defender, move, field) {
 		description.defenderAbility = defAbility;
 	}
 
-	if (gen < 7 && (!hitsPhysical && ["Latios","Latias"].indexOf(defender.name) !== -1) || defender.item === "Eviolite") {
+	if (gen < 7 && (!hitsPhysical && ["Latios","Latias"].indexOf(defender.name) !== -1) || defender.item === "Eviolite" || (!hitsPhysical && defender.item === "Assault Vest")) {
 		dfMods.push(0x1800);
 		description.defenderItem = defender.item;
 	}

--- a/js/damage_rby.js
+++ b/js/damage_rby.js
@@ -141,6 +141,7 @@ function buildDescription(description) {
 	if (description.hits) {
 		output += "(" + description.hits + " hits) ";
 	}
+	output = appendIfSet(output, description.moveTurns);
 	output += "vs. ";
 	if (description.defenseBoost) {
 		if (description.defenseBoost > 0) {

--- a/js/data/item_data.js
+++ b/js/data/item_data.js
@@ -388,7 +388,7 @@ function getFlingPower(item) {
 										'Life Orb', 'Light Ball', 'Magnet', 'Metal Coat', 'Miracle Seed', 'Mystic Water', 'Never-Melt Ice',
 										'Razor Fang', 'Soul Dew', 'Spell Tag', 'Toxic Orb', 'Twisted Spoon'].indexOf(item) !== -1 ? 30 :
 										item.indexOf('Berry') !== -1 ||
-										['Air Baloon', 'Choice Band', 'Choice Scarf', 'Choice Specs', 'Destiny Knot', 'Electric Seed', 'Expert Belt', 'Focus Band',
+										['Air Balloon', 'Choice Band', 'Choice Scarf', 'Choice Specs', 'Destiny Knot', 'Electric Seed', 'Expert Belt', 'Focus Band',
 											'Focus Sash', 'Grassy Seed', 'Lagging tail', 'leftovers', 'Mental Herb', 'Metal Powder', 'Misty Seed',
 											'Muscle Band', 'Power Herb', 'Psychic Seed', 'Quick Powder', 'Reaper Cloth', 'Red Card', 'Ring Target',
 											'Shed Shell', 'Silk Scarf', 'Silver Powder', 'Smooth Rock', 'Soft Sand', 'Soothe Bell', 'White Herb',
@@ -465,43 +465,8 @@ function getTechnoBlast(item) {
 }
 
 function getMultiAttack(item) {
-	switch (item) {
-	case 'Bug Memory':
-		return 'Bug';
-	case 'Dark Memory':
-		return 'Dark';
-	case 'Dragon Memory':
-		return 'Dragon';
-	case 'Electric Memory':
-		return 'Electric';
-	case 'Fairy Memory':
-		return 'Fairy';
-	case 'Fighting Memory':
-		return 'Fighting';
-	case 'Fire Memory':
-		return 'Fire';
-	case 'Flying Memory':
-		return 'Flying';
-	case 'Ghost Memory':
-		return 'Ghost';
-	case 'Grass Memory':
-		return 'Grass';
-	case 'Ground Memory':
-		return 'Ground';
-	case 'Ice Memory':
-		return 'Ice';
-	case 'Poison Memory':
-		return 'Poison';
-	case 'Psychic Memory':
-		return 'Psychic';
-	case 'Rock Memory':
-		return 'Rock';
-	case 'Steel Memory':
-		return 'Steel';
-	case 'Water Memory':
-		return 'Water';
-	default:
-		return '';
+	if (item.indexOf("Memory") !== -1) {
+		return item.substring(0, item.indexOf(" ")); 
 	}
+	return '';
 }
-

--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -1087,7 +1087,8 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 	'Overheat': {
 		bp: 140,
 		type: 'Fire',
-		category: 'Special'
+		category: 'Special',
+		dropsStats: 2
 	},
 	'Poison Fang': {
 		bp: 50,
@@ -1107,7 +1108,8 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 	'Psycho Boost': {
 		bp: 140,
 		type: 'Psychic',
-		category: 'Special'
+		category: 'Special',
+		dropsStats: 2
 	},
 	'Recycle': {
 		bp: 0,
@@ -1194,7 +1196,8 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
 		bp: 120,
 		type: 'Fighting',
 		category: 'Physical',
-		makesContact: true
+		makesContact: true,
+		dropsStats: 1
 	},
 	'Tail Glow': {
 		bp: 0,
@@ -1400,7 +1403,8 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 	'Draco Meteor': {
 		bp: 140,
 		type: 'Dragon',
-		category: 'Special'
+		category: 'Special',
+		dropsStats: 2
 	},
 	'Dragon Pulse': {
 		bp: 90,
@@ -1577,7 +1581,8 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
 	'Leaf Storm': {
 		bp: 140,
 		type: 'Grass',
-		category: 'Special'
+		category: 'Special',
+		dropsStats : 2
 	},
 	'Lunar Dance': {
 		bp: 0,
@@ -2901,7 +2906,8 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
 		type: 'Fairy',
 		category: 'Special',
 		hasSecondaryEffect: true,
-		zp: 195
+		zp: 195,
+		dropsStats: 2
 	},
 	'Fling': {zp: 100},
 	'Fly': {zp: 175},

--- a/js/ko_chance.js
+++ b/js/ko_chance.js
@@ -5,7 +5,7 @@
 	if (damage[damage.length - 1] === 0) {
 		return 'aim for the horn next time';
 	}
-	if (damage[0] >= defender.maxHP) {
+	if (damage[0] >= defender.maxHP && move.usedTimes === 1) {
 		return 'guaranteed OHKO';
 	}
 
@@ -44,7 +44,7 @@
 			eot -= Math.floor(defender.maxHP / 8);
 			eotText.push(defender.ability + ' damage');
 		}
-	} else if (field.weather === 'Rain' || field.weather === "Heavy Rain") {
+	} else if (field.weather.indexOf("Rain") !== -1) {
 		if (defender.ability === 'Dry Skin') {
 			eot += Math.floor(defender.maxHP / 8);
 			eotText.push('Dry Skin recovery');
@@ -92,10 +92,8 @@
 			eotText.push('Leech Seed damage');
 		}
 	}
-	if (field.isAttackerSeeded) {
-		if (attacker.ability === "Magic Guard") {
-			// No effect
-		} else if (attacker.ability === "Liquid Ooze") {
+	if (field.isAttackerSeeded && attacker.ability !== "Magic Guard") {
+		if (attacker.ability === "Liquid Ooze") {
 			eot -= gen >= 2 ? Math.floor(attacker.maxHP / 8) : Math.floor(attacker.maxHP / 16);
 			eotText.push("Liquid Ooze damage");
 		} else {
@@ -104,8 +102,7 @@
 		}
 	}
 	if (field.terrain === "Grassy") {
-		if (field.isGravity || (defender.type1 !== "Flying" && defender.type2 !== "Flying" &&
-                defender.item !== "Air Balloon" && defender.ability !== "Levitate")) {
+		if (isGroundedForCalc(defender, field)) {
 			eot += Math.floor(defender.maxHP / 16);
 			eotText.push('Grassy Terrain recovery');
 		}
@@ -139,7 +136,7 @@
 		eot -= Math.floor(defender.maxHP / 8);
 		eotText.push('Bad Dreams');
 	}
-	if (move.name === 'Bind' || move.name === 'Clamp' || move.name === 'Fire Spin' || move.name === 'Infestation' || move.name === 'Magma Storm' || move.name === 'Sand Tomb' || move.name === 'Whirlpool' || move.name === 'Wrap') {
+	if (['Bind', 'Clamp', 'Fire Spin', 'Infestation', 'Magma Storm', 'Sand Tomb', 'Whirlpool', 'Wrap'].indexOf(move.name) !== -1) {
 		if (attacker.item === "Binding Band") {
 			eot -= gen > 5 ? Math.floor(defender.maxHP / 6) : Math.floor(defender.maxHP / 8);
 			eotText.push('trapping damage');
@@ -148,7 +145,7 @@
 			eotText.push('trapping damage');
 		}
 	}
-	if ((move.name === 'Fire Pledge (Grass Pledge Boosted)' || move.name === 'Grass Pledge (Fire Pledge Boosted)') && (defender.type1 !== "Fire" && defender.type2 !== "Fire")) {
+	if ((move.name === 'Fire Pledge (Grass Pledge Boosted)' || move.name === 'Grass Pledge (Fire Pledge Boosted)') && [defender.type1, defender.type2].indexOf("Fire") === -1) {
 		eot -= Math.floor(defender.maxHP / 8);
 		eotText.push('Sea of Fire damage');
 	}
@@ -158,55 +155,76 @@
 		qualifier = 'approx. ';
 		damage = squashMultihit(damage, hits);
 	}
-
-	var c = getKOChance(damage, defender.maxHP - hazards, 0, 1, defender.maxHP, toxicCounter);
-	var afterText = hazardText.length > 0 ? ' after ' + serializeText(hazardText) : '';
-	if (c === 1) {
-		return 'guaranteed OHKO' + afterText;
-	} else if (c > 0) {
-		return qualifier + Math.round(c * 1000) / 10 + '% chance to OHKO' + afterText;
-	}
-
-	afterText = hazardText.length > 0 || eotText.length > 0 ? ' after ' + serializeText(hazardText.concat(eotText)) : '';
-	var i;
-	for (i = 2; i <= 4; i++) {
-		c = getKOChance(damage, defender.maxHP - hazards, eot, i, defender.maxHP, toxicCounter);
+	var c;
+	var afterText = hazardText.length > 0 || eotText.length > 0 ? ' after ' + serializeText(hazardText.concat(eotText)) : '';
+	if (move.usedTimes === 1) {
+		c = getKOChance(damage, defender.maxHP - hazards, 0, 1, defender.maxHP, toxicCounter);
+		afterText = hazardText.length > 0 ? ' after ' + serializeText(hazardText) : '';
 		if (c === 1) {
-			return 'guaranteed ' + i + 'HKO' + afterText;
+			return 'guaranteed OHKO' + afterText;
 		} else if (c > 0) {
-			return qualifier + Math.round(c * 1000) / 10 + '% chance to ' + i + 'HKO' + afterText;
+			return qualifier + Math.round(c * 1000) / 10 + '% chance to OHKO' + afterText;
 		}
-	}
+		var i;
 
-	for (i = 5; i <= 9; i++) {
-		if (predictTotal(damage[0], eot, i, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
-			return 'guaranteed ' + i + 'HKO' + afterText;
-		} else if (predictTotal(damage[damage.length - 1], eot, i, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
-			return 'possible ' + i + 'HKO' + afterText;
+		for (i = 2; i <= 4; i++) {
+			c = getKOChance(damage, defender.maxHP - hazards, eot, i, 1, defender.maxHP, toxicCounter);
+			if (c === 1) {
+				return 'guaranteed ' + i + 'HKO' + afterText;
+			} else if (c > 0) {
+				return qualifier + Math.round(c * 1000) / 10 + '% chance to ' + i + 'HKO' + afterText;
+			}
 		}
+
+		for (i = 5; i <= 9; i++) {
+			if (predictTotal(damage[0], eot, i, 1, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
+				return 'guaranteed ' + i + 'HKO' + afterText;
+			} else if (predictTotal(damage[damage.length - 1], eot, i, 1, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
+				return 'possible ' + i + 'HKO' + afterText;
+			}
+		}
+
+	} else {
+		qualifier = 'nearly ';
+		// until someone comes up with a better damage recalculation formula, we'll tell the user it's an estimate
+		c = getKOChance(damage, defender.maxHP - hazards, eot, move.usedTimes, move.usedTimes, defender.maxHP, toxicCounter);
+		if (c === 1) {
+			return 'guaranteed KO in ' + (move.usedTimes === 1 ? " a single turn" : move.usedTimes + " turns") + afterText;
+		} else if (c > 0) {
+			return qualifier + Math.round(c * 1000) / 10 + '% chance to ' + (move.usedTimes === 1 ? 'O' : move.usedTimes) + 'HKO' + afterText;
+		}
+		if (predictTotal(damage[0], eot, move.usedTimes, move.usedTimes, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
+			return 'guaranteed KO in ' + move.usedTimes + ' turns' + afterText;
+		} else if (predictTotal(damage[damage.length - 1], eot, move.usedTimes, move.usedTimes, toxicCounter, defender.maxHP) >= defender.maxHP - hazards) {
+			return 'possible KO in ' + move.usedTimes + ' turns' + afterText;
+		} 
+		return 'not a KO';
 	}
 
 	return 'possibly the worst move ever';
 }
 
-function getKOChance(damage, hp, eot, hits, maxHP, toxicCounter) {
+function getKOChance(damage, hp, eot, hits, moveHits, maxHP, toxicCounter) {
 	var n = damage.length;
 	var minDamage = damage[0];
 	var maxDamage = damage[n - 1];
 	var i;
 	if (hits === 1) {
-		if (maxDamage < hp) {
-			return 0;
-		}
 		for (i = 0; i < n; i++) {
 			if (damage[i] >= hp) {
 				return (n - i) / n;
 			}
 		}
+	} else {
+		for (var j = 0; j < n; j++) {
+			if (damage[j] >= hp) {
+				return j / n;
+			}
+		}
 	}
-	if (predictTotal(maxDamage, eot, hits, toxicCounter, maxHP) < hp) {
+	if (predictTotal(maxDamage, eot, hits, moveHits, toxicCounter, maxHP) < hp) {
 		return 0;
-	} else if (predictTotal(minDamage, eot, hits, toxicCounter, maxHP) >= hp) {
+	} else if (predictTotal(minDamage, eot, hits, moveHits, toxicCounter, maxHP) >= hp) {
 		return 1;
 	}
 	var toxicDamage = 0;
@@ -227,14 +245,18 @@ function getKOChance(damage, hp, eot, hits, maxHP, toxicCounter) {
 	return sum / n;
 }
 
-function predictTotal(damage, eot, hits, toxicCounter, maxHP) {
+function predictTotal(damage, eot, hits, moveHits, toxicCounter, maxHP) {
 	var toxicDamage = 0;
 	if (toxicCounter > 0) {
 		for (var i = 0; i < hits - 1; i++) {
 			toxicDamage += Math.floor((toxicCounter + i) * maxHP / 16);
 		}
 	}
-	var total = (damage * hits) - (eot * (hits - 1)) + toxicDamage;
+	if (hits > 1 && moveHits === 1) {
+		var total = (damage * hits) - (eot * (hits - 1)) + toxicDamage;
+	} else {
+		var total = damage - (eot * (hits - 1)) + toxicDamage;
+	}
 	return total;
 }
 

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -253,11 +253,16 @@ $(".move-selector").change(function () {
 	moveGroupObj.children(".move-cat").val(move.category);
 	moveGroupObj.children(".move-crit").prop("checked", move.alwaysCrit === true);
 	if (move.isMultiHit) {
+		moveGroupObj.children(".stat-drops").hide();
 		moveGroupObj.children(".move-hits").show();
 		moveGroupObj.children(".move-hits").val($(this).closest(".poke-info").find(".ability").val() === 'Skill Link' ? 5 : 3);
 		moveGroupObj.children(".move-hits").val($(this).closest(".poke-info").find(".item").val() === 'Grip Claw' ? 5 : 3);
+	} else if (move.dropsStats) {
+		moveGroupObj.children(".move-hits").hide();
+		moveGroupObj.children(".stat-drops").show();
 	} else {
 		moveGroupObj.children(".move-hits").hide();
+		moveGroupObj.children(".stat-drops").hide();
 	}
 	moveGroupObj.children(".move-z").prop("checked", false);
 });
@@ -292,13 +297,13 @@ $(".set-selector").change(function () {
 		if (pokemonName in setdex && setName in setdex[pokemonName]) {
 			var set = setdex[pokemonName][setName];
 			pokeObj.find(".level").val(set.level);
-			pokeObj.find(".hp .evs").val((set.evs && typeof set.evs.hp !== "undefined") ? set.evs.hp : 0);
-			pokeObj.find(".hp .ivs").val((set.ivs && typeof set.ivs.hp !== "undefined") ? set.ivs.hp : 31);
-			pokeObj.find(".hp .dvs").val((set.dvs && typeof set.dvs.hp !== "undefined") ? set.dvs.hp : 15);
+			pokeObj.find(".hp .evs").val((set.evs && set.evs.hp !== undefined) ? set.evs.hp : 0);
+			pokeObj.find(".hp .ivs").val((set.ivs && set.ivs.hp !== undefined) ? set.ivs.hp : 31);
+			pokeObj.find(".hp .dvs").val((set.dvs && set.dvs.hp !== undefined) ? set.dvs.hp : 15);
 			for (i = 0; i < STATS.length; i++) {
-				pokeObj.find("." + STATS[i] + " .evs").val((set.evs && typeof set.evs[STATS[i]] !== "undefined") ? set.evs[STATS[i]] : 0);
-				pokeObj.find("." + STATS[i] + " .ivs").val((set.ivs && typeof set.ivs[STATS[i]] !== "undefined") ? set.ivs[STATS[i]] : 31);
-				pokeObj.find("." + STATS[i] + " .dvs").val((set.dvs && typeof set.dvs[STATS[i]] !== "undefined") ? set.dvs[STATS[i]] : 15);
+				pokeObj.find("." + STATS[i] + " .evs").val((set.evs && set.evs[STATS[i]] !== undefined) ? set.evs[STATS[i]] : 0);
+				pokeObj.find("." + STATS[i] + " .ivs").val((set.ivs && set.ivs[STATS[i]] !== undefined) ? set.ivs[STATS[i]] : 31);
+				pokeObj.find("." + STATS[i] + " .dvs").val((set.dvs && set.dvs[STATS[i]] !== undefined) ? set.dvs[STATS[i]] : 15);
 			}
 			setSelectValueIfValid(pokeObj.find(".nature"), set.nature, "Hardy");
 			setSelectValueIfValid(abilityObj, pokemon.ab ? pokemon.ab : set.ability, "");
@@ -370,7 +375,7 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
 }
 
 function setSelectValueIfValid(select, value, fallback) {
-	select.val(select.children("option[value='" + value + "']").length !== 0 ? value : fallback);
+	select.val(select.children("option[value='" + value + "']").length ? value : fallback);
 }
 
 $(".forme").change(function () {
@@ -381,7 +386,7 @@ $(".forme").change(function () {
 		setName = fullSetName.substring(fullSetName.indexOf("(") + 1, fullSetName.lastIndexOf(")"));
 
 	$(this).parent().siblings().find(".type1").val(altForme.t1);
-	$(this).parent().siblings().find(".type2").val(typeof altForme.t2 != "undefined" ? altForme.t2 : "");
+	$(this).parent().siblings().find(".type2").val(altForme.t2 === undefined ? "" : altForme.t2);
 	$(this).parent().siblings().find(".weight").val(altForme.w);
 
 	for (var i = 0; i < STATS.length; i++) {
@@ -390,14 +395,14 @@ $(".forme").change(function () {
 		baseStat.keyup();
 	}
 
-	if (abilities.indexOf(altForme.ab) > -1) {
+	if (abilities.indexOf(altForme.ab) !== -1) {
 		container.find(".ability").val(altForme.ab);
 	} else {
 		container.find(".ability").val("");
 	}
 	container.find(".ability").keyup();
 
-	if ($(this).val().indexOf("Mega") === 0 && $(this).val() !== "Rayquaza-Mega") {
+	if ($(this).val().indexOf("-Mega") !== -1 && $(this).val() !== "Rayquaza-Mega") {
 		container.find(".item").val("").keyup();
 	} else {
 		container.find(".item").prop("disabled", false);
@@ -524,7 +529,8 @@ function getMoveDetails(moveInfo, item) {
 			type: moveInfo.find(".move-type").val(),
 			category: moveInfo.find(".move-cat").val(),
 			isCrit: moveInfo.find(".move-crit").prop("checked"),
-			hits: defaultDetails.isMultiHit ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isTwoHit ? 2 : 1
+			hits: defaultDetails.isMultiHit ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isTwoHit ? 2 : 1,
+			usedTimes: defaultDetails.dropsStats ? ~~moveInfo.find(".stat-drops").val() : 1
 		});
 	}
 }


### PR DESCRIPTION
_MK360 hits again_
Basically shows KO chances when using a stat-dropping move several turns in a row, with some (big) cleanups.
Commits : 
`index.template.html` : add dropdown for showing how many times this select move is used in a row.
`damage.js` : refactor + calculate stat-drop induced damage. Also handles Contrary and White Herb.
`damage_rby.js` : adding description in case a Pokémon used such a move.
`item_data.js` : refactor Multi-Attack item type detection. Somehow, no one noticed the type of the Memory held is fully mentioned in its name.
`move_data.js` : added a property for moves that drop stats, whose value is equal with by how much does a stat drop.
`shared_controls.js` : added the ability to handle - guess what - moves that drop stats by showing their select dropdown, and also binding a property that is used in several places.
`ko_chance.js` : little refactor + built a workaround to deal with multi-turn moves.