### PR TITLE
Fix crashes in One-vs-All due to Metronome controls

### DIFF
--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -307,11 +307,11 @@ $(".move-selector").change(function () {
 
 $(".item").change(function () {
 	var itemName = $(this).val();
-	var correspondingPokemon = $(this).parent().parent().parent().prop("id");
+	var $metronomeControl = $(this).closest('.poke-info').find('.metronome');
 	if (itemName === "Metronome") {
-		$("#" + correspondingPokemon + " .metronome").show();
+		$metronomeControl.show();
 	} else {
-		$("#" + correspondingPokemon + " .metronome").hide();
+		$metronomeControl.hide();
 	}
 });
 
@@ -584,7 +584,7 @@ function getMoveDetails(moveInfo, item) {
 			isCrit: moveInfo.find(".move-crit").prop("checked"),
 			hits: defaultDetails.isMultiHit ? ~~moveInfo.find(".move-hits").val() : defaultDetails.isTwoHit ? 2 : 1,
 			usedTimes: defaultDetails.dropsStats ? ~~moveInfo.find(".stat-drops").val() : 1,
-			metronomeCount : moveInfo.find(".metronome").prop("style").display !== "none" ? ~~moveInfo.find(".metronome").val() : 1
+			metronomeCount : moveInfo.find(".metronome").is(':visible') ? ~~moveInfo.find(".metronome").val() : 1
 		});
 	}
 }


### PR DESCRIPTION
The first issue was caused by the structure of the poke-info box being different between 1vsAll and 1vs1 mode, so hardcoding the DOM traversal with the `parent() `calls failed in the former case. I'm not sure if there was a reason for the roundabout implementation of "find poke-info, get id from poke-info, create new selector with that id", but this should be more tolerant to changes in the structure.

The second issue was because 1vsAll mode does not have the metronome hit counter elements (someone should add those I suppose), so it threw a TypeError due to property access of a null. Using `:visible` should not have that issue.