### PR TITLE
Fix KO chance display in All vs One mode

### DIFF
--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -465,7 +465,8 @@ function Pokemon(pokeInfo) {
 				type: defaultDetails.type,
 				category: defaultDetails.category,
 				isCrit: !!defaultDetails.alwaysCrit,
-				hits: defaultDetails.isMultiHit ? ((this.ability === "Skill Link" || this.item === "Grip Claw") ? 5 : 3) : defaultDetails.isTwoHit ? 2 : 1
+				hits: defaultDetails.isMultiHit ? ((this.ability === "Skill Link" || this.item === "Grip Claw") ? 5 : 3) : defaultDetails.isTwoHit ? 2 : 1,
+				usedTimes: 1
 			}));
 		}
 		this.weight = pokemon.w;


### PR DESCRIPTION
More issues due to move.usedTimes not being defined, so just always set it to 1 when creating pokemon from fixed sets.