### PR TITLE
Fix Struggle GSC calculation

### DIFF
--- a/js/data/move_data.js
+++ b/js/data/move_data.js
@@ -362,6 +362,7 @@ var MOVES_RBY = {
 	'Struggle': {
 		bp: 50,
 		type: 'Normal',
+		category: 'Physical',
 		hasRecoil: 50
 	},
 	'Submission': {

--- a/js/data/type_data.js
+++ b/js/data/type_data.js
@@ -1,5 +1,6 @@
 var TYPE_CHART_RBY = {
 	None: {
+		category: 'Physical',
 		Normal: 1,
 		Grass: 1,
 		Fire: 1,

--- a/js/data/type_data.js
+++ b/js/data/type_data.js
@@ -1,5 +1,6 @@
 var TYPE_CHART_RBY = {
 	None: {
+		category: 'Physical',
 		Normal: 1,
 		Grass: 1,
 		Fire: 1,
@@ -10,10 +11,10 @@ var TYPE_CHART_RBY = {
 		Bug: 1,
 		Poison: 1,
 		Ground: 1,
-		Rock: 1,
+		Rock: 0.5,
 		Fighting: 1,
 		Psychic: 1,
-		Ghost: 1,
+		Ghost: 0,
 		Dragon: 1
 	},
 	Normal: {
@@ -306,7 +307,9 @@ var TYPE_CHART_RBY = {
 var TYPE_CHART_GSC = $.extend(true, {}, TYPE_CHART_RBY, {
 	None: {
 		Dark: 1,
-		Steel: 1
+		Ghost: 1,
+		Rock: 1,
+		Steel: 1,
 	},
 	Normal: {
 		Dark: 1,

--- a/js/data/type_data.js
+++ b/js/data/type_data.js
@@ -1,6 +1,5 @@
 var TYPE_CHART_RBY = {
 	None: {
-		category: 'Physical',
 		Normal: 1,
 		Grass: 1,
 		Fire: 1,
@@ -11,10 +10,10 @@ var TYPE_CHART_RBY = {
 		Bug: 1,
 		Poison: 1,
 		Ground: 1,
-		Rock: 0.5,
+		Rock: 1,
 		Fighting: 1,
 		Psychic: 1,
-		Ghost: 0,
+		Ghost: 1,
 		Dragon: 1
 	},
 	Normal: {
@@ -307,9 +306,7 @@ var TYPE_CHART_RBY = {
 var TYPE_CHART_GSC = $.extend(true, {}, TYPE_CHART_RBY, {
 	None: {
 		Dark: 1,
-		Ghost: 1,
-		Rock: 1,
-		Steel: 1,
+		Steel: 1
 	},
 	Normal: {
 		Dark: 1,


### PR DESCRIPTION
According to Bulbapedia:
1) Struggle is treated as a Normal-type move in Gen I
2) It becomes "typeless" from gen 2 ownards.

We can deduce from 1) that:
- Struggle inherits all Normal-type properties including:
-- The offense/defense relationship with other types ;
-- The type category of Normal, which is Physical (it was a thing before gen IV).