### PR TITLE
Fix Aurora Veil interaction with Reflect and Light Screen

### DIFF
--- a/js/damage.js
+++ b/js/damage.js
@@ -667,7 +667,7 @@ function getDamageResult(attacker, defender, move, field) {
 	if (field.isReflect && move.category === "Physical" && !isCritical && !field.isAuroraVeil) { //doesn't stack with Aurora Veil
 		finalMods.push(field.format !== "Singles" ? (gen >= 6 ? 0xAAC : 0xA8F) : 0x800);
 		description.isReflect = true;
-	} else if (field.isLightScreen && move.category === "Special" && !isCritical) {
+	} else if (field.isLightScreen && move.category === "Special" && !isCritical && !field.isAuroraVeil) { //doesn't stack with Aurora Veil
 		finalMods.push(field.format !== "Singles" ? (gen >= 6 ? 0xAAC : 0xA8F) : 0x800);
 		description.isLightScreen = true;
 	}
@@ -691,7 +691,7 @@ function getDamageResult(attacker, defender, move, field) {
 		finalMods.push(0xC00);
 		description.isFriendGuard = true;
 	}
-	if (field.isAuroraVeil && !isCritical && !field.isReflect) { //doesn't protect from critical hits and doesn't stack with Reflect
+	if (field.isAuroraVeil && !isCritical) { //doesn't protect from critical hits
 		finalMods.push(field.format !== "Singles" ? 0xAAC : 0x800); // 0.5x damage from physical and special attacks in singles, 0.66x damage in Doubles
 		description.isAuroraVeil = true;
 	}


### PR DESCRIPTION
Aurora Veil shouldn't stack with Reflect and Light Screen. In the previous code having both Aurora Veil and Light Screen makes their effects sum up and on the other side having Aurora Veil and Reflect together nullifies both.