### PR TITLE
Fix crash on non-existent item in set

### DIFF
--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -386,7 +386,7 @@ $(".forme").change(function () {
 		setName = fullSetName.substring(fullSetName.indexOf("(") + 1, fullSetName.lastIndexOf(")"));
 
 	$(this).parent().siblings().find(".type1").val(altForme.t1);
-	$(this).parent().siblings().find(".type2").val(altForme.t2 === undefined ? "" : altForme.t2);
+	$(this).parent().siblings().find(".type2").val(altForme.t2 ? altForme.t2 : "");
 	$(this).parent().siblings().find(".weight").val(altForme.w);
 
 	for (var i = 0; i < STATS.length; i++) {
@@ -394,11 +394,11 @@ $(".forme").change(function () {
 		baseStat.val(altForme.bs[STATS[i]]);
 		baseStat.keyup();
 	}
-
+	var chosenSet = setdex[pokemonName][setName];
 	if (abilities.indexOf(altForme.ab) !== -1) {
 		container.find(".ability").val(altForme.ab);
 	} else {
-		container.find(".ability").val("");
+		container.find(".ability").val(chosenSet.ability);
 	}
 	container.find(".ability").keyup();
 

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -356,16 +356,17 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
 
 	if (setName !== 'Blank Set') {
 		var set = setdex[pokemonName][setName];
-
-		// Repurpose the previous filtering code to provide the "different default" logic
-		if ((set.item.indexOf('ite') !== -1 && set.item.indexOf('ite Y') === -1) ||
-            (pokemonName === "Groudon" && set.item.indexOf("Red Orb") !== -1) ||
-            (pokemonName === "Kyogre" && set.item.indexOf("Blue Orb") !== -1) ||
-            (pokemonName === "Meloetta" && set.moves.indexOf("Relic Song") !== -1) ||
-            (pokemonName === "Rayquaza" && set.moves.indexOf("Dragon Ascent") !== -1)) {
-			defaultForme = 1;
-		} else if (set.item.indexOf('ite Y') !== -1) {
-			defaultForme = 2;
+		if (set.item) {
+			// Repurpose the previous filtering code to provide the "different default" logic
+			if ((set.item.indexOf('ite') !== -1 && set.item.indexOf('ite Y') === -1) ||
+	            (pokemonName === "Groudon" && set.item.indexOf("Red Orb") !== -1) ||
+	            (pokemonName === "Kyogre" && set.item.indexOf("Blue Orb") !== -1) ||
+	            (pokemonName === "Meloetta" && set.moves.indexOf("Relic Song") !== -1) ||
+	            (pokemonName === "Rayquaza" && set.moves.indexOf("Dragon Ascent") !== -1)) {
+				defaultForme = 1;
+			} else if (set.item.indexOf('ite Y') !== -1) {
+				defaultForme = 2;
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #213 (again).
The reason why the calc would show Abomasnow as described in the issue was because the defender's set had no item, and the item is needed to check whether the Pokémon in question can mega-evolve or not (as far as I saw, at least). But because there was no item - nothing to compare, then - the calc would simply shout that `set.item is undefined`.