### PR TITLE
Make users aware their sets might disappear

### DIFF
--- a/js/moveset_import.js
+++ b/js/moveset_import.js
@@ -318,10 +318,12 @@ function checkExeptions(poke) {
 }
 
 $(bothPokemon("#clearSets")).click(function () {
-	localStorage.removeItem("customsets");
-	alert("Custom Sets successfully cleared. Please refresh the page.");
-	$(bothPokemon("#importedSetsOptions")).css("display","none");
-	loadDefaultLists();
+	if (confirm("Are you sure you want to delete your custom sets? This action cannot be undone.")) {
+		localStorage.removeItem("customsets");
+		alert("Custom Sets successfully cleared. Please refresh the page.");
+		$(bothPokemon("#importedSetsOptions")).hide();
+		loadDefaultLists();
+	}
 });
 
 $(bothPokemon("#importedSets")).click(function () {


### PR DESCRIPTION
Since I had a pretty difficult time relocating the "Clear custom sets" button(s), I thought that an easier way to prevent misclicks could be showing the user a warning message that will need conscious agreement if this is the action he wanted to do.