### PR TITLE
Update setdex

### DIFF
--- a/js/data/setdex_bw.js
+++ b/js/data/setdex_bw.js
@@ -969,7 +969,7 @@ var SETDEX_BW = {
 		"UU Choice": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Close Combat", "Ice Punch", "Zen Headbutt", "Trick"]},
 		"UU Bulk Up": {"level": 100, "evs": {"at": 68, "hp": 252, "sp": 188}, "nature": "Adamant", "ability": "Justified", "item": "Leftovers", "moves": ["Bulk Up", "Drain Punch", "Ice Punch", "Night Slash"]},
 		"OU Bulk Up": {"level": 100, "evs": {"sd": 216, "at": 40, "hp": 240, "sp": 12}, "nature": "Careful", "ability": "Steadfast", "item": "Leftovers", "moves": ["Bulk Up", "Drain Punch", "Ice Punch", "Shadow Sneak"]},
-		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Ice Punch", "Shadow Sneak"]},
+		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Steadfast", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Ice Punch", "Shadow Sneak"]},
 	},
 	"Galvantula": {
 		"RU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Compound Eyes", "item": "Life Orb", "moves": ["Thunder", "Bug Buzz", "Hidden Power Ground", "Giga Drain"]},
@@ -1201,7 +1201,7 @@ var SETDEX_BW = {
 		"Uber Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Scarf", "moves": ["Overheat", "Hidden Power Rock", "Dragon Pulse", "Flamethrower"]},
 		"Doubles Offensive Tran": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "item": "Fire Gem", "moves": ["Heat Wave", "Earth Power", "Dragon Pulse", "Protect"]},
 		"Doubles ErupTran": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "item": "Charcoal", "moves": ["Eruption", "Heat Wave", "Earth Power", "Protect"]},
-		"Doubles SubProtect": {"level": 100, "evs": {"df": 52, "hp": 252, "sa": 200}, "nature": "Modest", "item": "Chople Berry", "moves": ["Substitute", "Protect", "Heat Wave", "Earth Power"]},
+		"Doubles SubProtect": {"level": 100, "evs": {"df": 52, "hp": 252, "sa": 204}, "nature": "Modest", "item": "Chople Berry", "moves": ["Substitute", "Protect", "Heat Wave", "Earth Power"]},
 	},
 	"Heracross": {
 		"UU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Choice Scarf", "moves": ["Close Combat", "Megahorn", "Stone Edge", "Earthquake"]},
@@ -1436,7 +1436,7 @@ var SETDEX_BW = {
 		"OU Bulk Up": {"level": 100, "evs": {"at": 252, "hp": 156, "sp": 100}, "nature": "Adamant", "item": "Leftovers", "moves": ["Bulk Up", "Earthquake", "Crunch", "Stone Edge"]},
 	},
 	"Kyogre": {
-		"Uber Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "item": "Choice Scarf", "moves": ["Water Spout", "Surf", "Thunder", "Ice Beam"]},
+		"Uber Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Drizzle", "item": "Choice Scarf", "moves": ["Water Spout", "Surf", "Thunder", "Ice Beam"]},
 		"Uber Choice Specs": {"level": 100, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "item": "Choice Specs", "moves": ["Water Spout", "Surf", "Thunder", "Ice Beam"]},
 		"Uber Calm Mind + 3 Attacks": {"level": 100, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "item": "Leftovers", "moves": ["Calm Mind", "Surf", "Thunder", "Ice Beam"]},
 		"Uber Mono-Attacker": {"level": 100, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "item": "Leftovers", "moves": ["Calm Mind", "Scald", "Rest", "Sleep Talk"]},
@@ -1989,7 +1989,7 @@ var SETDEX_BW = {
 		"NU Generous Sparky": {"level": 100, "evs": {"sd": 44, "hp": 156, "sp": 252, "sa": 56}, "nature": "Timid", "ability": "Volt Absorb", "item": "Lum Berry", "moves": ["Bestow", "Covet", "Volt Switch", "Super Fang"]},
 	},
 	"Palkia": {
-		"Uber #penis (All-Out Attacker)": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Lustrous Orb", "moves": ["Spacial Rend", "Surf", "Fire Blast", "Thunder"]},
+		"Uber All-Out Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Lustrous Orb", "moves": ["Spacial Rend", "Surf", "Fire Blast", "Thunder"]},
 		"Uber Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Choice Scarf", "moves": ["Surf", "Spacial Rend", "Fire Blast", "Thunder"]},
 		"Uber Choice Specs": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Choice Specs", "moves": ["Hydro Pump", "Spacial Rend", "Draco Meteor", "Thunder"]},
 		"Uber Trick Room": {"level": 100, "evs": {"df": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "item": "Lustrous Orb", "moves": ["Trick Room", "Spacial Rend", "Hydro Pump", "Fire Blast"]},

--- a/js/data/setdex_dpp.js
+++ b/js/data/setdex_dpp.js
@@ -359,7 +359,11 @@ var SETDEX_DPP = {
 		"UU Cleric": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Calm", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Aromatherapy", "Soft-Boiled", "Seismic Toss", "Stealth Rock"]},
 	},
 	"Charizard": {
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Air Slash", "Fire Blast", "Hidden Power Grass", "Roost"]},
+		"NU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Fire Blast", "Air Slash", "Hidden Power Grass", "Roost"]},
+		"NU Toxic Stall": {"level": 100, "evs": {"hp": 248, "sp": 252, "sa": 8}, "nature": "Timid", "ability": "Blaze", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Flamethrower", "Roost"]},
+		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Life Orb", "moves": ["Swords Dance", "Flare Blitz", "Thunder Punch", "Earthquake"]},
+		"NU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Choice Specs", "moves": ["Fire Blast", "Air Slash", "Hidden Power Grass", "Focus Blast"]},
+		"NU Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Life Orb", "moves": ["Dragon Dance", "Flare Blitz", "Earthquake", "Thunder Punch"]},
 		"UU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Fire Blast", "Air Slash", "Hidden Power Grass", "Roost"]},
 		"UU Sunny Day": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Sunny Day", "Fire Blast", "Solar Beam", "Roost"]},
 		"UU Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Life Orb", "moves": ["Dragon Dance", "Flare Blitz", "Earthquake", "Thunder Punch"]},
@@ -544,7 +548,7 @@ var SETDEX_DPP = {
 	},
 	"Donphan": {
 		"UU Rapid Spin": {"level": 100, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Earthquake", "Assurance", "Stealth Rock"]},
-		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Sturdy", "item": "Choice Band", "moves": ["Earthquake", "Assurance", "Stone Edge", "Rapid Spin"]},
+		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Sturdy", "item": "Choice Band", "moves": ["Earthquake", "Assurance", "Head Smash", "Rapid Spin"]},
 		"OU Rapid Spin": {"level": 100, "evs": {"df": 68, "at": 188, "hp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Earthquake", "Assurance", "Stealth Rock"]},
 		"OU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Sturdy", "item": "Choice Band", "moves": ["Earthquake", "Stone Edge", "Assurance", "Rapid Spin"]},
 	},
@@ -1319,6 +1323,7 @@ var SETDEX_DPP = {
 		"UU Choice Specs": {"level": 100, "evs": {"at": 80, "sp": 176, "sa": 252}, "nature": "Rash", "ability": "Magnet Pull", "item": "Choice Specs", "moves": ["Thunderbolt", "Flash Cannon", "Hidden Power Water", "Explosion"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Thunderbolt", "Hidden Power Ice", "Flash Cannon", "Explosion"]},
 		"OU SubSalac": {"level": 100, "evs": {"hp": 12, "sp": 252, "sa": 244}, "nature": "Timid", "ability": "Magnet Pull", "item": "Salac Berry", "moves": ["Substitute", "Charge Beam", "Flash Cannon", "Hidden Power Grass"]},
+		"Uber Choice Scarf": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Thunder", "Hidden Power Fire", "Thunderbolt", "Explosion"]},
 	},
 	"Magnezone": {
 		"OU Substitute": {"level": 100, "evs": {"at": 40, "sp": 216, "sa": 252}, "nature": "Naive", "ability": "Magnet Pull", "item": "Leftovers", "moves": ["Substitute", "Thunderbolt", "Hidden Power Grass", "Explosion"]},
@@ -1705,6 +1710,8 @@ var SETDEX_DPP = {
 		"UU Life Orb Duck": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Download", "item": "Life Orb", "moves": ["Tri Attack", "Thunderbolt", "Ice Beam", "Recover"]},
 		"UU Charge Beam": {"level": 100, "evs": {"hp": 252, "sp": 96, "sa": 160}, "nature": "Modest", "item": "Leftovers", "moves": ["Charge Beam", "Ice Beam", "Tri Attack", "Recover"]},
 		"UU Offensive Choice Scarf": {"level": 100, "evs": {"hp": 52, "sp": 204, "sa": 252}, "nature": "Timid", "item": "Choice Scarf", "moves": ["Thunderbolt", "Ice Beam", "Tri Attack", "Trick"]},
+		"OU Utility Counter": {"level": 100, "evs": {"df": 216, "hp": 252, "sa": 40}, "nature": "Bold", "ability": "Trace", "item": "Leftovers", "moves": ["Recover", "Thunderbolt", "Ice Beam", "Thunder Wave"]},
+		"OU Trick Room": {"level": 100, "evs": {"df": 120, "hp": 252, "sa": 136}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Trace", "item": "Leftovers", "moves": ["Trick Room", "Recover", "Thunderbolt", "Ice Beam"]},
 	},
 	"Primeape": {
 		"UU Choice Scarf": {"level": 100, "evs": {"at": 252, "hp": 32, "sp": 224}, "nature": "Jolly", "ability": "Vital Spirit", "item": "Choice Scarf", "moves": ["U-turn", "Close Combat", "Stone Edge", "Ice Punch"]},
@@ -1732,8 +1739,8 @@ var SETDEX_DPP = {
 		"Uber Support": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Toxic", "Yawn", "Encore", "Recover"]},
 	},
 	"Qwilfish": {
-		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Swords Dance", "Waterfall", "Poison Jab", "Explosion"]},
 		"UU Spikes Lead": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "item": "Focus Sash", "moves": ["Spikes", "Explosion", "Taunt", "Waterfall"]},
+		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Swords Dance", "Waterfall", "Poison Jab", "Explosion"]},
 		"UU Rain Dance Lead": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Damp Rock", "moves": ["Rain Dance", "Waterfall", "Poison Jab", "Explosion"]},
 		"UU Offensive Spikes": {"level": 100, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Poison Point", "item": "Leftovers", "moves": ["Spikes", "Waterfall", "Poison Jab", "Explosion"]},
 		"UU Defensive Spikes": {"level": 100, "evs": {"sd": 104, "df": 152, "hp": 248, "sp": 4}, "nature": "Impish", "ability": "Poison Point", "item": "Leftovers", "moves": ["Spikes", "Pain Split", "Poison Jab", "Taunt"]},
@@ -1807,8 +1814,8 @@ var SETDEX_DPP = {
 		"UU Mono-Attacker": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "item": "Leftovers", "moves": ["Iron Head", "Curse", "Rest", "Sleep Talk"]},
 		"UU Lure": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "item": "Occa Berry", "moves": ["Curse", "Iron Head", "Explosion", "Earthquake"]},
 		"UU Rain Dance Support": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "item": "Damp Rock", "moves": ["Rain Dance", "Explosion", "Shadow Claw", "Seismic Toss"]},
-		"OU OU Tank": {"level": 100, "evs": {"df": 88, "at": 168, "hp": 252}, "nature": "Impish", "item": "Leftovers", "moves": ["Stealth Rock", "Explosion", "Ice Punch", "Earthquake"]},
-		"Uber Ubers Support": {"level": 100, "evs": {"sd": 152, "df": 80, "at": 24, "hp": 252}, "nature": "Careful", "item": "Leftovers", "moves": ["Stealth Rock", "Thunder Wave", "Ice Punch", "Explosion"]},
+		"OU Tank": {"level": 100, "evs": {"df": 88, "at": 168, "hp": 252}, "nature": "Impish", "item": "Leftovers", "moves": ["Stealth Rock", "Explosion", "Ice Punch", "Earthquake"]},
+		"Uber Support": {"level": 100, "evs": {"sd": 152, "df": 80, "at": 24, "hp": 252}, "nature": "Careful", "item": "Leftovers", "moves": ["Stealth Rock", "Thunder Wave", "Ice Punch", "Explosion"]},
 	},
 	"Relicanth": {
 		"NU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Earthquake", "Waterfall", "Rock Polish"]},
@@ -2258,7 +2265,7 @@ var SETDEX_DPP = {
 		"OU Knock it Off, Mojonbo Rules Here! (Physical Tank)": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "item": "Leftovers", "moves": ["Sleep Powder", "Knock Off", "Power Whip", "Earthquake"]},
 	},
 	"Tauros": {
-		"NU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Band", "moves": ["Double-Edge", "Earthquake", "Pursuit", "Return"]},
+		"NU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Band", "moves": ["Double-Edge", "Earthquake", "Pursuit", "Iron Head"]},
 		"UU All-Out Attacker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Band", "moves": ["Double-Edge", "Earthquake", "Stone Edge", "Payback"]},
 		"UU Anger Point": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Anger Point", "item": "Salac Berry", "moves": ["Substitute", "Return", "Earthquake", "Payback"]},
 	},
@@ -2309,6 +2316,7 @@ var SETDEX_DPP = {
 		"UU RestTalk": {"level": 100, "evs": {"df": 216, "hp": 252, "sp": 40}, "nature": "Impish", "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Roar", "Wood Hammer"]},
 		"UU Substitute + 3 Attacks": {"level": 100, "evs": {"at": 252, "hp": 216, "sp": 40}, "nature": "Adamant", "item": "Leftovers", "moves": ["Substitute", "Earthquake", "Wood Hammer", "Stone Edge"]},
 		"UU SubSeed": {"level": 100, "evs": {"at": 80, "hp": 216, "sp": 212}, "nature": "Adamant", "item": "Leftovers", "moves": ["Substitute", "Leech Seed", "Earthquake", "Toxic"]},
+		"OU Rock Polish": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Overgrow", "item": "Life Orb", "moves": ["Rock Polish", "Earthquake", "Wood Hammer", "Return"]},
 	},
 	"Totodile": {
 		"LC Swords Dance": {"level": 5, "evs": {"sd": 52, "df": 4, "at": 236, "hp": 36, "sp": 172}, "nature": "Jolly", "item": "Life Orb", "moves": ["Swords Dance", "Aqua Jet", "Return", "Crunch"]},

--- a/js/data/setdex_gsc.js
+++ b/js/data/setdex_gsc.js
@@ -1,10 +1,14 @@
 var SETDEX_GSC = {
+	"Abra": {
+		"NU Showdown Usage": {"level": 100, "item": "Twisted Spoon", "moves": ["Psychic", "Thunder Punch", "Encore", "Swagger"]},
+	},
 	"Aerodactyl": {
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Hidden Power Rock", "Wing Attack", "Fire Blast"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Earthquake", "Hidden Power Rock", "Substitute"]},
 		"OU Defensive": {"level": 100, "item": "Leftovers", "moves": ["Reflect", "Rest", "Whirlwind", "Hidden Power Rock"]},
 	},
 	"Aipom": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Agility", "Baton Pass", "Protect", "Return"]},
 		"OU Baton Pass": {"level": 100, "item": "Leftovers", "moves": ["Agility", "Baton Pass", "Return", "Counter"]},
 	},
 	"Alakazam": {
@@ -16,6 +20,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Fire Punch", "Rest", "Sleep Talk"]},
 	},
 	"Arbok": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Spite", "Earthquake", "Rest"]},
 		"OU Glare": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Glare", "Earthquake", "Giga Drain"]},
 	},
 	"Arcanine": {
@@ -23,6 +28,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Hidden Power Fighting", "Rest", "Sleep Talk"]},
 	},
 	"Ariados": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Baton Pass", "Agility", "Protect", "Sludge Bomb"]},
 		"UU Baton Pass Trapper": {"level": 100, "item": "Leftovers", "moves": ["Spider Web", "Protect", "Disable", "Baton Pass"]},
 		"UU Physical Attacker": {"level": 100, "moves": ["Sludge Bomb", "Hidden Power Bug", "Screech", "Thief"]},
 		"OU Baton Pass Trapper": {"level": 100, "item": "Leftovers", "moves": ["Spider Web", "Agility", "Baton Pass", "Sludge Bomb"]},
@@ -32,10 +38,15 @@ var SETDEX_GSC = {
 		"OU Reflect": {"level": 100, "item": "Leftovers", "moves": ["Ice Beam", "Toxic", "Reflect", "Rest"]},
 	},
 	"Azumarill": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Ice Beam", "Toxic", "Rest"]},
 		"UU Belly Drummer": {"level": 100, "item": "Leftovers", "moves": ["Belly Drum", "Return", "Surf", "Hidden Power Ghost"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Return", "Hydro Pump", "Hidden Power Ghost"]},
 	},
+	"Bayleef": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Leech Seed", "Synthesis", "Light Screen", "Body Slam"]},
+	},
 	"Beedrill": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Swords Dance", "Agility", "Hidden Power Bug"]},
 		"OU Swords Dance": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Hidden Power Ground", "Swords Dance", "Agility"]},
 	},
 	"Bellossom": {
@@ -51,6 +62,7 @@ var SETDEX_GSC = {
 		"OU Special Wall": {"level": 100, "item": "Leftovers", "moves": ["Soft-Boiled", "Heal Bell", "Light Screen", "Sing"]},
 	},
 	"Butterfree": {
+		"NU Showdown Usage": {"level": 100, "item": "Quick Claw", "moves": ["Sleep Powder", "Stun Spore", "Psychic", "Reflect"]},
 		"OU Double Powder": {"level": 100, "item": "Leftovers", "moves": ["Sleep Powder", "Stun Spore", "Psychic", "Giga Drain"]},
 	},
 	"Celebi": {
@@ -71,6 +83,7 @@ var SETDEX_GSC = {
 		"OU Defensive": {"level": 100, "item": "Leftovers", "moves": ["Rapid Spin", "Spikes", "Surf", "Toxic"]},
 	},
 	"Corsola": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Recover", "Curse", "Rock Slide"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Mirror Coat", "Curse", "Ancient Power", "Recover"]},
 		"OU Support": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Recover", "Toxic", "Mirror Coat"]},
 	},
@@ -79,14 +92,20 @@ var SETDEX_GSC = {
 		"OU Offensive": {"level": 100, "item": "Leftovers", "moves": ["Wing Attack", "Hidden Power Ground", "Toxic", "Screech"]},
 		"OU Toxic Staller": {"level": 100, "item": "Leftovers", "moves": ["Confuse Ray", "Toxic", "Wing Attack", "Mean Look"]},
 	},
+	"Cubone": {
+		"NU Showdown Usage": {"level": 100, "item": "Thick Club", "moves": ["Earthquake", "Swords Dance", "Rock Slide", "Rest"]},
+	},
 	"Delibird": {
+		"NU Showdown Usage": {"level": 100, "item": "", "moves": ["Spikes", "Ice Beam", "Thief", "Present"]},
 		"OU Spiker": {"level": 100, "item": "Leftovers", "moves": ["Spikes", "Ice Beam", "Toxic", "Hidden Power Flying"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Hidden Power Flying", "Ice Beam", "Rest"]},
 	},
 	"Dewgong": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Ice Beam", "Rest", "Surf", "Sleep Talk"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Ice Beam", "Rest", "Encore"]},
 	},
 	"Ditto": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["", "Transform"]},
 		"OU The Set": {"level": 100, "item": "Metal Powder", "moves": ["Transform"]},
 	},
 	"Dodrio": {
@@ -97,14 +116,19 @@ var SETDEX_GSC = {
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Hidden Power Rock", "Curse", "Rest"]},
 		"OU Utility": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Roar", "Rapid Spin", "Rest"]},
 	},
+	"Dragonair": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Extreme Speed", "Rest", "Thunderbolt", "Thunder Wave"]},
+	},
 	"Dragonite": {
 		"OU All-Out Attacker": {"level": 100, "item": "Leftovers", "moves": ["Ice Beam", "Thunder", "Dynamic Punch", "Body Slam"]},
 		"OU Haze Support": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Haze", "Double-Edge", "Reflect"]},
 	},
 	"Dugtrio": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Rock Slide", "Sludge Bomb", "Substitute"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Rock Slide", "Sludge Bomb", "Substitute"]},
 	},
 	"Dunsparce": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Return", "Curse", "Spite"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Return", "Rest", "Sleep Talk"]},
 		"OU Swagger + Psych Up": {"level": 100, "item": "Leftovers", "moves": ["Glare", "Swagger", "Psych Up", "Headbutt"]},
 		"OU SunnyBeam": {"level": 100, "item": "Leftovers", "moves": ["Sunny Day", "Solar Beam", "Flamethrower", "Return"]},
@@ -126,6 +150,9 @@ var SETDEX_GSC = {
 		"OU EspyJump": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Growth", "Baton Pass", "Substitute"]},
 		"OU Growth Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Morning Sun", "Growth", "Bite"]},
 	},
+	"Exeggcute": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Explosion", "Sleep Powder", "Psychic", "Giga Drain"]},
+	},
 	"Exeggutor": {
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Giga Drain", "Sleep Powder", "Explosion"]},
 	},
@@ -134,15 +161,18 @@ var SETDEX_GSC = {
 		"OU Offensive": {"level": 100, "item": "Stick", "moves": ["Swords Dance", "Return", "Hidden Power Flying", "Agility"]},
 	},
 	"Fearow": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Drill Peck", "Double-Edge", "Hidden Power Ground", "Sleep Talk"]},
 		"OU Substitute + 3 Attacks": {"level": 100, "item": "Leftovers", "moves": ["Drill Peck", "Return", "Substitute", "Hidden Power Ground"]},
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Double-Edge", "Drill Peck"]},
 	},
 	"Feraligatr": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Rest", "Sleep Talk", "Toxic"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Hydro Pump", "Crunch", "Surf"]},
 		"OU Mixed Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Hydro Pump", "Earthquake", "Rock Slide", "Curse"]},
 		"OU Special Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Hydro Pump", "Ice Beam", "Crunch", "Hidden Power Grass"]},
 	},
 	"Flareon": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Baton Pass", "Growth", "Zap Cannon"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Shadow Ball", "Baton Pass", "Growth"]},
 		"OU All-Out Attacker": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Shadow Ball", "Return", "Hidden Power Rock"]},
 	},
@@ -151,6 +181,9 @@ var SETDEX_GSC = {
 	},
 	"Furret": {
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Double-Edge", "Rest", "Curse", "Shadow Ball"]},
+	},
+	"Gastly": {
+		"NU Showdown Usage": {"level": 100, "item": "", "moves": ["Explosion", "Thunder", "Thief", "Night Shade"]},
 	},
 	"Gengar": {
 		"OU Assassin": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Ice Punch", "Hypnosis", "Explosion"]},
@@ -166,6 +199,7 @@ var SETDEX_GSC = {
 		"OU Thief": {"level": 100, "item": "Mint Berry", "moves": ["Earthquake", "Wing Attack", "Rest", "Thief"]},
 	},
 	"Golduck": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Ice Beam", "Hydro Pump", "Hypnosis", "Hidden Power Electric"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Surf", "Hypnosis", "Hidden Power Electric"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Hypnosis", "Surf", "Ice Beam"]},
 	},
@@ -177,6 +211,7 @@ var SETDEX_GSC = {
 		"OU Heal Bell": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Return", "Heal Bell"]},
 	},
 	"Graveler": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Explosion", "Rock Slide", "Hidden Power Rock"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Rapid Spin", "Hidden Power Rock", "Explosion"]},
 	},
 	"Gyarados": {
@@ -190,13 +225,16 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Megahorn", "Rest", "Sleep Talk", "Earthquake"]},
 	},
 	"Hitmonchan": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Hidden Power Ghost", "Mach Punch", "Rest"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Return", "Counter", "Hidden Power Ghost"]},
 	},
 	"Hitmonlee": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Meditate", "Body Slam", "Rest"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Meditate", "Mach Punch", "Reversal"]},
 		"OU Meditate": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Meditate", "Hidden Power Rock", "Return"]},
 	},
 	"Hitmontop": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Curse", "Rapid Spin", "Rest"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Curse", "Rapid Spin", "Hidden Power Ghost"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["High Jump Kick", "Curse", "Counter", "Hidden Power Ghost"]},
 	},
@@ -213,6 +251,9 @@ var SETDEX_GSC = {
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Thunder Wave", "Reflect", "Rest"]},
 		"OU Support": {"level": 100, "item": "Leftovers", "moves": ["Thunder Wave", "Psychic", "Light Screen", "Reflect"]},
 		"OU Offensive": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Thunder Punch", "Ice Punch", "Reflect"]},
+	},
+	"Ivysaur": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Synthesis", "Leech Seed", "Reflect", "Light Screen"]},
 	},
 	"Jolteon": {
 		"OU Baton Pass": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Hidden Power Water", "Agility", "Baton Pass"]},
@@ -241,6 +282,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Double-Edge", "Surf"]},
 	},
 	"Kingler": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Swords Dance", "Return", "Hidden Power Ground", "Substitute"]},
 		"OU Swords Dance": {"level": 100, "item": "Leftovers", "moves": ["Swords Dance", "Return", "Hidden Power Ground", "Substitute"]},
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Swords Dance", "Double-Edge", "Rest", "Sleep Talk"]},
 	},
@@ -254,9 +296,11 @@ var SETDEX_GSC = {
 		"OU Tank": {"level": 100, "item": "Leftovers", "moves": ["Confuse Ray", "Ice Beam", "Thunder", "Surf"]},
 	},
 	"Ledian": {
+		"NU Showdown Usage": {"level": 100, "item": "Berserk Gene", "moves": ["Baton Pass", "Light Screen", "Reflect", "Agility"]},
 		"OU Baton Pass": {"level": 100, "item": "Leftovers", "moves": ["Baton Pass", "Agility", "Light Screen", "Reflect"]},
 	},
 	"Lickitung": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Body Slam", "Sleep Talk", "Swords Dance"]},
 		"OU Swords Dance": {"level": 100, "item": "Leftovers", "moves": ["Body Slam", "Swords Dance", "Sleep Talk", "Rest"]},
 		"OU Special Attacker": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Ice Beam", "Sleep Talk", "Rest"]},
 	},
@@ -268,10 +312,14 @@ var SETDEX_GSC = {
 		"OU Pure Attacker": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Rock Slide", "Earthquake", "Fire Blast"]},
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Curse", "Rest", "Sleep Talk"]},
 	},
+	"Machoke": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Earthquake", "Rock Slide", "Meditate"]},
+	},
 	"Magcargo": {
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Rock Slide", "Earthquake", "Fire Blast"]},
 	},
 	"Magmar": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Thunder Punch", "Cross Chop", "Psychic"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Thunder Punch", "Cross Chop", "Hidden Power Water"]},
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Cross Chop", "Thunder Punch", "Hidden Power Water"]},
 	},
@@ -280,6 +328,7 @@ var SETDEX_GSC = {
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Thunder Wave", "Hidden Power Water", "Substitute"]},
 	},
 	"Mantine": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Rest", "Toxic", "Confuse Ray"]},
 		"OU Support": {"level": 100, "item": "Leftovers", "moves": ["Hydro Pump", "Confuse Ray", "Toxic", "Haze"]},
 	},
 	"Marowak": {
@@ -313,6 +362,7 @@ var SETDEX_GSC = {
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Explosion", "Sludge Bomb", "Curse"]},
 	},
 	"Murkrow": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Drill Peck", "Pursuit", "Haze", "Shadow Ball"]},
 		"OU All-Out Attacker": {"level": 100, "item": "Leftovers", "moves": ["Drill Peck", "Feint Attack", "Pursuit", "Night Shade"]},
 	},
 	"Nidoking": {
@@ -323,14 +373,17 @@ var SETDEX_GSC = {
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Lovely Kiss", "Thunder", "Ice Beam"]},
 	},
 	"Ninetales": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Hypnosis", "Toxic", "Roar"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Flamethrower", "Toxic", "Roar"]},
 		"OU Hypnosis": {"level": 100, "item": "Leftovers", "moves": ["Hypnosis", "Toxic", "Roar", "Fire Blast"]},
 	},
 	"Noctowl": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Curse", "Whirlwind", "Return"]},
 		"OU Reflect": {"level": 100, "item": "Leftovers", "moves": ["Hypnosis", "Reflect", "Night Shade", "Rest"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Hypnosis", "Curse", "Return", "Rest"]},
 	},
 	"Octillery": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Flamethrower", "Ice Beam", "Rest"]},
 		"OU Mixed Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Flamethrower", "Surf", "Return", "Ice Beam"]},
 	},
 	"Omastar": {
@@ -339,15 +392,18 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Hydro Pump", "Ice Beam"]},
 	},
 	"Parasect": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Hidden Power Bug", "Spore", "Stun Spore", "Giga Drain"]},
 		"OU Double Powder": {"level": 100, "item": "Leftovers", "moves": ["Spore", "Hidden Power Bug", "Giga Drain", "Stun Spore"]},
 		"OU Special Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Spore", "Growth", "Giga Drain", "Hidden Power Fire"]},
 		"OU Swords Dance": {"level": 100, "item": "Leftovers", "moves": ["Spore", "Hidden Power Bug", "Return", "Swords Dance"]},
 	},
 	"Persian": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Return", "Substitute", "Swagger", "Psych Up"]},
 		"OU Screech": {"level": 100, "item": "Leftovers", "moves": ["Return", "Hypnosis", "Screech", "Zap Cannon"]},
 		"OU Swagger + Psych Up": {"level": 100, "item": "Leftovers", "moves": ["Return", "Shadow Ball", "Swagger", "Psych Up"]},
 	},
 	"Pidgeot": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Double-Edge", "Whirlwind", "Rest", "Sleep Talk"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Return", "Hidden Power Flying", "Toxic", "Steel Wing"]},
 	},
 	"Pikachu": {
@@ -360,6 +416,7 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Earthquake", "Blizzard"]},
 	},
 	"Pineco": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Spikes", "Explosion", "Rapid Spin", "Toxic"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Spikes", "Explosion", "Rapid Spin", "Hidden Power Bug"]},
 	},
 	"Pinsir": {
@@ -372,15 +429,23 @@ var SETDEX_GSC = {
 		"OU Belly Drum": {"level": 100, "item": "Leftovers", "moves": ["Belly Drum", "Surf", "Lovely Kiss", "Body Slam"]},
 	},
 	"Poliwrath": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Belly Drum", "Earthquake", "Lovely Kiss", "Return"]},
 		"UU Showdown Usage": {"level": 100, "item": "", "moves": ["Belly Drum", "Earthquake", "Lovely Kiss", "Return"]},
 		"OU Belly Drum": {"level": 100, "item": "Leftovers", "moves": ["Belly Drum", "Lovely Kiss", "Hydro Pump", "Body Slam"]},
+	},
+	"Porygon": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Recover", "Thunderbolt", "Thunder Wave", "Ice Beam"]},
 	},
 	"Porygon2": {
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Recover", "Return", "Curse", "Ice Beam"]},
 	},
 	"Primeape": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Rock Slide", "Rest", "Sleep Talk"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Rock Slide", "Meditate", "Hidden Power Bug"]},
 		"OU Physical Attacker": {"level": 100, "item": "Leftovers", "moves": ["Cross Chop", "Rock Slide", "Hidden Power Bug", "Meditate"]},
+	},
+	"Pupitar": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rock Slide", "Earthquake", "Screech", "Pursuit"]},
 	},
 	"Quagsire": {
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Rest", "Belly Drum", "Hidden Power Rock"]},
@@ -391,6 +456,7 @@ var SETDEX_GSC = {
 		"OU Spikes": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Sludge Bomb", "Hydro Pump", "Spikes"]},
 	},
 	"Raichu": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Rest", "Sleep Talk", "Surf"]},
 		"UU Showdown Usage": {"level": 100, "item": "", "moves": ["Surf", "Thunderbolt", "Thunder Wave", "Seismic Toss"]},
 		"OU Rain Dance": {"level": 100, "item": "Leftovers", "moves": ["Thunder", "Surf", "Rain Dance", "Substitute"]},
 		"OU Thunder Wave": {"level": 100, "item": "Miracle Berry", "moves": ["Thunderbolt", "Surf", "Thunder Wave", "Seismic Toss"]},
@@ -401,10 +467,12 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Thunderbolt", "Hidden Power Ice", "Rest", "Sleep Talk"]},
 	},
 	"Rapidash": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Double-Edge", "Rest", "Sleep Talk"]},
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Return", "Hypnosis", "Hidden Power Ground"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Fire Blast", "Return", "Hypnosis"]},
 	},
 	"Raticate": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Super Fang", "Double-Edge", "Roar", "Thunder"]},
 		"OU Super Fang": {"level": 100, "item": "Leftovers", "moves": ["Super Fang", "Substitute", "Mimic", "Body Slam"]},
 	},
 	"Rhydon": {
@@ -427,6 +495,7 @@ var SETDEX_GSC = {
 		"OU Special Attacker": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Ice Beam", "Rest", "Sleep Talk"]},
 	},
 	"Shuckle": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Toxic", "Encore", "Sandstorm"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rollout", "Defense Curl", "Encore", "Rest"]},
 		"OU Wrap": {"level": 100, "item": "Leftovers", "moves": ["Toxic", "Wrap", "Rest", "Encore"]},
 	},
@@ -447,6 +516,7 @@ var SETDEX_GSC = {
 		"OU Spikes": {"level": 100, "item": "Leftovers", "moves": ["Spikes", "Encore", "Destiny Bond", "Mirror Coat"]},
 	},
 	"Sneasel": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Shadow Ball", "Return", "Screech", "Reflect"]},
 		"OU Physical Attacker": {"level": 100, "item": "Leftovers", "moves": ["Dynamic Punch", "Shadow Ball", "Return", "Reflect"]},
 	},
 	"Snorlax": {
@@ -455,6 +525,7 @@ var SETDEX_GSC = {
 		"OU MixLax": {"level": 100, "item": "Leftovers", "moves": ["Double-Edge", "Earthquake", "Fire Blast", "Self-Destruct"]},
 	},
 	"Stantler": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Return", "Earthquake", "Confuse Ray", "Rest"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Return", "Earthquake", "Confuse Ray", "Hypnosis"]},
 		"OU Screen Support": {"level": 100, "item": "Leftovers", "moves": ["Confuse Ray", "Return", "Reflect", "Earthquake"]},
 	},
@@ -465,6 +536,7 @@ var SETDEX_GSC = {
 		"OU Curse + Roar": {"level": 100, "item": "Leftovers", "moves": ["Earthquake", "Curse", "Roar", "Explosion"]},
 	},
 	"Sudowoodo": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rock Slide", "Self-Destruct", "Earthquake", "Curse"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rock Slide", "Earthquake", "Self-Destruct", "Curse"]},
 		"OU Physical Attacker": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Rock Slide", "Earthquake", "Self-Destruct"]},
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Self-Destruct", "Rock Slide", "Thunder Punch", "Fire Punch"]},
@@ -474,11 +546,13 @@ var SETDEX_GSC = {
 		"OU RestTalk": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Sleep Talk", "Ice Beam", "Rest"]},
 	},
 	"Sunflora": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Synthesis", "Growth", "Giga Drain", "Razor Leaf"]},
 		"OU Growth": {"level": 100, "item": "Leftovers", "moves": ["Growth", "Razor Leaf", "Hidden Power Water", "Synthesis"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Sludge Bomb", "Return", "Hidden Power Ghost"]},
 		"OU SunnyBeam": {"level": 100, "item": "Leftovers", "moves": ["Growth", "Sunny Day", "Solar Beam", "Hidden Power Fire"]},
 	},
 	"Tangela": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Synthesis", "Giga Drain", "Sleep Powder", "Growth"]},
 		"OU Double Powder": {"level": 100, "item": "Leftovers", "moves": ["Stun Spore", "Sleep Powder", "Giga Drain", "Reflect"]},
 	},
 	"Tauros": {
@@ -488,6 +562,7 @@ var SETDEX_GSC = {
 		"OU Swords Dance": {"level": 100, "item": "Leftovers", "moves": ["Substitute", "Swords Dance", "Surf", "Sludge Bomb"]},
 	},
 	"Togetic": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Fire Blast", "Encore", "Toxic", "Solar Beam"]},
 		"OU Special Attacker": {"level": 100, "item": "Leftovers", "moves": ["Charm", "Fire Blast", "Safeguard", "Psychic"]},
 		"OU SunnyBeam": {"level": 100, "item": "Leftovers", "moves": ["Sunny Day", "Solar Beam", "Fire Blast", "Encore"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Hidden Power Flying", "Return", "Rest"]},
@@ -516,6 +591,7 @@ var SETDEX_GSC = {
 		"OU Growth Sweeper": {"level": 100, "item": "Leftovers", "moves": ["Surf", "Growth", "Rest", "Sleep Talk"]},
 	},
 	"Venomoth": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Sleep Powder", "Psychic", "Baton Pass"]},
 		"OU Curse": {"level": 100, "item": "Leftovers", "moves": ["Curse", "Sludge Bomb", "Stun Spore", "Hidden Power Bug"]},
 	},
 	"Venusaur": {
@@ -532,17 +608,21 @@ var SETDEX_GSC = {
 		"OU Standard": {"level": 100, "item": "Leftovers", "moves": ["Sleep Powder", "Leech Seed", "Sludge Bomb", "Moonlight"]},
 	},
 	"Weezing": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Explosion", "Thunder", "Fire Blast"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Sludge Bomb", "Explosion", "Thunder", "Pain Split"]},
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Thunder", "Fire Blast", "Sludge Bomb", "Explosion"]},
 	},
 	"Wigglytuff": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Rest", "Thunder Wave", "Sleep Talk", "Curse"]},
 		"UU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Body Slam", "Rest", "Sleep Talk", "Curse"]},
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Double-Edge", "Ice Beam", "Thunderbolt", "Thunder Wave"]},
 	},
 	"Wobbuffet": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Mirror Coat", "Counter", "Destiny Bond", "Mimic"]},
 		"OU Oh, no! It's Wobbuffet! (Counter + Mirror Coat)": {"level": 100, "item": "Leftovers", "moves": ["Counter", "Mirror Coat", "Destiny Bond", "Safeguard"]},
 	},
 	"Xatu": {
+		"NU Showdown Usage": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Drill Peck", "Rest", "Giga Drain"]},
 		"UU Showdown Usage": {"level": 100, "item": "", "moves": ["Psychic", "Drill Peck", "Giga Drain", "Thief"]},
 		"OU Mixed Attacker": {"level": 100, "item": "Leftovers", "moves": ["Psychic", "Drill Peck", "Confuse Ray", "Giga Drain"]},
 	},

--- a/js/data/setdex_rse.js
+++ b/js/data/setdex_rse.js
@@ -287,10 +287,10 @@ var SETDEX_ADV = {
 	},
 	"Electabuzz": {
 		"UU Special Sweeper": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "item": "Leftovers", "moves": ["Thunderbolt", "Ice Punch", "Hidden Power Grass", "Thief"]},
-		"UU SubPunch": {"level": 100, "evs": {"at": 84, "sp": 216, "sa": 208}, "nature": "Adamant", "item": "Leftovers", "moves": ["Thunderbolt", "Substitute", "Thunder Wave", "Focus Punch"]},
+		"UU SubPunch": {"level": 100, "evs": {"at": 172, "sp": 240, "sa": 98}, "nature": "Hasty", "item": "Leftovers", "moves": ["Thunderbolt", "Substitute", "Thunder Wave", "Focus Punch"]},
 		"UU Support": {"level": 100, "evs": {"hp": 84, "sp": 216, "sa": 208}, "nature": "Modest", "item": "Leftovers", "moves": ["Thunderbolt", "Light Screen", "Counter", "Toxic"]},
 		"OU Mixed Sweeper": {"level": 100, "evs": {"at": 84, "sp": 216, "sa": 208}, "nature": "Modest", "item": "Leftovers", "moves": ["Thunderbolt", "Ice Punch", "Hidden Power Grass", "Cross Chop"]},
-		"OU SubPunch": {"level": 100, "evs": {"at": 84, "sp": 216, "sa": 208}, "nature": "Adamant", "item": "Leftovers", "moves": ["Thunderbolt", "Substitute", "Focus Punch", "Thunder Wave"]},
+		"OU SubPunch": {"level": 100, "evs": {"at": 172, "sp": 240, "sa": 98}, "nature": "Hasty", "item": "Leftovers", "moves": ["Thunderbolt", "Substitute", "Focus Punch", "Thunder Wave"]},
 		"OU Support": {"level": 100, "evs": {"hp": 84, "sp": 216, "sa": 208}, "nature": "Modest", "ability": "Static", "item": "Leftovers", "moves": ["Thunderbolt", "Light Screen", "Counter", "Toxic"]},
 	},
 	"Electrode": {
@@ -329,8 +329,9 @@ var SETDEX_ADV = {
 		"OU SubPunch": {"level": 100, "evs": {"df": 136, "at": 116, "hp": 136, "sa": 120}, "nature": "Brave", "item": "Leftovers", "moves": ["Substitute", "Focus Punch", "Surf", "Rest"]},
 	},
 	"Flareon": {
-		"NU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 146, "sa": 112}, "nature": "Brave", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Wish", "Protect", "Flamethrower", "Overheat"]},
-		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 146, "sa": 112}, "nature": "Brave", "item": "Choice Band", "moves": ["Body Slam", "Overheat", "Shadow Ball", "Quick Attack"]},
+		"NU Specially Defensive": {"level": 100, "evs": {"sd": 252, "hp": 252, "sa": 4}, "nature": "Calm", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Wish", "Flamethrower", "Protect", "Baton Pass"]},
+		"NU Choice Band": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Adamant", "ability": "Flash Fire", "item": "Choice Band", "moves": ["Double-Edge", "Shadow Ball", "Hidden Power Ground", "Baton Pass"]},
+		"NU Special Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Fire Blast", "Hidden Power Grass", "Toxic", "Baton Pass"]},
 	},
 	"Flygon": {
 		"OU Bulky": {"level": 100, "evs": {"at": 180, "hp": 188, "sp": 140}, "nature": "Naughty", "item": "Leftovers", "moves": ["Earthquake", "Rock Slide", "Fire Blast", "Hidden Power Bug"]},
@@ -681,8 +682,7 @@ var SETDEX_ADV = {
 		"Uber Stallbreaker": {"level": 100, "evs": {"sd": 160, "hp": 252, "sp": 96}, "nature": "Timid", "item": "Leftovers", "moves": ["Toxic", "Substitute", "Taunt", "Flamethrower"]},
 	},
 	"Mightyena": {
-		"NU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 48, "sp": 208}, "nature": "Jolly", "item": "Choice Band", "moves": ["Shadow Ball", "Hidden Power Fighting", "Body Slam", "Iron Tail"]},
-		"NU Howl": {"level": 100, "evs": {"at": 252, "hp": 48, "sp": 208}, "nature": "Jolly", "item": "Leftovers", "moves": ["Howl", "Shadow Ball", "Hidden Power Fighting", "Counter"]},
+		"NU Cleric Phazer": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Intimidate", "item": "Leftovers", "moves": ["Heal Bell", "Roar", "Crunch", "Toxic"]},
 	},
 	"Milotic": {
 		"OU Standard": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "item": "Leftovers", "moves": ["Surf", "Recover", "Ice Beam", "Hypnosis"]},
@@ -758,7 +758,7 @@ var SETDEX_ADV = {
 		"NU Special Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Insomnia", "item": "Leftovers", "moves": ["Psychic", "Feint Attack", "Hidden Power Ice", "Hypnosis"]},
 	},
 	"Nosepass": {
-		"NU Skarmory Counter": {"level": 100, "evs": {"df": 4, "hp": 252, "sa": 252}, "nature": "Relaxed", "ability": "Magnet Pull", "item": "Leftovers", "moves": ["Thunderbolt", "Taunt", "Mimic", "Explosion"]},
+		"NU Trapper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magnet Pull", "item": "Leftovers", "moves": ["Taunt", "Fire Punch", "Block", "Explosion"]},
 	},
 	"Octillery": {
 		"NU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 196, "sa": 60}, "nature": "Brave", "ability": "Suction Cups", "item": "Leftovers", "moves": ["Surf", "Thunder Wave", "Sludge Bomb", "Rock Blast"]},
@@ -770,6 +770,9 @@ var SETDEX_ADV = {
 		"UU Spiker": {"level": 100, "evs": {"df": 200, "hp": 252, "sa": 56}, "nature": "Bold", "ability": "Shell Armor", "item": "Leftovers", "moves": ["Spikes", "Surf", "Ice Beam", "Thief"]},
 		"OU Rain Dance Sweeper": {"level": 100, "evs": {"hp": 116, "sp": 140, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Leftovers", "moves": ["Rain Dance", "Hydro Pump", "Ice Beam", "Hidden Power Electric"]},
 		"OU Spikes": {"level": 100, "evs": {"df": 200, "hp": 252, "sa": 56}, "nature": "Bold", "ability": "Shell Armor", "item": "Leftovers", "moves": ["Spikes", "Surf", "Ice Beam", "Thief"]},
+	},
+	"Onix": {
+		"NU Sunny Day Support": {"level": 100, "evs": {"at": 144, "hp": 112, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Salac Berry", "moves": ["Sunny Day", "Explosion", "Block", "Earthquake"]},
 	},
 	"Parasect": {
 		"NU Support": {"level": 100, "evs": {"df": 168, "at": 64, "hp": 252, "sp": 24}, "nature": "Adamant", "item": "Leftovers", "moves": ["Spore", "Aromatherapy", "Sludge Bomb", "Hidden Power Rock"]},
@@ -1109,7 +1112,7 @@ var SETDEX_ADV = {
 		"OU Mean Look + Toxic": {"level": 100, "evs": {"df": 32, "hp": 252, "sp": 224}, "nature": "Careful", "item": "Leftovers", "moves": ["Mean Look", "Toxic", "Taunt", "Moonlight"]},
 	},
 	"Unown": {
-		"NU Unown": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "item": "Choice Band", "moves": ["Hidden Power Fighting"]},
+		"NU Use Chimecho Instead": {"level": 100, "evs": {"df": 84, "sp": 180, "sa": 244}, "nature": "Modest", "ability": "Levitate", "item": "Twisted Spoon", "moves": ["Hidden Power Psychic"]},
 	},
 	"Ursaring": {
 		"OU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 160, "sp": 96}, "nature": "Adamant", "item": "Choice Band", "moves": ["Return", "Earthquake", "Hidden Power Ghost", "Focus Punch"]},
@@ -1167,6 +1170,9 @@ var SETDEX_ADV = {
 	"Wartortle": {
 		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Torrent", "item": "Leftovers", "moves": ["Surf", "Rapid Spin", "Ice Beam", "Haze"]},
 	},
+	"Weepinbell": {
+		"NU Physical Sun Sweeper": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Chlorophyll", "item": "Poison Barb", "moves": ["Sunny Day", "Sludge Bomb", "Hidden Power Ground", "Solar Beam"]},
+	},
 	"Weezing": {
 		"OU Defensive": {"level": 100, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Impish", "item": "Leftovers", "moves": ["Sludge Bomb", "Haze", "Will-O-Wisp", "Pain Split"]},
 		"OU Offensive": {"level": 100, "evs": {"at": 178, "hp": 252, "sp": 12, "sa": 68}, "nature": "Brave", "item": "Leftovers", "moves": ["Sludge Bomb", "Flamethrower", "Haze", "Explosion"]},
@@ -1190,9 +1196,7 @@ var SETDEX_ADV = {
 		"UU Thief": {"level": 100, "evs": {"hp": 252, "sp": 224, "sa": 32}, "nature": "Timid", "ability": "Synchronize", "item": "Lum Berry", "moves": ["Calm Mind", "Thief", "Psychic", "Wish"]},
 	},
 	"Yanma": {
-		"NU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 4, "sa": 252}, "nature": "Naughty", "ability": "Speed Boost", "item": "Liechi Berry", "moves": ["Detect", "Psychic", "Silver Wind", "Double-Edge"]},
-		"UU Reversal": {"level": 100, "evs": {"at": 252, "hp": 8, "sp": 248}, "nature": "Adamant", "ability": "Speed Boost", "item": "Liechi Berry", "moves": ["Protect", "Substitute", "Reversal", "Hidden Power Bug"]},
-		"UU All-Out Attacker": {"level": 100, "evs": {"sd": 248, "df": 248, "hp": 12}, "nature": "Jolly", "ability": "Compound Eyes", "item": "Leftovers", "moves": ["Hypnosis", "Aerial Ace", "Signal Beam", "Hidden Power Rock"]},
+		"NU Substitute + Reversal": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Speed Boost", "item": "Liechi Berry", "moves": ["Substitute", "Reversal", "Hidden Power Flying", "Protect"]},
 	},
 	"Zangoose": {
 		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "item": "Leftovers", "moves": ["Swords Dance", "Return", "Shadow Ball", "Brick Break"]},

--- a/js/data/setdex_sm.js
+++ b/js/data/setdex_sm.js
@@ -10,6 +10,7 @@ var SETDEX_SM = {
 		"Doubles Trick Room Attacker": {"level": 100, "evs": {"at": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Snow Warning", "item": "Abomasite", "moves": ["Blizzard", "Giga Drain", "Ice Shard", "Protect"]},
 	},
 	"Abomasnow-Mega": {
+		"NU Showdown Usage": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Mild", "ability": "Snow Warning", "item": "Abomasite", "moves": ["Ice Shard", "Blizzard", "Giga Drain", "Focus Blast"]},
 		"RU Mixed Attacker": {"level": 100, "evs": {"at": 92, "sp": 164, "sa": 252}, "nature": "Rash", "ability": "Soundproof", "item": "Abomasite", "moves": ["Blizzard", "Wood Hammer", "Ice Shard", "Focus Blast"]},
 		"RU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Soundproof", "item": "Abomasite", "moves": ["Swords Dance", "Wood Hammer", "Ice Shard", "Earthquake"]},
 		"UU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Soundproof", "item": "Abomasite", "moves": ["Swords Dance", "Ice Shard", "Seed Bomb", "Earthquake"]},
@@ -23,20 +24,17 @@ var SETDEX_SM = {
 	"Absol": {
 		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
 		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Iron Tail"]},
-		"UU All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Fire Blast"]},
-		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
+		"UU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Naive", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Pursuit", "Fire Blast", "Sucker Punch"]},
 	},
 	"Absol-Mega": {
-		"UU All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Fire Blast"]},
-		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
+		"UU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Naive", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Pursuit", "Fire Blast", "Sucker Punch"]},
 	},
 	"Accelgor": {
 		"NU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sticky Hold", "item": "Choice Specs", "moves": ["Bug Buzz", "Focus Blast", "Energy Ball", "Spikes"]},
 	},
 	"Aegislash-Blade": {
 		"Uber Specially Defensive": {"level": 100, "evs": {"sd": 252, "hp": 252, "sa": 4}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Stance Change", "item": "Leftovers", "moves": ["King\u0027s Shield", "Toxic", "Gyro Ball", "Shadow Ball"]},
-		"Doubles Wide Guard Attacker": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Ghostium Z", "moves": ["Shadow Ball", "Flash Cannon", "Wide Guard", "King\u0027s Shield"]},
-		"Doubles Substitute Tank": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Leftovers", "moves": ["Shadow Ball", "Flash Cannon", "Substitute", "King\u0027s Shield"]},
+		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Spooky Plate", "moves": ["Shadow Ball", "Flash Cannon", "Wide Guard", "King\u0027s Shield"]},
 		"Battle Spot Singles RETURN OF THE CRUMBLER (Special Attacker)": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Weakness Policy", "moves": ["Shadow Ball", "Shadow Sneak", "King\u0027s Shield", "Sacred Sword"]},
 		"Battle Spot Singles Toxic Staller": {"level": 50, "evs": {"hp": 204, "sp": 140, "sa": 164}, "nature": "Modest", "ability": "Stance Change", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Shadow Ball", "King\u0027s Shield"]},
 		"Battle Spot Singles Swords Dance": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Brave", "ability": "Stance Change", "item": "Weakness Policy", "moves": ["Swords Dance", "Shadow Sneak", "Iron Head", "Sacred Sword"]},
@@ -44,45 +42,41 @@ var SETDEX_SM = {
 	},
 	"Aegislash-Shield": {
 		"Uber Specially Defensive": {"level": 100, "evs": {"sd": 252, "hp": 252, "sa": 4}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Stance Change", "item": "Leftovers", "moves": ["King\u0027s Shield", "Toxic", "Gyro Ball", "Shadow Ball"]},
-		"Doubles Wide Guard Attacker": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Ghostium Z", "moves": ["Shadow Ball", "Flash Cannon", "Wide Guard", "King\u0027s Shield"]},
-		"Doubles Substitute Tank": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Leftovers", "moves": ["Shadow Ball", "Flash Cannon", "Substitute", "King\u0027s Shield"]},
+		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Spooky Plate", "moves": ["Shadow Ball", "Flash Cannon", "Wide Guard", "King\u0027s Shield"]},
 		"Battle Spot Singles RETURN OF THE CRUMBLER (Special Attacker)": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Weakness Policy", "moves": ["Shadow Ball", "Shadow Sneak", "King\u0027s Shield", "Sacred Sword"]},
 		"Battle Spot Singles Toxic Staller": {"level": 50, "evs": {"hp": 204, "sp": 140, "sa": 164}, "nature": "Modest", "ability": "Stance Change", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Shadow Ball", "King\u0027s Shield"]},
 		"Battle Spot Singles Swords Dance": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Brave", "ability": "Stance Change", "item": "Weakness Policy", "moves": ["Swords Dance", "Shadow Sneak", "Iron Head", "Sacred Sword"]},
 		"Battle Spot Doubles Bulky Attacker": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Stance Change", "item": "Leftovers", "moves": ["Shadow Ball", "Flash Cannon", "Wide Guard", "King\u0027s Shield"]},
 	},
 	"Aerodactyl": {
-		"NU Choice Band": {"level": 100, "evs": {"df": 84, "at": 252, "sp": 176}, "nature": "Jolly", "ability": "Unnerve", "item": "Choice Band", "moves": ["Stone Edge", "Earthquake", "Aqua Tail", "Pursuit"]},
+		"NU Choice Band": {"level": 100, "evs": {"df": 80, "at": 252, "sp": 176}, "nature": "Jolly", "ability": "Unnerve", "item": "Choice Band", "moves": ["Stone Edge", "Earthquake", "Pursuit", "Aqua Tail"]},
 		"RU Physical Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Life Orb", "moves": ["Stone Edge", "Earthquake", "Ice Fang", "Pursuit"]},
-		"UU Offensive": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Wing Attack", "Earthquake", "Pursuit"]},
-		"UU Hone Claws": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Hone Claws", "Stone Edge", "Wing Attack", "Aqua Tail"]},
+		"UU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Aqua Tail", "Pursuit"]},
 		"OU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pressure", "item": "Aerodactylite", "moves": ["Stone Edge", "Aerial Ace", "Ice Fang", "Fire Fang"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Focus Sash", "moves": ["Rock Slide", "Wide Guard", "Tailwind", "Whirlwind"]},
 		"VGC17 Offensive Support": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Focus Sash", "moves": ["Rock Slide", "Sky Drop", "Tailwind", "Protect"]},
-		"Monotype Offensive Stealth Rock Setter (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Pursuit", "Stealth Rock"]},
+		"Monotype Offensive (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Pursuit", "Stealth Rock"]},
 	},
 	"Aerodactyl-Mega": {
-		"UU Offensive": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Wing Attack", "Earthquake", "Pursuit"]},
-		"UU Hone Claws": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Hone Claws", "Stone Edge", "Wing Attack", "Aqua Tail"]},
+		"UU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Aqua Tail", "Pursuit"]},
 		"OU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pressure", "item": "Aerodactylite", "moves": ["Stone Edge", "Aerial Ace", "Ice Fang", "Fire Fang"]},
-		"Monotype Offensive Stealth Rock Setter (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Pursuit", "Stealth Rock"]},
+		"Monotype Offensive (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Unnerve", "item": "Aerodactylite", "moves": ["Stone Edge", "Earthquake", "Pursuit", "Stealth Rock"]},
 	},
 	"Aggron": {
-		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Heavy Slam", "Earthquake", "Fire Punch"]},
+		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Heavy Slam", "Ice Punch", "Earthquake"]},
 		"PU Offensive Stealth Rock": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Shuca Berry", "moves": ["Stealth Rock", "Head Smash", "Heavy Slam", "Taunt"]},
-		"UU Defensive": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Sturdy", "item": "Aggronite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
+		"UU Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Aggronite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
 	},
 	"Aggron-Mega": {
-		"UU Defensive": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Sturdy", "item": "Aggronite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
+		"UU Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Aggronite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
 	},
 	"Alakazam": {
-		"OU Special Sweeper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Recover", "Shadow Ball"]},
+		"OU Special Sweeper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Recover", "Shadow Ball"]},
 		"OU Life Orb": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Life Orb", "moves": ["Psychic", "Focus Blast", "Hidden Power Fire", "Recover"]},
 		"Battle Spot Singles Psychic Terrain Sweeper": {"level": 50, "evs": {"sd": 4, "df": 172, "hp": 52, "sp": 244, "sa": 36}, "nature": "Timid", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Shadow Ball", "Hidden Power Ice"]},
 		"Monotype Counter + Focus Sash": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "ivs": {"df": 0}, "nature": "Hasty", "ability": "Magic Guard", "item": "Focus Sash", "moves": ["Counter", "Psychic", "Focus Blast", "Shadow Ball"]},
 	},
 	"Alakazam-Mega": {
-		"OU Special Sweeper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Recover", "Shadow Ball"]},
+		"OU Special Sweeper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Recover", "Shadow Ball"]},
 		"Battle Spot Singles Psychic Terrain Sweeper": {"level": 50, "evs": {"sd": 4, "df": 172, "hp": 52, "sp": 244, "sa": 36}, "nature": "Timid", "ability": "Magic Guard", "item": "Alakazite", "moves": ["Psychic", "Focus Blast", "Shadow Ball", "Hidden Power Ice"]},
 	},
 	"Alomomola": {
@@ -91,12 +85,11 @@ var SETDEX_SM = {
 		"Monotype Defensive Utility": {"level": 100, "evs": {"sd": 248, "df": 252, "hp": 8}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Wish", "Scald", "Protect", "Mirror Coat"]},
 	},
 	"Altaria": {
-		"PU Defensive Defog": {"level": 100, "evs": {"sd": 244, "hp": 248, "sp": 16}, "nature": "Calm", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Defog", "Roost", "Flamethrower", "Toxic"]},
+		"PU Defensive Defog": {"level": 100, "evs": {"sd": 160, "hp": 252, "sp": 96}, "nature": "Calm", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Defog", "Toxic", "Dragon Pulse", "Roost"]},
 		"NU Defensive Defog": {"level": 100, "evs": {"sd": 72, "df": 168, "hp": 252, "sp": 16}, "nature": "Calm", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Defog", "Roost", "Toxic", "Flamethrower"]},
 		"UU Offensive Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Dragon Dance", "Return", "Earthquake", "Roost"]},
 		"UU Support": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Hyper Voice", "Roost", "Heal Bell", "Flamethrower"]},
 		"UU Specially Based Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Hyper Voice", "Fire Blast", "Earthquake", "Roost"]},
-		"OU Defog": {"level": 100, "evs": {"sd": 68, "df": 176, "hp": 248, "sp": 16}, "nature": "Impish", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Body Slam", "Earthquake", "Defog", "Roost"]},
 		"Monotype Offensive Dragon Dance (Dragon)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Return", "Dragon Dance", "Roost", "Earthquake"]},
 		"Monotype Bulky Dragon Dance (Dragon)": {"level": 100, "evs": {"df": 16, "hp": 252, "sp": 240}, "nature": "Impish", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Return", "Dragon Dance", "Roost", "Refresh"]},
 	},
@@ -104,7 +97,6 @@ var SETDEX_SM = {
 		"UU Offensive Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Dragon Dance", "Return", "Earthquake", "Roost"]},
 		"UU Support": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Hyper Voice", "Roost", "Heal Bell", "Flamethrower"]},
 		"UU Specially Based Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Hyper Voice", "Fire Blast", "Earthquake", "Roost"]},
-		"OU Defog": {"level": 100, "evs": {"sd": 68, "df": 176, "hp": 248, "sp": 16}, "nature": "Impish", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Body Slam", "Earthquake", "Defog", "Roost"]},
 		"Monotype Offensive Dragon Dance (Dragon)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Return", "Dragon Dance", "Roost", "Earthquake"]},
 		"Monotype Bulky Dragon Dance (Dragon)": {"level": 100, "evs": {"df": 16, "hp": 252, "sp": 240}, "nature": "Impish", "ability": "Natural Cure", "item": "Altarianite", "moves": ["Return", "Dragon Dance", "Roost", "Refresh"]},
 	},
@@ -118,7 +110,7 @@ var SETDEX_SM = {
 		"UU Defensive Pivot": {"level": 100, "evs": {"sd": 72, "df": 184, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Spore", "Giga Drain", "Hidden Power Fire", "Clear Smog"]},
 		"OU Assault Vest": {"level": 100, "evs": {"sd": 160, "df": 96, "hp": 252}, "nature": "Sassy", "ability": "Regenerator", "item": "Assault Vest", "moves": ["Giga Drain", "Sludge Bomb", "Stomping Tantrum", "Hidden Power Fire"]},
 		"OU Defensive": {"level": 100, "evs": {"sd": 216, "df": 44, "hp": 248}, "nature": "Calm", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Spore", "Giga Drain", "Hidden Power Fire", "Stun Spore"]},
-		"Doubles Redirection Support": {"level": 100, "evs": {"sd": 68, "df": 200, "hp": 240}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Regenerator", "item": "Wiki Berry", "moves": ["Rage Powder", "Spore", "Sludge Bomb", "Protect"]},
+		"Doubles Redirection Support": {"level": 100, "evs": {"sd": 96, "df": 172, "hp": 240}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Regenerator", "item": "Wiki Berry", "moves": ["Rage Powder", "Spore", "Sludge Bomb", "Protect"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Spore", "Giga Drain", "Foul Play", "Clear Smog"]},
 	},
 	"Ampharos": {
@@ -135,20 +127,22 @@ var SETDEX_SM = {
 	"Araquanid": {
 		"RU Totem Trapper": {"level": 100, "evs": {"at": 220, "hp": 96, "sp": 192}, "nature": "Adamant", "ability": "Water Bubble", "item": "Splash Plate", "moves": ["Liquidation", "Toxic", "Spider Web", "Rest"]},
 		"RU Sticky Web": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Water Bubble", "item": "Splash Plate", "moves": ["Sticky Web", "Liquidation", "Magic Coat", "Mirror Coat"]},
-		"UU Sticky Web": {"level": 100, "evs": {"df": 20, "at": 236, "hp": 24, "sp": 228}, "nature": "Adamant", "ability": "Water Bubble", "item": "Splash Plate", "moves": ["Sticky Web", "Liquidation", "Toxic", "Magic Coat"]},
+		"UU Sticky Web": {"level": 100, "evs": {"at": 252, "hp": 68, "sp": 188}, "nature": "Adamant", "ability": "Water Bubble", "item": "Splash Plate", "moves": ["Sticky Web", "Liquidation", "Toxic", "Magic Coat"]},
 		"OU Sticky Web Lead": {"level": 100, "evs": {"at": 252, "hp": 216, "sa": 40}, "nature": "Brave", "ability": "Water Bubble", "item": "Focus Sash", "moves": ["Sticky Web", "Liquidation", "Magic Coat", "Hidden Power Fire"]},
 		"Doubles Wide Guard Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Water Bubble", "item": "Mystic Water", "moves": ["Liquidation", "Poison Jab", "Wide Guard", "Protect"]},
 		"VGC17 Attacking Arachnid": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Water Bubble", "item": "Waterium Z", "moves": ["Liquidation", "Lunge", "Wide Guard", "Protect"]},
 		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Water Bubble", "item": "Choice Band", "moves": ["Liquidation", "Leech Life", "Sleep Talk", "Poison Jab"]},
 		"Battle Spot Singles Offensive": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Water Bubble", "item": "Waterium Z", "moves": ["Liquidation", "Mirror Coat", "Leech Life", "Sticky Web"]},
-		"Monotype Assault Vest (Bug)": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 200, "sp": 52}, "nature": "Adamant", "ability": "Water Bubble", "item": "Assault Vest", "moves": ["Liquidation", "Scald", "Leech Life", "Mirror Coat"]},
+		"Monotype Assault Vest (Bug)": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 184, "sp": 68}, "nature": "Adamant", "ability": "Water Bubble", "item": "Assault Vest", "moves": ["Liquidation", "Scald", "Leech Life", "Mirror Coat"]},
+		"Monotype Sticky Web Utility (Bug)": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Water Bubble", "item": "Wacan Berry", "moves": ["Sticky Web", "Scald", "Toxic", "Mirror Coat"]},
 	},
 	"Arbok": {
 		"PU Offensive Coil": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Waterium Z", "moves": ["Coil", "Gunk Shot", "Sucker Punch", "Aqua Tail"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Black Sludge", "moves": ["Gunk Shot", "Coil", "Earthquake", "Sucker Punch"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Waterium Z", "moves": ["Gunk Shot", "Coil", "Sucker Punch", "Aqua Tail"]},
 	},
 	"Arcanine": {
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 248, "sa": 8}, "nature": "Lax", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Flare Blitz", "Morning Sun", "Extreme Speed", "Toxic"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Flare Blitz", "Extreme Speed", "Morning Sun", "Wild Charge"]},
+		"UU Defensive": {"level": 100, "evs": {"df": 244, "hp": 248, "sp": 16}, "nature": "Bold", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Flamethrower", "Will-O-Wisp", "Morning Sun", "Toxic"]},
 		"VGC17 Helpful Pupper (Bulky Support)": {"level": 50, "evs": {"sd": 76, "df": 188, "hp": 244}, "nature": "Calm", "ability": "Intimidate", "item": "Aguav Berry", "moves": ["Flamethrower", "Snarl", "Will-O-Wisp", "Protect"]},
 		"VGC17 Attack Doggo (Physically Offensive)": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Firium Z", "moves": ["Flare Blitz", "Wild Charge", "Extreme Speed", "Protect"]},
 	},
@@ -160,8 +154,10 @@ var SETDEX_SM = {
 		"Uber Stealth Rock": {"level": 100, "evs": {"df": 16, "hp": 248, "sp": 96, "sa": 144}, "nature": "Timid", "ability": "Multitype", "item": "Insect Plate", "moves": ["Stealth Rock", "Judgment", "Recover", "Toxic"]},
 	},
 	"Arceus-Dark": {
-		"Uber Support": {"level": 100, "evs": {"df": 160, "hp": 252, "sp": 96}, "nature": "Timid", "ability": "Multitype", "item": "Dread Plate", "moves": ["Judgment", "Recover", "Toxic", "Defog"]},
+		"Uber Support": {"level": 100, "evs": {"df": 160, "hp": 252, "sp": 96}, "nature": "Timid", "ability": "Multitype", "item": "Dread Plate", "moves": ["Judgment", "Recover", "Ice Beam", "Toxic"]},
 		"Uber Calm Mind": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Multitype", "item": "Dread Plate", "moves": ["Judgment", "Calm Mind", "Recover", "Refresh"]},
+		"AG Calm Mind": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Multitype", "item": "Dread Plate", "moves": ["Calm Mind", "Judgment", "Recover", "Refresh"]},
+		"AG Defensive Support": {"level": 100, "evs": {"df": 180, "hp": 240, "sp": 88}, "nature": "Timid", "ability": "Multitype", "item": "Dread Plate", "moves": ["Judgment", "Recover", "Will-O-Wisp", "Defog"]},
 	},
 	"Arceus-Dragon": {
 		"Uber Support": {"level": 100, "evs": {"df": 64, "hp": 252, "sp": 192}, "nature": "Timid", "ability": "Multitype", "item": "Draco Plate", "moves": ["Defog", "Recover", "Judgment", "Will-O-Wisp"]},
@@ -172,6 +168,8 @@ var SETDEX_SM = {
 	"Arceus-Fairy": {
 		"Uber Stealth Rock": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Multitype", "item": "Pixie Plate", "moves": ["Judgment", "Stealth Rock", "Recover", "Will-O-Wisp"]},
 		"Uber Calm Mind": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Multitype", "item": "Pixie Plate", "moves": ["Calm Mind", "Judgment", "Earth Power", "Recover"]},
+		"AG Support": {"level": 100, "evs": {"df": 180, "hp": 240, "sp": 88}, "nature": "Bold", "ability": "Multitype", "item": "Pixie Plate", "moves": ["Judgment", "Recover", "Stealth Rock", "Toxic"]},
+		"AG Calm Mind": {"level": 100, "evs": {"hp": 248, "sp": 252, "sa": 8}, "nature": "Timid", "ability": "Multitype", "item": "Pixie Plate", "moves": ["Judgment", "Calm Mind", "Recover", "Earth Power"]},
 	},
 	"Arceus-Fighting": {
 		"Uber Offensive Utility": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Multitype", "item": "Fist Plate", "moves": ["Judgment", "Ice Beam", "Stone Edge", "Shadow Ball"]},
@@ -183,7 +181,7 @@ var SETDEX_SM = {
 		"Uber Calm Mind": {"level": 100, "evs": {"hp": 248, "sp": 252, "sa": 8}, "nature": "Timid", "ability": "Multitype", "item": "Sky Plate", "moves": ["Calm Mind", "Refresh", "Recover", "Judgment"]},
 	},
 	"Arceus-Ghost": {
-		"Uber Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multitype", "item": "Ghostium Z", "moves": ["Swords Dance", "Shadow Force", "Brick Break", "Extreme Speed"]},
+		"Uber Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multitype", "item": "Ghostium Z", "moves": ["Swords Dance", "Shadow Force", "Brick Break", "Substitute"]},
 	},
 	"Arceus-Grass": {
 		"Uber Offensive": {"level": 100, "evs": {"hp": 80, "sp": 252, "sa": 176}, "nature": "Timid", "ability": "Multitype", "item": "Meadow Plate", "moves": ["Grass Knot", "Ice Beam", "Fire Blast", "Recover"]},
@@ -197,7 +195,7 @@ var SETDEX_SM = {
 		"Uber Calm Mind": {"level": 100, "evs": {"hp": 172, "sp": 252, "sa": 84}, "nature": "Timid", "ability": "Multitype", "item": "Icicle Plate", "moves": ["Calm Mind", "Recover", "Judgment", "Thunder"]},
 	},
 	"Arceus-Poison": {
-		"Uber Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multitype", "item": "Toxic Plate", "moves": ["Swords Dance", "Poison Jab", "Earthquake", "Recover"]},
+		"Uber Calm Mind": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Multitype", "item": "Toxic Plate", "moves": ["Calm Mind", "Sludge Bomb", "Recover", "Earth Power"]},
 	},
 	"Arceus-Psychic": {
 		"Uber Wall": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Multitype", "item": "Mind Plate", "moves": ["Judgment", "Will-O-Wisp", "Recover", "Ice Beam"]},
@@ -206,10 +204,11 @@ var SETDEX_SM = {
 		"Uber Stealth Rock": {"level": 100, "evs": {"df": 16, "hp": 252, "sp": 96, "sa": 144}, "nature": "Timid", "ability": "Multitype", "item": "Stone Plate", "moves": ["Judgment", "Will-O-Wisp", "Recover", "Stealth Rock"]},
 	},
 	"Arceus-Steel": {
-		"Uber Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multitype", "item": "Steelium Z", "moves": ["Swords Dance", "Iron Head", "Earthquake", "Stone Edge"]},
+		"Uber Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multitype", "item": "Steelium Z", "moves": ["Swords Dance", "Iron Head", "Earthquake", "Stone Edge"]},
 	},
 	"Arceus-Water": {
-		"Uber Support": {"level": 100, "evs": {"df": 64, "hp": 252, "sp": 192}, "nature": "Timid", "ability": "Multitype", "item": "Splash Plate", "moves": ["Recover", "Toxic", "Defog", "Ice Beam"]},
+		"Uber Support": {"level": 100, "evs": {"df": 64, "hp": 252, "sp": 192}, "nature": "Timid", "ability": "Multitype", "item": "Splash Plate", "moves": ["Judgment", "Ice Beam", "Recover", "Toxic"]},
+		"Uber Stealth Rock": {"level": 100, "evs": {"df": 16, "hp": 252, "sp": 96, "sa": 144}, "nature": "Timid", "ability": "Multitype", "item": "Splash Plate", "moves": ["Stealth Rock", "Judgment", "Ice Beam", "Recover"]},
 	},
 	"Archen": {
 		"LC The Hero": {"level": 5, "evs": {"at": 180, "hp": 76, "sp": 196}, "nature": "Jolly", "ability": "Defeatist", "item": "Berry Juice", "moves": ["Acrobatics", "Rock Slide", "Heat Wave", "Hidden Power Grass"]},
@@ -218,44 +217,49 @@ var SETDEX_SM = {
 	"Archeops": {
 		"NU Lead": {"level": 100, "evs": {"at": 252, "sp": 252}, "nature": "Naive", "ability": "Defeatist", "item": "Focus Sash", "moves": ["Stealth Rock", "Taunt", "Endeavor", "Head Smash"]},
 		"NU Offensive": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defeatist", "moves": ["Acrobatics", "Stone Edge", "Earthquake", "Roost"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defeatist", "item": "Focus Sash", "moves": ["Stealth Rock", "Endeavor", "Taunt", "Head Smash"]},
+	},
+	"Arghonaut": {
+		"CAP Support": {"level": 100, "evs": {"sd": 132, "df": 124, "hp": 252}, "nature": "Careful", "ability": "Unaware", "item": "Leftovers", "moves": ["Spikes", "Knock Off", "Earthquake", "Recover"]},
 	},
 	"Ariados": {
 		"PU Sticky Web": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Insomnia", "item": "Focus Sash", "moves": ["Sticky Web", "Toxic Spikes", "Megahorn", "Toxic Thread"]},
 	},
 	"Armaldo": {
-		"PU Rapid Spin": {"level": 100, "evs": {"at": 92, "hp": 252, "sp": 164}, "nature": "Adamant", "ability": "Battle Armor", "item": "Leftovers", "moves": ["Rapid Spin", "Stone Edge", "Knock Off", "Earthquake"]},
-		"Monotype Defensive Spinner (Bug)": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Careful", "ability": "Battle Armor", "item": "Leftovers", "moves": ["Stealth Rock", "Rapid Spin", "Knock Off", "Stone Edge"]},
+		"PU Offensive Spinner": {"level": 100, "evs": {"at": 92, "hp": 252, "sp": 164}, "nature": "Adamant", "ability": "Battle Armor", "item": "Leftovers", "moves": ["Rapid Spin", "Stone Edge", "Knock Off", "Earthquake"]},
+		"Monotype Defensive Spinner (Bug)": {"level": 100, "evs": {"sd": 172, "df": 84, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Leftovers", "moves": ["Stealth Rock", "Rapid Spin", "Knock Off", "Stone Edge"]},
 	},
 	"Aromatisse": {
 		"NU Offensive Trick Room": {"level": 100, "evs": {"sd": 8, "hp": 248, "sa": 252}, "ivs": {"at": 0, "sp": 0}, "nature": "Quiet", "ability": "Aroma Veil", "item": "Fairium Z", "moves": ["Trick Room", "Nasty Plot", "Moonblast", "Psychic"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Aroma Veil", "item": "Leftovers", "moves": ["Moonblast", "Wish", "Protect", "Refresh"]},
 	},
 	"Aron": {
 		"LC Rock Polish": {"level": 5, "evs": {"sd": 116, "at": 196, "sp": 196}, "nature": "Jolly", "ability": "Rock Head", "item": "Eviolite", "moves": ["Rock Polish", "Head Smash", "Heavy Slam", "Earthquake"]},
 	},
 	"Articuno": {
 		"PU SubRoost": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Substitute", "Roost", "Freeze-Dry", "Hurricane"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 140, "hp": 252, "sp": 116}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Roost", "Freeze-Dry", "Defog", "Heal Bell"]},
+		"PU Specially Defensive": {"level": 100, "evs": {"sd": 204, "hp": 248, "sp": 56}, "nature": "Calm", "ability": "Pressure", "item": "Leftovers", "moves": ["Roost", "Defog", "Freeze-Dry", "Heal Bell"]},
+		"NU Utility": {"level": 100, "evs": {"sd": 44, "hp": 248, "sp": 216}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Freeze-Dry", "Roost", "Defog", "Heal Bell"]},
+		"UU Specially Defensive": {"level": 100, "evs": {"sd": 160, "df": 4, "hp": 248, "sp": 96}, "nature": "Calm", "ability": "Pressure", "item": "Leftovers", "moves": ["Defog", "Heal Bell", "Freeze-Dry", "Roost"]},
 	},
 	"Audino": {
 		"PU Wish Passer": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Regenerator", "item": "Leftovers", "moves": ["Wish", "Protect", "Knock Off", "Heal Bell"]},
-		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Audinite", "moves": ["Wish", "Protect", "Toxic", "Dazzling Gleam"]},
-		"UU MegaMind": {"level": 100, "evs": {"df": 208, "hp": 252, "sa": 48}, "nature": "Bold", "ability": "Regenerator", "item": "Audinite", "moves": ["Calm Mind", "Dazzling Gleam", "Wish", "Protect"]},
+		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Audinite", "moves": ["Wish", "Protect", "Heal Bell", "Dazzling Gleam"]},
 	},
 	"Audino-Mega": {
-		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Audinite", "moves": ["Wish", "Protect", "Toxic", "Dazzling Gleam"]},
-		"UU MegaMind": {"level": 100, "evs": {"df": 208, "hp": 252, "sa": 48}, "nature": "Bold", "ability": "Regenerator", "item": "Audinite", "moves": ["Calm Mind", "Dazzling Gleam", "Wish", "Protect"]},
+		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Audinite", "moves": ["Wish", "Protect", "Heal Bell", "Dazzling Gleam"]},
 	},
 	"Aurorus": {
 		"PU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Snow Warning", "item": "Choice Specs", "moves": ["Blizzard", "Freeze-Dry", "Earth Power", "Hidden Power Rock"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Choice Scarf", "moves": ["Blizzard", "Freeze-Dry", "Earth Power", "Hidden Power Rock"]},
 		"PU Stealth Rock Lead": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Snow Warning", "item": "Focus Sash", "moves": ["Stealth Rock", "Blizzard", "Encore", "Rock Tomb"]},
-		"NU Lead": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Focus Sash", "moves": ["Stealth Rock", "Blizzard", "Freeze-Dry", "Encore"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Focus Sash", "moves": ["Freeze-Dry", "Blizzard", "Stealth Rock", "Encore"]},
 		"UU Aurora Veil Lead": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Focus Sash", "moves": ["Stealth Rock", "Freeze-Dry", "Hidden Power Fire", "Encore"]},
 	},
+	"Aurumoth": {
+		"CAP Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "No Guard", "item": "Fightinium Z", "moves": ["Quiver Dance", "Psychic", "Bug Buzz", "Focus Blast"]},
+	},
 	"Avalugg": {
-		"OU Physical Wall": {"level": 100, "evs": {"sd": 64, "df": 104, "at": 88, "hp": 252}, "nature": "Impish", "ability": "Sturdy", "item": "Leftovers", "moves": ["Avalanche", "Recover", "Rapid Spin", "Toxic"]},
+		"PU Defensive Spinner": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Recover", "Avalanche", "Earthquake"]},
+		"OU Physical Wall": {"level": 100, "evs": {"sd": 64, "df": 104, "at": 88, "hp": 252}, "nature": "Impish", "ability": "Sturdy", "item": "Leftovers", "moves": ["Avalanche", "Recover", "Rapid Spin", "Earthquake"]},
 		"Monotype Defensive Rapid Spin": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Recover", "Roar", "Avalanche"]},
 	},
 	"Axew": {
@@ -263,17 +267,22 @@ var SETDEX_SM = {
 	},
 	"Azelf": {
 		"UU Suicide Lead": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Jolly", "ability": "Levitate", "item": "Focus Sash", "moves": ["Stealth Rock", "Explosion", "Taunt", "Knock Off"]},
-		"OU Suicide Rocker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Focus Sash", "moves": ["Stealth Rock", "Taunt", "Fire Blast", "Hidden Power Ice"]},
 	},
 	"Azumarill": {
 		"OU Belly Drum": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Huge Power", "item": "Normalium Z", "moves": ["Belly Drum", "Aqua Jet", "Play Rough", "Knock Off"]},
 		"OU Perish Trap": {"level": 100, "evs": {"sd": 228, "hp": 252, "sp": 28}, "nature": "Calm", "ability": "Sap Sipper", "item": "Leftovers", "moves": ["Perish Song", "Whirlpool", "Protect", "Toxic"]},
 		"Doubles Belly Drum Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Huge Power", "item": "Sitrus Berry", "moves": ["Aqua Jet", "Knock Off", "Belly Drum", "Protect"]},
 		"Battle Spot Singles Belly Drum": {"level": 50, "evs": {"sd": 12, "df": 12, "at": 252, "hp": 228, "sp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Sitrus Berry", "moves": ["Belly Drum", "Aqua Jet", "Play Rough", "Superpower"]},
-		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Choice Band", "moves": ["Aqua Jet", "Play Rough", "Superpower", "Waterfall"]},
-		"Battle Spot Singles Assault Vest": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Assault Vest", "moves": ["Aqua Jet", "Play Rough", "Waterfall", "Knock Off"]},
+		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Choice Band", "moves": ["Aqua Jet", "Play Rough", "Superpower", "Liquidation"]},
+		"Battle Spot Singles Assault Vest": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Assault Vest", "moves": ["Aqua Jet", "Play Rough", "Liquidation", "Knock Off"]},
 		"Monotype Belly Drum (Fairy)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Huge Power", "item": "Normalium Z", "moves": ["Belly Drum", "Aqua Jet", "Play Rough", "Knock Off"]},
 		"Monotype Perish Trap (Water)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Sap Sipper", "item": "Leftovers", "moves": ["Perish Song", "Whirlpool", "Rest", "Protect"]},
+	},
+	"Azurill": {
+		"LC Trick Room Sweeper": {"level": 5, "evs": {"df": 116, "at": 196, "hp": 196}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Huge Power", "item": "Life Orb", "moves": ["Double-Edge", "Knock Off", "Waterfall", "Return"]},
+	},
+	"Bagon": {
+		"LC Dragon Dance": {"level": 5, "evs": {"df": 76, "at": 236, "sp": 196}, "ivs": {"hp": 0}, "nature": "Adamant", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Dragon Dance", "Outrage", "Zen Headbutt", "Fire Fang"]},
 	},
 	"Banette": {
 		"PU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Insomnia", "item": "Life Orb", "moves": ["Shadow Claw", "Sucker Punch", "Will-O-Wisp", "Knock Off"]},
@@ -283,17 +292,17 @@ var SETDEX_SM = {
 		"RU Offensive": {"level": 100, "evs": {"at": 252, "hp": 40, "sp": 216}, "nature": "Adamant", "ability": "Frisk", "item": "Banettite", "moves": ["Destiny Bond", "Shadow Claw", "Gunk Shot", "Taunt"]},
 	},
 	"Barbaracle": {
-		"RU Shell Smash": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Tough Claws", "item": "Rockium Z", "moves": ["Shell Smash", "Liquidation", "Stone Edge", "Return"]},
+		"RU Shell Smash": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Tough Claws", "item": "Rockium Z", "moves": ["Shell Smash", "Liquidation", "Stone Edge", "Low Kick"]},
 		"UU Shell Smash": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Tough Claws", "item": "Rockium Z", "moves": ["Shell Smash", "Stone Edge", "Liquidation", "Grass Knot"]},
 	},
 	"Basculin": {
-		"PU All-Out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Adaptability", "item": "Life Orb", "moves": ["Waterfall", "Aqua Jet", "Zen Headbutt", "Ice Beam"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Adaptability", "item": "Waterium Z", "moves": ["Waterfall", "Aqua Jet", "Ice Beam", "Crunch"]},
 	},
 	"Bastiodon": {
 		"PU Utility": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Sturdy", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Roar", "Magic Coat"]},
 	},
 	"Beartic": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Slush Rush", "item": "Icium Z", "moves": ["Icicle Crash", "Superpower", "Swords Dance", "Aqua Jet"]},
+		"PU Weather Sweeper": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Slush Rush", "item": "Icium Z", "moves": ["Icicle Crash", "Superpower", "Aqua Jet", "Swords Dance"]},
 		"Monotype Slush Rush Sweeper (Ice)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Slush Rush", "item": "Life Orb", "moves": ["Icicle Crash", "Superpower", "Stone Edge", "Swords Dance"]},
 	},
 	"Beautifly": {
@@ -308,10 +317,10 @@ var SETDEX_SM = {
 		"Battle Spot Singles Mega Scout": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Swarm", "item": "Beedrillite", "moves": ["U-turn", "Poison Jab", "Drill Run", "Knock Off"]},
 	},
 	"Beheeyem": {
-		"PU Nasty Plot": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Analytic", "item": "Colbur Berry", "moves": ["Nasty Plot", "Recover", "Psychic", "Signal Beam"]},
+		"PU Offensive Trick Room": {"level": 100, "evs": {"df": 8, "hp": 248, "sa": 252}, "ivs": {"at": 0, "sp": 0}, "nature": "Quiet", "ability": "Analytic", "item": "Psychium Z", "moves": ["Trick Room", "Psychic", "Nasty Plot", "Signal Beam"]},
 	},
 	"Bellossom": {
-		"PU Bulky Quiver Dance": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Modest", "ability": "Chlorophyll", "item": "Grassium Z", "moves": ["Quiver Dance", "Giga Drain", "Strength Sap", "Moonblast"]},
+		"PU Bulky Quiver Dance": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Grassium Z", "moves": ["Strength Sap", "Quiver Dance", "Giga Drain", "Safeguard"]},
 	},
 	"Bellsprout": {
 		"LC Praise The Sun (Sun Sweeper)": {"level": 5, "evs": {"sd": 36, "df": 76, "sp": 196, "sa": 196}, "nature": "Modest", "ability": "Chlorophyll", "item": "Poisonium Z", "moves": ["Solar Beam", "Sludge Bomb", "Weather Ball", "Sleep Powder"]},
@@ -323,8 +332,7 @@ var SETDEX_SM = {
 		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Fluffy", "item": "Normalium Z", "moves": ["Swords Dance", "Drain Punch", "Double-Edge", "Earthquake"]},
 	},
 	"Bibarel": {
-		"PU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Simple", "item": "Lum Berry", "moves": ["Aqua Jet", "Swords Dance", "Return", "Liquidation"]},
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Simple", "item": "Life Orb", "moves": ["Swords Dance", "Return", "Waterfall", "Aqua Jet"]},
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Simple", "item": "Life Orb", "moves": ["Swords Dance", "Return", "Waterfall", "Aqua Jet"]},
 	},
 	"Bidoof": {
 		"LC Swords Dance": {"level": 5, "evs": {"sd": 116, "df": 116, "at": 236, "sp": 28}, "nature": "Adamant", "ability": "Simple", "item": "Eviolite", "moves": ["Swords Dance", "Return", "Quick Attack", "Crunch"]},
@@ -333,11 +341,13 @@ var SETDEX_SM = {
 		"LC Shell Smash": {"level": 5, "evs": {"sd": 148, "df": 60, "at": 180, "hp": 20, "sp": 36}, "nature": "Adamant", "ability": "Tough Claws", "item": "Eviolite", "moves": ["Shell Smash", "Liquidation", "Stone Edge", "Cross Chop"]},
 	},
 	"Bisharp": {
+		"UU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Life Orb", "moves": ["Iron Head", "Knock Off", "Sucker Punch", "Swords Dance"]},
 		"OU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Dread Plate", "moves": ["Knock Off", "Iron Head", "Sucker Punch", "Swords Dance"]},
 		"Monotype Offensive (Dark)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Life Orb", "moves": ["Swords Dance", "Sucker Punch", "Knock Off", "Iron Head"]},
 		"Monotype Swords Dance (Steel)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Life Orb", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Iron Head"]},
 	},
 	"Blacephalon": {
+		"OU Substitute + Calm Mind": {"level": 100, "evs": {"df": 4, "hp": 232, "sp": 252, "sa": 20}, "nature": "Timid", "ability": "Beast Boost", "item": "Ghostium Z", "moves": ["Flamethrower", "Shadow Ball", "Substitute", "Calm Mind"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Shadow Ball", "Flamethrower", "Fire Blast", "Trick"]},
 		"OU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Choice Specs", "moves": ["Shadow Ball", "Fire Blast", "Overheat", "Trick"]},
 		"Battle Spot Singles Z-Attack": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "ivs": {"at": 0}, "nature": "Timid", "ability": "Beast Boost", "item": "Firium Z", "moves": ["Mind Blown", "Shadow Ball", "Hidden Power Ice", "Fire Blast"]},
@@ -351,13 +361,13 @@ var SETDEX_SM = {
 	},
 	"Blastoise": {
 		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Torrent", "item": "Leftovers", "moves": ["Scald", "Toxic", "Rapid Spin", "Refresh"]},
-		"RU Offensive Spinner": {"level": 100, "evs": {"hp": 136, "sp": 204, "sa": 168}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Rapid Spin", "Scald", "Dark Pulse", "Ice Beam"]},
-		"UU Offensive Spinner": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Water Pulse", "Dark Pulse", "Aura Sphere", "Rapid Spin"]},
+		"RU Offensive Spinner": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Rapid Spin", "Dark Pulse", "Aura Sphere", "Ice Beam"]},
+		"UU Offensive Wallbreaker": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Water Pulse", "Dark Pulse", "Aura Sphere", "Ice Beam"]},
 		"Battle Spot Singles Mega Tank": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Torrent", "item": "Blastoisinite", "moves": ["Water Pulse", "Ice Beam", "Aura Sphere", "Aqua Jet"]},
 	},
 	"Blastoise-Mega": {
-		"RU Offensive Spinner": {"level": 100, "evs": {"hp": 136, "sp": 204, "sa": 168}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Rapid Spin", "Scald", "Dark Pulse", "Ice Beam"]},
-		"UU Offensive Spinner": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Water Pulse", "Dark Pulse", "Aura Sphere", "Rapid Spin"]},
+		"RU Offensive Spinner": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Rapid Spin", "Dark Pulse", "Aura Sphere", "Ice Beam"]},
+		"UU Offensive Wallbreaker": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Rain Dish", "item": "Blastoisinite", "moves": ["Water Pulse", "Dark Pulse", "Aura Sphere", "Ice Beam"]},
 		"Battle Spot Singles Mega Tank": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Torrent", "item": "Blastoisinite", "moves": ["Water Pulse", "Ice Beam", "Aura Sphere", "Aqua Jet"]},
 	},
 	"Blaziken": {
@@ -372,18 +382,18 @@ var SETDEX_SM = {
 	},
 	"Blissey": {
 		"UU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Seismic Toss", "Toxic", "Soft-Boiled", "Heal Bell"]},
-		"Uber Cleric": {"level": 100, "evs": {"sd": 252, "df": 252, "sp": 4}, "nature": "Calm", "ability": "Natural Cure", "item": "Shed Shell", "moves": ["Soft-Boiled", "Toxic", "Heal Bell", "Confide"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 6}, "nature": "Bold", "ability": "Serene Grace", "item": "Rocky Helmet", "moves": ["Soft-Boiled", "Flamethrower", "Calm Mind", "Hyper Voice"]},
+		"Uber Support": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Natural Cure", "item": "Shed Shell", "moves": ["Soft-Boiled", "Heal Bell", "Confide", "Toxic"]},
 		"Battle Spot Singles Special Wall": {"level": 50, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Bold", "ability": "Natural Cure", "item": "Shed Shell", "moves": ["Soft-Boiled", "Toxic", "Seismic Toss", "Flamethrower"]},
 	},
 	"Bouffalant": {
-		"PU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Reckless", "item": "Choice Band", "moves": ["Head Charge", "Earthquake", "Megahorn", "Pursuit"]},
+		"PU Assault Vest": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sap Sipper", "item": "Assault Vest", "moves": ["Return", "Earthquake", "Stone Edge", "Pursuit"]},
 	},
 	"Braviary": {
 		"NU Substitute + Bulk Up": {"level": 100, "evs": {"sd": 252, "hp": 172, "sp": 84}, "nature": "Careful", "ability": "Defiant", "item": "Leftovers", "moves": ["Bulk Up", "Brave Bird", "Substitute", "Roost"]},
 		"NU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Scarf", "moves": ["Brave Bird", "Return", "Superpower", "U-turn"]},
 	},
 	"Breloom": {
+		"OU Not Kartana (Breloom)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Life Orb", "moves": ["Swords Dance", "Mach Punch", "Bullet Seed", "Spore"]},
 		"Battle Spot Singles Offensive Spore": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Focus Sash", "moves": ["Spore", "Bullet Seed", "Mach Punch", "Rock Tomb"]},
 		"Monotype Technician Attacker (Fighting)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Focus Sash", "moves": ["Spore", "Bullet Seed", "Mach Punch", "Rock Tomb"]},
 		"Monotype Focus Sash (Grass)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Technician", "item": "Focus Sash", "moves": ["Spore", "Mach Punch", "Bullet Seed", "Rock Tomb"]},
@@ -391,7 +401,7 @@ var SETDEX_SM = {
 	"Bronzong": {
 		"RU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Levitate", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Gyro Ball", "Protect"]},
 		"UU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Levitate", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Gyro Ball", "Psywave"]},
-		"Doubles Trick Room": {"level": 100, "evs": {"sd": 56, "df": 200, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Heatproof", "item": "Psychium Z", "moves": ["Trick Room", "Gyro Ball", "Hypnosis", "Protect"]},
+		"Doubles Trick Room": {"level": 100, "evs": {"sd": 160, "df": 96, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Heatproof", "item": "Psychium Z", "moves": ["Trick Room", "Gyro Ball", "Hypnosis", "Protect"]},
 	},
 	"Bronzor": {
 		"LC Stealth Rock Setter": {"level": 5, "evs": {"sd": 148, "df": 228, "at": 4, "hp": 64, "sp": 12, "sa": 4}, "nature": "Relaxed", "ability": "Levitate", "item": "Berry Juice", "moves": ["Stealth Rock", "Recycle", "Psychic", "Heavy Slam"]},
@@ -402,10 +412,10 @@ var SETDEX_SM = {
 		"RU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Strong Jaw", "item": "Choice Band", "moves": ["Psychic Fangs", "Aqua Jet", "Waterfall", "Crunch"]},
 	},
 	"Budew": {
-		"LC Entry Hazard Setter": {"level": 5, "evs": {"sd": 236, "df": 236, "hp": 36}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Spikes", "Sleep Powder", "Synthesis", "Giga Drain"]},
+		"LC Entry Hazard Setter": {"level": 5, "evs": {"sd": 196, "df": 236, "hp": 36, "sa": 40}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Spikes", "Sleep Powder", "Synthesis", "Giga Drain"]},
 	},
 	"Bulbasaur": {
-		"LC Z-Celebrate Sweeper": {"level": 5, "evs": {"df": 52, "sp": 240, "sa": 160}, "nature": "Modest", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Celebrate", "Sludge Bomb", "Giga Drain", "Hidden Power Fire"]},
+		"LC Z-Celebrate Sweeper": {"level": 5, "evs": {"df": 44, "sp": 240, "sa": 160}, "nature": "Modest", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Celebrate", "Sludge Bomb", "Giga Drain", "Hidden Power Fire"]},
 	},
 	"Buneary": {
 		"LC Offensive Utility": {"level": 5, "evs": {"df": 4, "at": 228, "sp": 236}, "nature": "Jolly", "ability": "Limber", "item": "Eviolite", "moves": ["Healing Wish", "Return", "Drain Punch", "Thunder Wave"]},
@@ -416,30 +426,30 @@ var SETDEX_SM = {
 		"LC Life Orb": {"level": 5, "evs": {"df": 52, "at": 228, "sp": 220}, "ivs": {"hp": 4}, "nature": "Adamant", "ability": "Huge Power", "item": "Life Orb", "moves": ["Return", "Quick Attack", "Earthquake", "Iron Head"]},
 	},
 	"Butterfree": {
-		"PU Quiver Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Tinted Lens", "item": "Buginium Z", "moves": ["Quiver Dance", "Bug Buzz", "Energy Ball", "Sleep Powder"]},
+		"PU Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Tinted Lens", "item": "Focus Sash", "moves": ["Quiver Dance", "Sleep Powder", "Bug Buzz", "Air Slash"]},
 	},
 	"Buzzwole": {
+		"OU Bulk Up": {"level": 100, "evs": {"df": 144, "hp": 252, "sp": 112}, "nature": "Impish", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Drain Punch", "Ice Punch", "Bulk Up", "Roost"]},
 		"Uber Physical Wall": {"level": 100, "evs": {"sd": 76, "df": 184, "hp": 248}, "nature": "Impish", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Hammer Arm", "Toxic", "Roost", "Earthquake"]},
 		"VGC17 Pummeling Buzzwole": {"level": 50, "evs": {"sd": 140, "df": 4, "at": 220, "hp": 44, "sp": 100}, "nature": "Adamant", "ability": "Beast Boost", "item": "Fightinium Z", "moves": ["Superpower", "Poison Jab", "Ice Punch", "Protect"]},
 		"Battle Spot Singles Physically Defensive": {"level": 50, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Beast Boost", "item": "Rocky Helmet", "moves": ["Toxic", "Roost", "Leech Life", "Hammer Arm"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Superpower", "Earthquake", "Leech Life", "Ice Punch"]},
 		"Battle Spot Singles Bulky Attacker": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Beast Boost", "item": "Assault Vest", "moves": ["Leech Life", "Superpower", "Earthquake", "Ice Punch"]},
 		"Monotype Choice Scarf (Bug)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Superpower", "Ice Punch", "Stone Edge", "Earthquake"]},
+		"Monotype Choice Scarf Sweeper (Fighting)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Leech Life", "Superpower", "Ice Punch", "Poison Jab"]},
 	},
 	"Cacturne": {
 		"PU Offensive Spikes": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Mild", "ability": "Water Absorb", "item": "Life Orb", "moves": ["Spikes", "Dark Pulse", "Sucker Punch", "Energy Ball"]},
 	},
 	"Camerupt": {
-		"PU Trick Room Attacker": {"level": 100, "evs": {"df": 8, "hp": 248, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Solid Rock", "item": "Choice Specs", "moves": ["Eruption", "Fire Blast", "Earth Power", "Hidden Power Ice"]},
+		"PU Choice Specs": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Solid Rock", "item": "Choice Specs", "moves": ["Eruption", "Fire Blast", "Earth Power", "Hidden Power Ice"]},
 		"RU Wallbreaker": {"level": 100, "evs": {"hp": 172, "sp": 84, "sa": 252}, "nature": "Modest", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Hidden Power Ice", "Toxic"]},
-		"UU Wallbreaker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Ancient Power", "Toxic"]},
-		"OU Wallbreaker": {"level": 100, "evs": {"hp": 128, "sp": 128, "sa": 252}, "nature": "Modest", "ability": "Magma Armor", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Toxic", "Stealth Rock"]},
+		"OU Wallbreaker": {"level": 100, "evs": {"hp": 128, "sp": 128, "sa": 252}, "nature": "Modest", "ability": "Magma Armor", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Nature Power", "Stealth Rock"]},
 		"Doubles Trick Room Attacker": {"level": 100, "evs": {"df": 8, "hp": 248, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Heat Wave", "Earth Power", "Nature Power", "Protect"]},
 	},
 	"Camerupt-Mega": {
 		"RU Wallbreaker": {"level": 100, "evs": {"hp": 172, "sp": 84, "sa": 252}, "nature": "Modest", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Hidden Power Ice", "Toxic"]},
-		"UU Wallbreaker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Ancient Power", "Toxic"]},
-		"OU Wallbreaker": {"level": 100, "evs": {"hp": 128, "sp": 128, "sa": 252}, "nature": "Modest", "ability": "Magma Armor", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Toxic", "Stealth Rock"]},
+		"OU Wallbreaker": {"level": 100, "evs": {"hp": 128, "sp": 128, "sa": 252}, "nature": "Modest", "ability": "Magma Armor", "item": "Cameruptite", "moves": ["Fire Blast", "Earth Power", "Nature Power", "Stealth Rock"]},
 		"Doubles Trick Room Attacker": {"level": 100, "evs": {"df": 8, "hp": 248, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Solid Rock", "item": "Cameruptite", "moves": ["Heat Wave", "Earth Power", "Nature Power", "Protect"]},
 	},
 	"Carbink": {
@@ -461,35 +471,37 @@ var SETDEX_SM = {
 		"PU Z-Rain Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Forecast", "item": "Waterium Z", "moves": ["Rain Dance", "Hurricane", "Hydro Pump", "Energy Ball"]},
 	},
 	"Celebi": {
-		"UU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Nasty Plot", "Giga Drain", "Psychic", "Hidden Power Fire"]},
-		"UU Offensive Stealth Rock": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Meadow Plate", "moves": ["Stealth Rock", "Leaf Storm", "Psychic", "U-turn"]},
-		"UU Bulky Support": {"level": 100, "evs": {"sd": 148, "df": 88, "hp": 252, "sp": 20}, "nature": "Bold", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Stealth Rock", "Recover", "U-turn", "Giga Drain"]},
+		"UU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Groundium Z", "moves": ["Nasty Plot", "Giga Drain", "Earth Power", "Psychic"]},
+		"UU Defensive": {"level": 100, "evs": {"df": 236, "hp": 252, "sp": 20}, "nature": "Bold", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Stealth Rock", "U-turn", "Psychic", "Recover"]},
 		"Monotype Nasty Plot (Grass)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Groundium Z", "moves": ["Nasty Plot", "Psychic", "Earth Power", "Hidden Power Fire"]},
+		"Monotype Nasty Plot (Psychic)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Groundium Z", "moves": ["Nasty Plot", "Giga Drain", "Earth Power", "Hidden Power Fire"]},
+		"Monotype Defensive (Psychic)": {"level": 100, "evs": {"sd": 48, "df": 128, "hp": 252, "sp": 80}, "nature": "Calm", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Stealth Rock", "Recover", "Giga Drain", "U-turn"]},
 	},
 	"Celesteela": {
-		"OU Defensive": {"level": 100, "evs": {"sd": 156, "df": 104, "hp": 248}, "nature": "Relaxed", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Protect", "Heavy Slam", "Flamethrower"]},
+		"OU Defensive": {"level": 100, "evs": {"sd": 232, "df": 28, "hp": 248}, "nature": "Sassy", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Protect", "Heavy Slam", "Flamethrower"]},
 		"Uber Physically Defensive": {"level": 100, "evs": {"df": 252, "at": 8, "hp": 248}, "nature": "Impish", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Heavy Slam", "Toxic", "Protect"]},
 		"Doubles Utility Attacker": {"level": 100, "evs": {"sd": 172, "df": 48, "at": 40, "hp": 248}, "nature": "Careful", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Heavy Slam", "Leech Seed", "Substitute", "Protect"]},
 		"VGC17 Defensive": {"level": 50, "evs": {"sd": 116, "df": 116, "at": 44, "hp": 228, "sp": 4}, "nature": "Adamant", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Heavy Slam", "Leech Seed", "Substitute", "Protect"]},
 		"Battle Spot Singles Defensive (Physical Attacker)": {"level": 50, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Relaxed", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Heavy Slam", "Flamethrower", "Protect"]},
 		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"at": 252, "hp": 252, "sp": 4}, "nature": "Brave", "ability": "Beast Boost", "item": "Assault Vest", "moves": ["Heavy Slam", "Earthquake", "Flamethrower", "Hidden Power Ice"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Modest", "ability": "Beast Boost", "item": "Assault Vest", "moves": ["Air Slash", "Hidden Power Ice", "Flamethrower", "Flash Cannon"]},
-		"Battle Spot Singles Fast SubSeed": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Heavy Slam", "Substitute", "Protect"]},
-		"Monotype Bulky Attacker (Steel)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Heavy Slam", "Earthquake", "Protect"]},
-		"Monotype Assault Vest (Steel)": {"level": 100, "evs": {"sd": 32, "hp": 252, "sa": 224}, "nature": "Quiet", "ability": "Beast Boost", "item": "Assault Vest", "moves": ["Hidden Power Ice", "Giga Drain", "Earthquake", "Flamethrower"]},
+		"Battle Spot Singles Fast SubSeed": {"level": 50, "evs": {"sd": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Heavy Slam", "Substitute", "Protect"]},
+		"BH Primordial Sea": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Primordial Sea", "item": "Leftovers", "moves": ["Shore Up", "Scald", "Topsy-Turvy", "Defog"]},
+		"Monotype Leech Seed Tank (Steel)": {"level": 100, "evs": {"sd": 96, "df": 160, "hp": 252}, "nature": "Impish", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Leech Seed", "Protect", "Heavy Slam", "Toxic"]},
 		"Monotype Specially Defensive (Flying)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Sassy", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Heavy Slam", "Leech Seed", "Flamethrower", "Protect"]},
 	},
 	"Chandelure": {
-		"UU Substitute + Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Infiltrator", "item": "Ghostium Z", "moves": ["Fire Blast", "Shadow Ball", "Calm Mind", "Substitute"]},
+		"UU Substitute + Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Ghostium Z", "moves": ["Fire Blast", "Shadow Ball", "Calm Mind", "Substitute"]},
 		"UU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Scarf", "moves": ["Fire Blast", "Shadow Ball", "Trick", "Flamethrower"]},
-		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Infiltrator", "item": "Choice Specs", "moves": ["Fire Blast", "Shadow Ball", "Memento", "Trick"]},
+		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Specs", "moves": ["Fire Blast", "Shadow Ball", "Memento", "Trick"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Focus Sash", "moves": ["Shadow Ball", "Flamethrower", "Energy Ball", "Hidden Power Ice"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Scarf", "moves": ["Shadow Ball", "Flamethrower", "Energy Ball", "Hidden Power Ice"]},
 		"Monotype Revenge Killer (Ghost)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Scarf", "moves": ["Fire Blast", "Shadow Ball", "Energy Ball", "Trick"]},
 	},
 	"Chansey": {
-		"OU Defensive": {"level": 100, "evs": {"sd": 12, "df": 252, "hp": 244}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Seismic Toss", "Toxic", "Stealth Rock", "Soft-Boiled"]},
+		"OU Defensive": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Seismic Toss", "Toxic", "Stealth Rock", "Soft-Boiled"]},
 		"Uber Support": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Soft-Boiled", "Heal Bell", "Toxic", "Wish"]},
+		"Doubles Bulky Utility": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Healer", "item": "Eviolite", "moves": ["Psywave", "Icy Wind", "Soft-Boiled", "Toxic"]},
 		"Battle Spot Singles Special Wall": {"level": 50, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Seismic Toss", "Soft-Boiled", "Toxic", "Stealth Rock"]},
 		"Monotype Utility": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Stealth Rock", "Soft-Boiled", "Seismic Toss", "Toxic"]},
 	},
@@ -498,8 +510,8 @@ var SETDEX_SM = {
 		"RU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Solar Power", "item": "Choice Specs", "moves": ["Fire Blast", "Solar Beam", "Focus Blast", "Flamethrower"]},
 		"OU 3 Attacks + Roost": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Flare Blitz", "Dragon Claw", "Earthquake", "Roost"]},
 		"OU Drought Wallbreaker Y": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Flamethrower", "Solar Beam", "Focus Blast", "Roost"]},
-		"OU Dragon Dance X": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Roost", "Flare Blitz", "Earthquake"]},
-		"Doubles Sun Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Heat Wave", "Solar Beam", "Tailwind", "Protect"]},
+		"OU Dragon Dance X": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Outrage", "Flare Blitz", "Earthquake"]},
+		"Doubles Sun Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Heat Wave", "Solar Beam", "Overheat", "Protect"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Flare Blitz", "Outrage", "Earthquake"]},
 		"Battle Spot Singles Versatile Sweeper": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Blaze", "item": "Charizardite X", "moves": ["Swords Dance", "Flame Charge", "Outrage", "Flare Blitz"]},
 		"Battle Spot Singles Drought Attacker": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Flamethrower", "Solar Beam", "Focus Blast", "Overheat"]},
@@ -510,7 +522,7 @@ var SETDEX_SM = {
 	},
 	"Charizard-Mega-X": {
 		"OU 3 Attacks + Roost": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Flare Blitz", "Dragon Claw", "Earthquake", "Roost"]},
-		"OU Dragon Dance X": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Roost", "Flare Blitz", "Earthquake"]},
+		"OU Dragon Dance X": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Outrage", "Flare Blitz", "Earthquake"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Dragon Dance", "Flare Blitz", "Outrage", "Earthquake"]},
 		"Battle Spot Singles Versatile Sweeper": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Blaze", "item": "Charizardite X", "moves": ["Swords Dance", "Flame Charge", "Outrage", "Flare Blitz"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 116, "hp": 164, "sp": 228}, "nature": "Jolly", "ability": "Blaze", "item": "Charizardite X", "moves": ["Will-O-Wisp", "Roost", "Dragon Claw", "Earthquake"]},
@@ -518,7 +530,7 @@ var SETDEX_SM = {
 	},
 	"Charizard-Mega-Y": {
 		"OU Drought Wallbreaker Y": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Flamethrower", "Solar Beam", "Focus Blast", "Roost"]},
-		"Doubles Sun Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Heat Wave", "Solar Beam", "Tailwind", "Protect"]},
+		"Doubles Sun Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Heat Wave", "Solar Beam", "Overheat", "Protect"]},
 		"Battle Spot Singles Drought Attacker": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Flamethrower", "Solar Beam", "Focus Blast", "Overheat"]},
 		"Monotype Wallbreaker (Fire)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Fire Blast", "Solar Beam", "Focus Blast", "Roost"]},
 		"Monotype Drought Wallbreaker (Flying)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Charizardite Y", "moves": ["Fire Blast", "Solar Beam", "Focus Blast", "Roost"]},
@@ -528,12 +540,12 @@ var SETDEX_SM = {
 		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Tangled Feet", "item": "Normalium Z", "moves": ["Boomburst", "Heat Wave", "Nasty Plot", "Encore"]},
 	},
 	"Cherrim": {
-		"PU Healing Wish": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flower Gift", "item": "Life Orb", "moves": ["Healing Wish", "Energy Ball", "Hidden Power Fire", "Dazzling Gleam"]},
+		"PU Z-Sunny Day": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Flower Gift", "item": "Firium Z", "moves": ["Sunny Day", "Swords Dance", "Petal Blizzard", "Return"]},
 	},
 	"Chesnaught": {
 		"RU Defensive Spikes": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Bulletproof", "item": "Leftovers", "moves": ["Spikes", "Wood Hammer", "Synthesis", "Drain Punch"]},
 		"RU Fast Taunt": {"level": 100, "evs": {"df": 84, "hp": 252, "sp": 172}, "nature": "Impish", "ability": "Bulletproof", "item": "Leftovers", "moves": ["Spikes", "Taunt", "Leech Seed", "Wood Hammer"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Bulletproof", "item": "Leftovers", "moves": ["Drain Punch", "Spikes", "Leech Seed", "Spiky Shield"]},
+		"UU Spikes": {"level": 100, "evs": {"df": 252, "hp": 244, "sp": 12}, "nature": "Impish", "ability": "Bulletproof", "item": "Leftovers", "moves": ["Spikes", "Wood Hammer", "Drain Punch", "Synthesis"]},
 	},
 	"Chespin": {
 		"LC Offensive Utility": {"level": 5, "evs": {"sd": 236, "df": 156, "at": 28, "hp": 68}, "nature": "Impish", "ability": "Bulletproof", "item": "Eviolite", "moves": ["Seed Bomb", "Zen Headbutt", "Synthesis", "Spikes"]},
@@ -553,13 +565,14 @@ var SETDEX_SM = {
 	},
 	"Clawitzer": {
 		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Mega Launcher", "item": "Choice Specs", "moves": ["Water Pulse", "Ice Beam", "Dark Pulse", "Aura Sphere"]},
+		"NU Substitute + Toxic": {"level": 100, "evs": {"hp": 84, "sp": 184, "sa": 240}, "nature": "Modest", "ability": "Mega Launcher", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Water Pulse", "Dark Pulse"]},
 	},
 	"Claydol": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Leftovers", "moves": ["Rapid Spin", "Earth Power", "Psychic", "Stealth Rock"]},
-		"NU Offensive Utility": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Expert Belt", "moves": ["Rapid Spin", "Stealth Rock", "Earth Power", "Psychic"]},
+		"PU Rapid Spin": {"level": 100, "evs": {"df": 120, "hp": 252, "sp": 136}, "nature": "Bold", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Rapid Spin", "Toxic", "Earth Power", "Psychic"]},
 	},
 	"Clefable": {
 		"OU Magic Guard": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Magic Guard", "item": "Leftovers", "moves": ["Moonblast", "Soft-Boiled", "Stealth Rock", "Wish"]},
+		"OU Calm Mind": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Magic Guard", "item": "Leftovers", "moves": ["Calm Mind", "Moonblast", "Soft-Boiled", "Stealth Rock"]},
 		"OU Unaware": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Moonblast", "Wish", "Protect", "Heal Bell"]},
 		"Battle Spot Singles Booster": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Magic Guard", "item": "Kee Berry", "moves": ["Minimize", "Calm Mind", "Moonlight", "Moonblast"]},
 		"Monotype Utility (Fairy)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Magic Guard", "item": "Babiri Berry", "moves": ["Stealth Rock", "Soft-Boiled", "Moonblast", "Fire Blast"]},
@@ -571,7 +584,7 @@ var SETDEX_SM = {
 	},
 	"Cloyster": {
 		"RU Shell Smash Sweeper": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Skill Link", "item": "Normalium Z", "moves": ["Shell Smash", "Icicle Spear", "Explosion", "Hydro Pump"]},
-		"UU Shell Smash": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Skill Link", "item": "Normalium Z", "moves": ["Shell Smash", "Icicle Spear", "Hydro Pump", "Explosion"]},
+		"UU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Skill Link", "item": "Focus Sash", "moves": ["Shell Smash", "Icicle Spear", "Spikes", "Explosion"]},
 		"Uber Entry Hazard Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Skill Link", "item": "Focus Sash", "moves": ["Spikes", "Shell Smash", "Icicle Spear", "Rapid Spin"]},
 		"Battle Spot Singles Smash 'n' Sweep": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Skill Link", "item": "Focus Sash", "moves": ["Shell Smash", "Icicle Spear", "Rock Blast", "Ice Shard"]},
 		"Monotype Shell Smash Sweeper (Water)": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Jolly", "ability": "Skill Link", "item": "Focus Sash", "moves": ["Shell Smash", "Icicle Spear", "Rock Blast", "Ice Shard"]},
@@ -585,15 +598,19 @@ var SETDEX_SM = {
 	},
 	"Cofagrigus": {
 		"RU Trick Room Sweeper": {"level": 100, "evs": {"df": 40, "hp": 248, "sa": 220}, "nature": "Quiet", "ability": "Mummy", "item": "Ghostium Z", "moves": ["Trick Room", "Nasty Plot", "Shadow Ball", "Hidden Power Fighting"]},
-		"UU Trick Room": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "nature": "Quiet", "ability": "Mummy", "item": "Ghostium Z", "moves": ["Shadow Ball", "Hidden Power Fighting", "Trick Room", "Nasty Plot"]},
+		"UU Trick Room": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Mummy", "item": "Ghostium Z", "moves": ["Shadow Ball", "Hidden Power Fighting", "Trick Room", "Nasty Plot"]},
 	},
 	"Combusken": {
-		"PU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Speed Boost", "item": "Fightinium Z", "moves": ["Fire Blast", "Focus Blast", "Hidden Power Ice", "Protect"]},
+		"PU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Speed Boost", "item": "Fightinium Z", "moves": ["Fire Blast", "Focus Blast", "Hidden Power Electric", "Protect"]},
+		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Firium Z", "moves": ["Swords Dance", "Flare Blitz", "Sky Uppercut", "Protect"]},
 	},
 	"Comfey": {
-		"NU Showdown Usage": {"level": 100, "evs": {"hp": 236, "sp": 20, "sa": 252}, "nature": "Modest", "ability": "Triage", "item": "Pixie Plate", "moves": ["Draining Kiss", "Calm Mind", "Taunt", "Synthesis"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"hp": 236, "sp": 20, "sa": 252}, "nature": "Modest", "ability": "Triage", "item": "Life Orb", "moves": ["Draining Kiss", "Calm Mind", "Giga Drain", "Hidden Power Fire"]},
 		"RU Calm Mind": {"level": 100, "evs": {"hp": 236, "sp": 20, "sa": 252}, "nature": "Modest", "ability": "Triage", "item": "Pixie Plate", "moves": ["Draining Kiss", "Calm Mind", "Taunt", "Synthesis"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 248, "hp": 8, "sa": 252}, "nature": "Modest", "ability": "Triage", "item": "Metronome", "moves": ["Draining Kiss", "Calm Mind", "Synthesis", "Taunt"]},
+		"UU Showdown Usage": {"level": 100, "evs": {"df": 68, "hp": 236, "sp": 20, "sa": 184}, "nature": "Modest", "ability": "Triage", "item": "Pixie Plate", "moves": ["Draining Kiss", "Calm Mind", "Taunt", "Synthesis"]},
+	},
+	"Conkeldurr": {
+		"OU Offensive": {"level": 100, "evs": {"at": 252, "hp": 104, "sp": 152}, "nature": "Adamant", "ability": "Guts", "item": "Flame Orb", "moves": ["Drain Punch", "Mach Punch", "Knock Off", "Facade"]},
 	},
 	"Corphish": {
 		"LC Wallbreaker": {"level": 5, "evs": {"df": 76, "at": 196, "sp": 236}, "nature": "Adamant", "ability": "Adaptability", "item": "Eviolite", "moves": ["Crabhammer", "Aqua Jet", "Knock Off", "Swords Dance"]},
@@ -606,7 +623,8 @@ var SETDEX_SM = {
 		"LC Offensive Prankster": {"level": 5, "evs": {"sd": 40, "df": 40, "hp": 36, "sp": 232, "sa": 144}, "nature": "Timid", "ability": "Prankster", "item": "Darkinium Z", "moves": ["Giga Drain", "Dazzling Gleam", "Encore", "Memento"]},
 	},
 	"Crabominable": {
-		"PU Trick Room Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Iron Fist", "item": "Life Orb", "moves": ["Ice Hammer", "Close Combat", "Facade", "Power-Up Punch"]},
+		"PU Assault Vest": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Adamant", "ability": "Iron Fist", "item": "Assault Vest", "moves": ["Drain Punch", "Ice Hammer", "Stone Edge", "Thunder Punch"]},
+		"PU Trick Room Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Iron Fist", "item": "Life Orb", "moves": ["Ice Hammer", "Close Combat", "Stone Edge", "Power-Up Punch"]},
 	},
 	"Crabrawler": {
 		"LC Physical Attacker": {"level": 5, "evs": {"df": 60, "at": 180, "sp": 252}, "ivs": {"hp": 0}, "nature": "Jolly", "ability": "Hyper Cutter", "item": "Life Orb", "moves": ["Close Combat", "Crabhammer", "Earthquake", "Stone Edge"]},
@@ -622,12 +640,13 @@ var SETDEX_SM = {
 	},
 	"Crawdaunt": {
 		"UU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Adaptability", "item": "Waterium Z", "moves": ["Swords Dance", "Crabhammer", "Knock Off", "Aqua Jet"]},
+		"UU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Adaptability", "item": "Choice Band", "moves": ["Knock Off", "Crabhammer", "Aqua Jet", "Superpower"]},
 		"OU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Adaptability", "item": "Life Orb", "moves": ["Knock Off", "Crabhammer", "Aqua Jet", "Swords Dance"]},
 		"OU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Adaptability", "item": "Choice Band", "moves": ["Knock Off", "Crabhammer", "Aqua Jet", "Superpower"]},
 	},
 	"Cresselia": {
 		"RU Physically Defensive": {"level": 100, "evs": {"df": 112, "hp": 252, "sp": 144}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Moonlight", "Psyshock", "Moonblast", "Toxic"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Relaxed", "ability": "Levitate", "item": "Mental Herb", "moves": ["Lunar Dance", "Trick Room", "Moonlight", "Ice Beam"]},
+		"UU Trick Room": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Relaxed", "ability": "Levitate", "item": "Mental Herb", "moves": ["Trick Room", "Lunar Dance", "Moonlight", "Moonblast"]},
 		"OU Trick Room": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Levitate", "item": "Mental Herb", "moves": ["Trick Room", "Ice Beam", "Moonlight", "Lunar Dance"]},
 		"Doubles Bulky Support": {"level": 100, "evs": {"sd": 24, "df": 216, "hp": 252, "sa": 16}, "nature": "Sassy", "ability": "Levitate", "item": "Wiki Berry", "moves": ["Ice Beam", "Trick Room", "Ally Switch", "Helping Hand"]},
 		"Battle Spot Singles Defensive Support": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Levitate", "item": "Rocky Helmet", "moves": ["Ice Beam", "Moonlight", "Psychic", "Lunar Dance"]},
@@ -640,14 +659,11 @@ var SETDEX_SM = {
 		"LC Physical Support": {"level": 5, "evs": {"sd": 116, "df": 116, "at": 188, "hp": 52, "sp": 36}, "nature": "Adamant", "ability": "Dry Skin", "item": "Eviolite", "moves": ["Drain Punch", "Gunk Shot", "Knock Off", "Sucker Punch"]},
 	},
 	"Crobat": {
-		"UU Offensive Utility": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Infiltrator", "item": "Flyinium Z", "moves": ["Brave Bird", "Taunt", "Roost", "U-turn"]},
-		"UU Defensive Utility": {"level": 100, "evs": {"at": 36, "hp": 248, "sp": 224}, "nature": "Jolly", "ability": "Infiltrator", "item": "Black Sludge", "moves": ["Brave Bird", "U-turn", "Roost", "Taunt"]},
-		"UU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Infiltrator", "item": "Choice Band", "moves": ["Brave Bird", "Cross Poison", "U-turn", "Sleep Talk"]},
+		"UU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Infiltrator", "item": "Flyinium Z", "moves": ["Brave Bird", "U-turn", "Roost", "Taunt"]},
 		"Monotype Utility (Poison)": {"level": 100, "evs": {"df": 64, "hp": 252, "sp": 192}, "nature": "Jolly", "ability": "Infiltrator", "item": "Black Sludge", "moves": ["Defog", "Roost", "Brave Bird", "U-turn"]},
 	},
 	"Crustle": {
 		"PU Entry Hazard Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Weak Armor", "item": "Focus Sash", "moves": ["Stealth Rock", "Spikes", "Knock Off", "Rock Blast"]},
-		"NU Dual Hazard Setter": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Stealth Rock", "Spikes", "Rock Blast", "Shell Smash"]},
 	},
 	"Cryogonal": {
 		"NU Offensive Spinner": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Never-Melt Ice", "moves": ["Rapid Spin", "Freeze-Dry", "Toxic", "Recover"]},
@@ -658,6 +674,13 @@ var SETDEX_SM = {
 	},
 	"Cubone": {
 		"LC Physical Attacker": {"level": 5, "evs": {"df": 76, "at": 196, "sp": 236}, "nature": "Jolly", "ability": "Battle Armor", "item": "Thick Club", "moves": ["Bonemerang", "Knock Off", "Rock Slide", "Fire Punch"]},
+	},
+	"Cyclohm": {
+		"CAP Physically Defensive": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Static", "item": "Leftovers", "moves": ["Discharge", "Flamethrower", "Ice Beam", "Slack Off"]},
+		"CAP Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Choice Specs", "moves": ["Volt Switch", "Draco Meteor", "Fire Blast", "Hydro Pump"]},
+	},
+	"Cyndaquil": {
+		"LC Choice Scarf": {"level": 5, "evs": {"df": 12, "hp": 44, "sp": 236, "sa": 200}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Scarf", "moves": ["Eruption", "Hidden Power Grass", "Fire Blast", "Extrasensory"]},
 	},
 	"Darkrai": {
 		"Uber Special Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Bad Dreams", "item": "Life Orb", "moves": ["Hypnosis", "Nasty Plot", "Dark Pulse", "Thunder"]},
@@ -672,6 +695,7 @@ var SETDEX_SM = {
 	},
 	"Decidueye": {
 		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Overgrow", "item": "Decidium Z", "moves": ["Swords Dance", "Spirit Shackle", "Leaf Blade", "Shadow Sneak"]},
+		"NU Utility": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Grassium Z", "moves": ["Defog", "Leaf Storm", "U-turn", "Roost"]},
 		"RU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Overgrow", "item": "Grassium Z", "moves": ["Swords Dance", "Spirit Shackle", "Leaf Blade", "Substitute"]},
 		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Overgrow", "item": "Decidium Z", "moves": ["Swords Dance", "Spirit Shackle", "Leaf Blade", "Sucker Punch"]},
 	},
@@ -679,7 +703,7 @@ var SETDEX_SM = {
 		"PU Cheek Pouch": {"level": 100, "evs": {"hp": 12, "sp": 252, "sa": 244}, "nature": "Timid", "ability": "Cheek Pouch", "item": "Aguav Berry", "moves": ["Recycle", "Substitute", "Discharge", "Hidden Power Ice"]},
 	},
 	"Delcatty": {
-		"PU Normalize": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Normalize", "item": "Life Orb", "moves": ["Fake Out", "Sucker Punch", "Return", "Thunder Wave"]},
+		"PU Normalize": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Normalize", "item": "Silk Scarf", "moves": ["Fake Out", "Sucker Punch", "Return", "Thunder Wave"]},
 	},
 	"Delibird": {
 		"PU Spikes": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Insomnia", "item": "Focus Sash", "moves": ["Spikes", "Rapid Spin", "Destiny Bond", "Freeze-Dry"]},
@@ -710,34 +734,38 @@ var SETDEX_SM = {
 		"LC RestTalk": {"level": 5, "evs": {"sd": 20, "df": 180, "hp": 212, "sp": 60, "sa": 36}, "nature": "Modest", "ability": "Water Bubble", "item": "Eviolite", "moves": ["Rest", "Sleep Talk", "Scald", "Infestation"]},
 	},
 	"Dhelmise": {
-		"NU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 120, "sp": 136}, "nature": "Adamant", "ability": "Steelworker", "item": "Choice Band", "moves": ["Anchor Shot", "Power Whip", "Earthquake", "Knock Off"]},
-		"RU Offensive Spinner": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Steelworker", "item": "Spooky Plate", "moves": ["Rapid Spin", "Shadow Claw", "Power Whip", "Anchor Shot"]},
+		"NU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 52, "sp": 204}, "nature": "Adamant", "ability": "Steelworker", "item": "Choice Band", "moves": ["Power Whip", "Heavy Slam", "Earthquake", "Knock Off"]},
+		"NU Rapid Spin": {"level": 100, "evs": {"at": 252, "hp": 156, "sp": 100}, "nature": "Adamant", "ability": "Steelworker", "item": "Colbur Berry", "moves": ["Power Whip", "Anchor Shot", "Rapid Spin", "Rest"]},
 		"VGC17 Offensive": {"level": 50, "evs": {"sd": 52, "df": 12, "at": 252, "hp": 188}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Steelworker", "item": "Life Orb", "moves": ["Heavy Slam", "Power Whip", "Shadow Claw", "Protect"]},
 		"VGC17 Assault Vest": {"level": 50, "evs": {"sd": 100, "at": 252, "hp": 156}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Steelworker", "item": "Assault Vest", "moves": ["Power Whip", "Heavy Slam", "Shadow Claw", "Rock Slide"]},
 	},
 	"Dialga": {
 		"Uber Offensive Utility": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Pressure", "item": "Life Orb", "moves": ["Stealth Rock", "Draco Meteor", "Fire Blast", "Thunder"]},
+		"BH Doom Desire": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Tinted Lens", "item": "Steelium Z", "moves": ["Doom Desire", "Tail Glow", "Core Enforcer", "Shore Up"]},
+		"BH RegenVest": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Regenerator", "item": "Assault Vest", "moves": ["U-turn", "Core Enforcer", "Revelation Dance", "Spectral Thief"]},
 	},
 	"Diancie": {
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Sassy", "ability": "Clear Body", "item": "Leftovers", "moves": ["Moonblast", "Stealth Rock", "Earth Power", "Diamond Storm"]},
+		"NU Stealth Rock": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Clear Body", "item": "Leftovers", "moves": ["Stealth Rock", "Moonblast", "Power Gem", "Heal Bell"]},
+		"NU Calm Mind": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Clear Body", "item": "Leftovers", "moves": ["Calm Mind", "Moonblast", "Substitute", "Earth Power"]},
+		"NU Choice Specs": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Clear Body", "item": "Choice Specs", "moves": ["Moonblast", "Power Gem", "Earth Power", "Hidden Power Fire"]},
 		"RU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Sassy", "ability": "Clear Body", "item": "Leftovers", "moves": ["Stealth Rock", "Moonblast", "Diamond Storm", "Heal Bell"]},
-		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Hidden Power Fire", "Stealth Rock"]},
-		"OU Substitute + Endeavor": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Substitute", "Endeavor", "Moonblast", "Diamond Storm"]},
+		"UU Showdown Usage": {"level": 100, "evs": {"sd": 144, "df": 92, "hp": 252, "sp": 20}, "nature": "Calm", "ability": "Clear Body", "item": "Leftovers", "moves": ["Moonblast", "Stealth Rock", "Heal Bell", "Diamond Storm"]},
+		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Earth Power", "Protect"]},
 		"Uber Mega Diancie": {"level": 100, "evs": {"at": 24, "sp": 252, "sa": 232}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Earth Power", "Stealth Rock"]},
-		"Doubles Offensive Trick Room": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Clear Body", "item": "Stone Plate", "moves": ["Diamond Storm", "Moonblast", "Trick Room", "Protect"]},
+		"Doubles Offensive Trick Room": {"level": 100, "evs": {"at": 160, "hp": 252, "sa": 96}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Clear Body", "item": "Weakness Policy", "moves": ["Diamond Storm", "Moonblast", "Trick Room", "Protect"]},
 		"Doubles Mega Mixed Attacker": {"level": 100, "evs": {"sd": 20, "at": 140, "hp": 28, "sp": 252, "sa": 68}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Diamond Storm", "Moonblast", "Earth Power", "Protect"]},
 		"Monotype Offensive (Fairy)": {"level": 100, "evs": {"hp": 16, "sp": 252, "sa": 240}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Psychic", "Hidden Power Fire"]},
 		"Monotype Mixed Attacker (Rock)": {"level": 100, "evs": {"hp": 16, "sp": 252, "sa": 240}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Diamond Storm", "Moonblast", "Psychic", "Hidden Power Fire"]},
 	},
 	"Diancie-Mega": {
-		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Hidden Power Fire", "Stealth Rock"]},
-		"OU Substitute + Endeavor": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Substitute", "Endeavor", "Moonblast", "Diamond Storm"]},
+		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Earth Power", "Protect"]},
 		"Uber Mega Diancie": {"level": 100, "evs": {"at": 24, "sp": 252, "sa": 232}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Earth Power", "Stealth Rock"]},
 		"Doubles Mega Mixed Attacker": {"level": 100, "evs": {"sd": 20, "at": 140, "hp": 28, "sp": 252, "sa": 68}, "nature": "Hasty", "ability": "Clear Body", "item": "Diancite", "moves": ["Diamond Storm", "Moonblast", "Earth Power", "Protect"]},
 		"Monotype Offensive (Fairy)": {"level": 100, "evs": {"hp": 16, "sp": 252, "sa": 240}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Moonblast", "Diamond Storm", "Psychic", "Hidden Power Fire"]},
 		"Monotype Mixed Attacker (Rock)": {"level": 100, "evs": {"hp": 16, "sp": 252, "sa": 240}, "nature": "Naive", "ability": "Clear Body", "item": "Diancite", "moves": ["Diamond Storm", "Moonblast", "Psychic", "Hidden Power Fire"]},
 	},
 	"Diggersby": {
+		"OU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Huge Power", "item": "Choice Band", "moves": ["Earthquake", "Return", "Quick Attack", "Spikes"]},
 		"Monotype Physical Wallbreaker (Normal)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Huge Power", "item": "Choice Band", "moves": ["Return", "Earthquake", "Fire Punch", "Quick Attack"]},
 	},
 	"Diglett": {
@@ -751,12 +779,15 @@ var SETDEX_SM = {
 		"PU Imposter": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"at": 30, "sp": 0, "sa": 30}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
 		"NU Imposter": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"at": 30, "sp": 0, "sa": 30}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
 		"OU Imposter": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
-		"Uber Revenge Killer": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"sd": 30, "df": 30, "at": 30, "hp": 30, "sp": 0}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
+		"Uber no u (Revenge Killer)": {"level": 100, "evs": {"df": 252, "at": 8, "hp": 248}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
 		"Battle Spot Singles Imposter!": {"level": 50, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
 		"Monotype Revenge Killer": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"at": 30, "sp": 0, "sa": 30}, "nature": "Relaxed", "ability": "Imposter", "item": "Choice Scarf", "moves": ["Transform"]},
 	},
 	"Dodrio": {
-		"NU Setup Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Flyinium Z", "moves": ["Swords Dance", "Brave Bird", "Return", "Jump Kick"]},
+		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Flyinium Z", "moves": ["Swords Dance", "Brave Bird", "Jump Kick", "Return"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Choice Scarf", "moves": ["Brave Bird", "Jump Kick", "Return", "Knock Off"]},
+		"PU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Choice Band", "moves": ["Brave Bird", "Return", "Jump Kick", "Knock Off"]},
+		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Flyinium Z", "moves": ["Swords Dance", "Brave Bird", "Return", "Jump Kick"]},
 	},
 	"Doduo": {
 		"LC Physical Attacker": {"level": 5, "evs": {"at": 236, "sp": 236}, "nature": "Jolly", "ability": "Early Bird", "item": "Berry Juice", "moves": ["Brave Bird", "Knock Off", "Jump Kick", "Quick Attack"]},
@@ -767,27 +798,24 @@ var SETDEX_SM = {
 	},
 	"Doublade": {
 		"RU Bulky Swords Dance": {"level": 100, "evs": {"sd": 76, "at": 180, "hp": 252}, "nature": "Adamant", "ability": "No Guard", "item": "Eviolite", "moves": ["Swords Dance", "Shadow Sneak", "Sacred Sword", "Shadow Claw"]},
-		"UU Swords Dance": {"level": 100, "evs": {"sd": 16, "at": 252, "hp": 240}, "nature": "Brave", "ability": "No Guard", "item": "Eviolite", "moves": ["Swords Dance", "Gyro Ball", "Shadow Claw", "Shadow Sneak"]},
+		"UU Swords Dance": {"level": 100, "evs": {"sd": 16, "at": 252, "hp": 240}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "No Guard", "item": "Eviolite", "moves": ["Swords Dance", "Gyro Ball", "Shadow Claw", "Shadow Sneak"]},
 	},
 	"Dragalge": {
 		"RU Defensive": {"level": 100, "evs": {"sd": 204, "hp": 252, "sp": 52}, "nature": "Calm", "ability": "Adaptability", "item": "Black Sludge", "moves": ["Draco Meteor", "Sludge Wave", "Toxic Spikes", "Scald"]},
 		"RU Offensive": {"level": 100, "evs": {"hp": 204, "sp": 52, "sa": 252}, "nature": "Modest", "ability": "Adaptability", "item": "Dragonium Z", "moves": ["Draco Meteor", "Sludge Wave", "Hidden Power Fire", "Toxic Spikes"]},
-		"Monotype Offensive Toxic Spikes (Dragon)": {"level": 100, "evs": {"hp": 228, "sp": 28, "sa": 252}, "nature": "Modest", "ability": "Adaptability", "item": "Dragon Fang", "moves": ["Draco Meteor", "Sludge Wave", "Toxic Spikes", "Hidden Power Fire"]},
+		"Monotype Offensive Toxic Spikes (Dragon)": {"level": 100, "evs": {"sd": 4, "hp": 224, "sp": 28, "sa": 252}, "nature": "Modest", "ability": "Adaptability", "item": "Poison Barb", "moves": ["Draco Meteor", "Sludge Wave", "Toxic Spikes", "Hidden Power Fire"]},
 	},
 	"Dragonite": {
 		"OU Flyinium Z": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Multiscale", "item": "Flyinium Z", "moves": ["Dragon Dance", "Fly", "Earthquake", "Extreme Speed"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Multiscale", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Extreme Speed"]},
 		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Multiscale", "item": "Choice Band", "moves": ["Outrage", "Extreme Speed", "Earthquake", "Fire Punch"]},
-		"Monotype All-out Attacker (Dragon)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Multiscale", "item": "Choice Band", "moves": ["Outrage", "Extreme Speed", "Fire Punch", "Earthquake"]},
+		"Monotype Physical Wallbreaker (Dragon)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Multiscale", "item": "Choice Band", "moves": ["Outrage", "Extreme Speed", "Fire Punch", "Superpower"]},
 		"Monotype Choice Band (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Multiscale", "item": "Choice Band", "moves": ["Outrage", "Extreme Speed", "Fire Punch", "Earthquake"]},
 	},
 	"Drampa": {
 		"PU Choice Specs": {"level": 100, "evs": {"hp": 136, "sp": 120, "sa": 252}, "nature": "Modest", "ability": "Sap Sipper", "item": "Choice Specs", "moves": ["Draco Meteor", "Hyper Voice", "Fire Blast", "Focus Blast"]},
-		"NU Choice Specs": {"level": 100, "evs": {"hp": 136, "sp": 120, "sa": 252}, "nature": "Modest", "ability": "Sap Sipper", "item": "Choice Specs", "moves": ["Draco Meteor", "Fire Blast", "Hyper Voice", "Surf"]},
 	},
 	"Drapion": {
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Waterium Z", "moves": ["Swords Dance", "Poison Jab", "Knock Off", "Aqua Tail"]},
-		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Choice Scarf", "moves": ["Knock Off", "Poison Jab", "Pursuit", "Earthquake"]},
 		"RU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Choice Band", "moves": ["Knock Off", "Poison Jab", "Aqua Tail", "Pursuit"]},
 		"RU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Waterium Z", "moves": ["Swords Dance", "Knock Off", "Poison Jab", "Aqua Tail"]},
 	},
@@ -796,18 +824,20 @@ var SETDEX_SM = {
 		"LC Dragon Dance": {"level": 5, "evs": {"sd": 36, "at": 244, "sp": 196}, "ivs": {"hp": 17}, "nature": "Adamant", "ability": "Shed Skin", "item": "Life Orb", "moves": ["Dragon Dance", "Outrage", "Extreme Speed", "Iron Tail"]},
 	},
 	"Drifblim": {
+		"PU AcroHex": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "ivs": {"hp": 30}, "nature": "Naughty", "ability": "Unburden", "item": "Sitrus Berry", "moves": ["Acrobatics", "Substitute", "Will-O-Wisp", "Hex"]},
 		"VGC17 Tailwind Disruptor": {"level": 50, "evs": {"sd": 236, "df": 236, "hp": 12, "sp": 12, "sa": 12}, "nature": "Timid", "ability": "Unburden", "item": "Psychic Seed", "moves": ["Shadow Ball", "Tailwind", "Will-O-Wisp", "Disable"]},
 	},
 	"Drilbur": {
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 36, "at": 236, "sp": 212}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Earthquake", "Rock Slide", "Rapid Spin", "Poison Jab"]},
-		"LC All-out Attacker": {"level": 5, "evs": {"at": 236, "hp": 36, "sp": 212}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Life Orb", "moves": ["Earthquake", "Rock Slide", "Shadow Claw", "Rapid Spin"]},
 		"LC Utility": {"level": 5, "evs": {"sd": 76, "df": 36, "at": 76, "hp": 36, "sp": 212}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Berry Juice", "moves": ["Earthquake", "Rock Slide", "Stealth Rock", "Rapid Spin"]},
+		"LC All-out Attacker": {"level": 5, "evs": {"at": 236, "hp": 36, "sp": 212}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Life Orb", "moves": ["Earthquake", "Rock Slide", "Shadow Claw", "Rapid Spin"]},
 	},
 	"Druddigon": {
 		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Mold Breaker", "item": "Rocky Helmet", "moves": ["Stealth Rock", "Glare", "Dragon Tail", "Earthquake"]},
 		"NU Life Orb": {"level": 100, "evs": {"at": 252, "hp": 116, "sp": 140}, "nature": "Adamant", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Outrage", "Fire Punch", "Sucker Punch", "Gunk Shot"]},
 	},
 	"Dugtrio": {
+		"PU Suicide Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Force", "item": "Focus Sash", "moves": ["Earthquake", "Stone Edge", "Memento", "Stealth Rock"]},
 		"Uber Utility Trapper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Arena Trap", "item": "Groundium Z", "moves": ["Earthquake", "Screech", "Substitute", "Memento"]},
 		"Monotype Revenge Killer": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "ivs": {"sd": 0, "df": 0, "hp": 21}, "nature": "Naive", "ability": "Arena Trap", "item": "Focus Sash", "moves": ["Earthquake", "Reversal", "Sucker Punch", "Sludge Wave"]},
 	},
@@ -822,12 +852,16 @@ var SETDEX_SM = {
 		"RU All-out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hustle", "item": "Life Orb", "moves": ["Iron Head", "Crunch", "Superpower", "Rock Slide"]},
 		"RU Hone Claws": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hustle", "item": "Darkinium Z", "moves": ["Hone Claws", "Iron Head", "Crunch", "Superpower"]},
 		"RU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hustle", "item": "Choice Scarf", "moves": ["Iron Head", "X-Scissor", "Rock Slide", "Superpower"]},
+		"UU Hone Claws": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hustle", "item": "Fightinium Z", "moves": ["Hone Claws", "Iron Head", "Superpower", "X-Scissor"]},
 	},
 	"Dusclops": {
 		"PU Tank": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Frisk", "item": "Eviolite", "moves": ["Night Shade", "Will-O-Wisp", "Rest", "Sleep Talk"]},
 	},
 	"Dusknoir": {
 		"PU Tank": {"level": 100, "evs": {"df": 8, "at": 252, "hp": 248}, "nature": "Relaxed", "ability": "Frisk", "item": "Leftovers", "moves": ["Shadow Sneak", "Ice Punch", "Earthquake", "Will-O-Wisp"]},
+	},
+	"Duskull": {
+		"LC Bulky Utility": {"level": 5, "evs": {"sd": 116, "df": 196, "hp": 196}, "nature": "Relaxed", "ability": "Levitate", "item": "Eviolite", "moves": ["Pain Split", "Will-O-Wisp", "Substitute", "Shadow Sneak"]},
 	},
 	"Dustox": {
 		"PU Bulky Quiver Dance": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Shield Dust", "item": "Black Sludge", "moves": ["Quiver Dance", "Roost", "Sludge Bomb", "Bug Buzz"]},
@@ -846,30 +880,31 @@ var SETDEX_SM = {
 		"LC Coil Sweeper": {"level": 5, "evs": {"sd": 244, "df": 84, "hp": 156}, "nature": "Careful", "ability": "Intimidate", "item": "Berry Juice", "moves": ["Coil", "Gunk Shot", "Earthquake", "Sucker Punch"]},
 	},
 	"Electivire": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Motor Drive", "item": "Choice Scarf", "moves": ["Earthquake", "Wild Charge", "Volt Switch", "Ice Punch"]},
-		"NU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Motor Drive", "item": "Choice Scarf", "moves": ["Wild Charge", "Earthquake", "Ice Punch", "Volt Switch"]},
+		"PU Mixed Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Motor Drive", "item": "Life Orb", "moves": ["Volt Switch", "Flamethrower", "Earthquake", "Focus Blast"]},
+	},
+	"Electrike": {
+		"LC Choice Scarf": {"level": 5, "evs": {"sp": 236, "sa": 240}, "ivs": {"at": 0, "sa": 30}, "nature": "Timid", "ability": "Lightning Rod", "item": "Choice Scarf", "moves": ["Volt Switch", "Thunderbolt", "Flamethrower", "Switcheroo"]},
 	},
 	"Electrode": {
-		"PU Showdown Usage": {"level": 100, "evs": {"hp": 160, "sp": 172, "sa": 176}, "nature": "Mild", "ability": "Aftermath", "item": "Light Clay", "moves": ["Volt Switch", "Taunt", "Explosion", "Light Screen"]},
 		"NU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Soundproof", "item": "Life Orb", "moves": ["Thunderbolt", "Volt Switch", "Signal Beam", "Hidden Power Grass"]},
 	},
 	"Elekid": {
 		"LC Special Attacker": {"level": 5, "evs": {"sp": 236, "sa": 240}, "nature": "Timid", "ability": "Vital Spirit", "item": "Life Orb", "moves": ["Volt Switch", "Thunderbolt", "Psychic", "Hidden Power Grass"]},
 	},
+	"Elgyem": {
+		"LC Offensive Trick Room": {"level": 5, "evs": {"hp": 236, "sa": 240}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Analytic", "item": "Eviolite", "moves": ["Trick Room", "Nasty Plot", "Psychic", "Hidden Power Fighting"]},
+	},
 	"Emboar": {
-		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Scarf", "moves": ["Flare Blitz", "Superpower", "Wild Charge", "Sleep Talk"]},
-		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Reckless", "item": "Choice Band", "moves": ["Flare Blitz", "Superpower", "Wild Charge", "Sucker Punch"]},
 		"RU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Band", "moves": ["Flare Blitz", "Superpower", "Wild Charge", "Earthquake"]},
 	},
 	"Emolga": {
-		"PU Support": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Motor Drive", "item": "Leftovers", "moves": ["Taunt", "U-turn", "Roost", "Encore"]},
+		"PU Utility Pivot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Motor Drive", "item": "Rocky Helmet", "moves": ["Thunderbolt", "U-turn", "Encore", "Roost"]},
 	},
 	"Empoleon": {
-		"UU Utility": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Calm", "ability": "Torrent", "item": "Leftovers", "moves": ["Scald", "Defog", "Toxic", "Roar"]},
+		"UU Utility": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Calm", "ability": "Torrent", "item": "Leftovers", "moves": ["Scald", "Defog", "Toxic", "Protect"]},
 		"Monotype Utility (Water)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Torrent", "item": "Leftovers", "moves": ["Stealth Rock", "Defog", "Scald", "Roar"]},
 	},
 	"Entei": {
-		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Pressure", "item": "Choice Band", "moves": ["Sacred Fire", "Extreme Speed", "Stone Edge", "Flare Blitz"]},
 		"UU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Pressure", "item": "Choice Band", "moves": ["Sacred Fire", "Extreme Speed", "Stone Edge", "Flare Blitz"]},
 		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 52, "df": 52, "at": 252, "hp": 132, "sp": 20}, "nature": "Adamant", "ability": "Pressure", "item": "Assault Vest", "moves": ["Sacred Fire", "Stone Edge", "Stomping Tantrum", "Flame Charge"]},
 		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Pressure", "item": "Choice Band", "moves": ["Sacred Fire", "Stone Edge", "Stomping Tantrum", "Iron Head"]},
@@ -881,43 +916,45 @@ var SETDEX_SM = {
 		"RU RestTalk Swords Dance": {"level": 100, "evs": {"sd": 172, "hp": 252, "sp": 84}, "nature": "Careful", "ability": "Overcoat", "item": "Leftovers", "moves": ["Swords Dance", "Megahorn", "Rest", "Sleep Talk"]},
 	},
 	"Espeon": {
+		"RU Calm Mind": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Bounce", "item": "Leftovers", "moves": ["Calm Mind", "Psychic", "Shadow Ball", "Morning Sun"]},
 		"RU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Bounce", "item": "Choice Specs", "moves": ["Psychic", "Shadow Ball", "Dazzling Gleam", "Trick"]},
-		"RU Calm Mind": {"level": 100, "evs": {"hp": 8, "sp": 252, "sa": 248}, "nature": "Timid", "ability": "Magic Bounce", "item": "Leftovers", "moves": ["Calm Mind", "Psyshock", "Shadow Ball", "Morning Sun"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"hp": 156, "sp": 252, "sa": 100}, "nature": "Timid", "ability": "Magic Bounce", "item": "Light Clay", "moves": ["Hidden Power Fire", "Morning Sun", "Reflect", "Light Screen"]},
 		"Battle Spot Singles Dual Screens": {"level": 50, "evs": {"sd": 4, "df": 44, "hp": 236, "sp": 220, "sa": 4}, "nature": "Timid", "ability": "Magic Bounce", "item": "Light Clay", "moves": ["Yawn", "Psychic", "Reflect", "Light Screen"]},
 		"Battle Spot Singles Baton Pass Recipient": {"level": 50, "evs": {"sd": 4, "df": 220, "hp": 244, "sp": 36, "sa": 4}, "nature": "Bold", "ability": "Magic Bounce", "item": "Kee Berry", "moves": ["Stored Power", "Dazzling Gleam", "Substitute", "Morning Sun"]},
 		"Battle Spot Singles Psychium Z": {"level": 50, "evs": {"sd": 60, "df": 4, "hp": 4, "sp": 228, "sa": 212}, "nature": "Timid", "ability": "Magic Bounce", "item": "Psychium Z", "moves": ["Psychic", "Dazzling Gleam", "Calm Mind", "Morning Sun"]},
+		"AG Baton Pass Sweeper": {"level": 100, "evs": {"df": 208, "hp": 8, "sp": 224, "sa": 68}, "nature": "Modest", "ability": "Magic Bounce", "item": "Shell Bell", "moves": ["Baton Pass", "Stored Power", "Dazzling Gleam", "Substitute"]},
 	},
 	"Excadrill": {
 		"OU Focus Sash": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Focus Sash", "moves": ["Stealth Rock", "Rapid Spin", "Earthquake", "Toxic"]},
+		"OU Sand Rush Sweeper": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Rush", "item": "Steelium Z", "moves": ["Swords Dance", "Earthquake", "Iron Head", "Rapid Spin"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Earthquake", "Iron Head", "Rapid Spin", "Rock Slide"]},
-		"OU Sand Rush Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Rush", "item": "Life Orb", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Rapid Spin"]},
 		"Uber Suicide Lead": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Focus Sash", "moves": ["Stealth Rock", "Toxic", "Earthquake", "Rapid Spin"]},
 		"Uber Sand Rush": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Rush", "item": "Life Orb", "moves": ["Earthquake", "Iron Head", "Swords Dance", "Rock Slide"]},
 		"Doubles Sand Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Groundium Z", "moves": ["Earthquake", "Iron Head", "Swords Dance", "Protect"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Horn Drill"]},
 		"Battle Spot Singles Sand Sweeper": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Groundium Z", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Swords Dance"]},
 		"Battle Spot Singles Versatile Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Mold Breaker", "item": "Focus Sash", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Swords Dance"]},
+		"AG Suicide Lead": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Focus Sash", "moves": ["Stealth Rock", "Rapid Spin", "Rock Tomb", "Toxic"]},
 		"Monotype Sand Rush (Ground)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Choice Band", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Rapid Spin"]},
 		"Monotype Choice Scarf (Ground)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Rapid Spin"]},
 		"Monotype Choice Scarf (Steel)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Earthquake", "Iron Head", "Rock Slide", "Rapid Spin"]},
 	},
 	"Exeggutor": {
-		"PU Chlorophyll": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Solar Beam", "Psyshock", "Hidden Power Fire", "Sleep Powder"]},
+		"PU Chlorophyll Sweeper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Solar Beam", "Psyshock", "Hidden Power Fire", "Sleep Powder"]},
 	},
 	"Exeggutor-Alola": {
 		"PU Offensive Trick Room": {"level": 100, "evs": {"sd": 8, "hp": 248, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Frisk", "item": "Dragonium Z", "moves": ["Trick Room", "Draco Meteor", "Giga Drain", "Flamethrower"]},
 		"PU Choice Specs": {"level": 100, "evs": {"hp": 212, "sp": 44, "sa": 252}, "nature": "Modest", "ability": "Frisk", "item": "Choice Specs", "moves": ["Leaf Storm", "Draco Meteor", "Flamethrower", "Giga Drain"]},
-		"NU Trick Room": {"level": 100, "evs": {"df": 4, "hp": 252, "sa": 252}, "ivs": {"at": 0, "sp": 0}, "nature": "Quiet", "ability": "Frisk", "item": "Dragonium Z", "moves": ["Draco Meteor", "Giga Drain", "Flamethrower", "Trick Room"]},
+		"NU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Frisk", "item": "Choice Specs", "moves": ["Draco Meteor", "Leaf Storm", "Flamethrower", "Giga Drain"]},
 	},
 	"Exploud": {
 		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Scrappy", "item": "Choice Specs", "moves": ["Boomburst", "Fire Blast", "Surf", "Sleep Talk"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Scrappy", "item": "Choice Specs", "moves": ["Boomburst", "Fire Blast", "Surf", "Sleep Talk"]},
 	},
 	"Farfetch'd": {
-		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Stick", "moves": ["Swords Dance", "Brave Bird", "Leaf Blade", "Quick Attack"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Stick", "moves": ["First Impression", "Brave Bird", "Leaf Blade", "Knock Off"]},
 	},
 	"Fearow": {
-		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Choice Band", "moves": ["Drill Peck", "Double-Edge", "Drill Run", "U-turn"]},
+		"PU Critical Hit": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sniper", "item": "Scope Lens", "moves": ["Frustration", "Drill Peck", "Drill Run", "U-turn"]},
 	},
 	"Feraligatr": {
 		"RU Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Dragon Dance", "Liquidation", "Ice Punch", "Crunch"]},
@@ -927,7 +964,6 @@ var SETDEX_SM = {
 	},
 	"Ferroseed": {
 		"LC Wall": {"level": 5, "evs": {"sd": 228, "df": 108, "at": 36, "hp": 84, "sp": 36}, "nature": "Impish", "ability": "Iron Barbs", "item": "Eviolite", "moves": ["Bullet Seed", "Knock Off", "Thunder Wave", "Stealth Rock"]},
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 132, "df": 128, "hp": 248}, "nature": "Sassy", "ability": "Iron Barbs", "item": "Eviolite", "moves": ["Leech Seed", "Spikes", "Protect", "Gyro Ball"]},
 		"NU Defensive Hazard Setter": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Iron Barbs", "item": "Eviolite", "moves": ["Spikes", "Leech Seed", "Gyro Ball", "Protect"]},
 		"RU Spikes": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Iron Barbs", "item": "Eviolite", "moves": ["Spikes", "Leech Seed", "Protect", "Gyro Ball"]},
 	},
@@ -937,8 +973,12 @@ var SETDEX_SM = {
 		"Doubles Tanky Pivot": {"level": 100, "evs": {"sd": 80, "df": 88, "at": 88, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Iron Barbs", "item": "Wiki Berry", "moves": ["Gyro Ball", "Power Whip", "Stealth Rock", "Protect"]},
 		"Battle Spot Singles Support": {"level": 50, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Relaxed", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Gyro Ball", "Stealth Rock", "Leech Seed", "Protect"]},
 		"Battle Spot Singles Choice Band": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Brave", "ability": "Iron Barbs", "item": "Choice Band", "moves": ["Gyro Ball", "Bullet Seed", "Power Whip", "Knock Off"]},
+		"AG Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Leech Seed", "Gyro Ball", "Spikes", "Protect"]},
 		"Monotype Utility (Grass)": {"level": 100, "evs": {"sd": 188, "df": 68, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Leech Seed", "Protect", "Gyro Ball", "Spikes"]},
-		"Monotype Utility Support (Steel)": {"level": 100, "evs": {"sd": 184, "df": 72, "hp": 252}, "nature": "Careful", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Power Whip", "Leech Seed", "Protect", "Spikes"]},
+		"Monotype Utility (Steel)": {"level": 100, "evs": {"sd": 184, "df": 72, "hp": 252}, "nature": "Careful", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Power Whip", "Leech Seed", "Protect", "Stealth Rock"]},
+	},
+	"Fidgit": {
+		"CAP Trick Room": {"level": 100, "evs": {"sd": 208, "df": 48, "hp": 252}, "nature": "Bold", "ability": "Persistent", "item": "Iapapa Berry", "moves": ["Trick Room", "Stealth Rock", "Earth Power", "Rapid Spin"]},
 	},
 	"Finneon": {
 		"LC Defog": {"level": 5, "evs": {"sd": 112, "df": 232, "hp": 44, "sp": 72, "sa": 48}, "nature": "Bold", "ability": "Storm Drain", "item": "Berry Juice", "moves": ["Defog", "Scald", "U-turn", "Hidden Power Fighting"]},
@@ -955,20 +995,21 @@ var SETDEX_SM = {
 	},
 	"Florges": {
 		"RU Cleric Support": {"level": 100, "evs": {"df": 120, "hp": 252, "sp": 136}, "nature": "Timid", "ability": "Flower Veil", "item": "Leftovers", "moves": ["Defog", "Moonblast", "Synthesis", "Heal Bell"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Flower Veil", "item": "Leftovers", "moves": ["Moonblast", "Wish", "Protect", "Hidden Power Fire"]},
+		"UU Cleric": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Symbiosis", "item": "Leftovers", "moves": ["Moonblast", "Synthesis", "Aromatherapy", "Hidden Power Fire"]},
 	},
 	"Flygon": {
 		"RU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Dragon Dance", "Earthquake", "Outrage", "Iron Tail"]},
 		"RU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Levitate", "item": "Choice Scarf", "moves": ["U-turn", "Outrage", "Earthquake", "Dragon Claw"]},
-		"UU Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Iron Tail"]},
-		"UU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Outrage", "Earthquake", "U-turn", "Fire Punch"]},
+	},
+	"Fomantis": {
+		"LC Defensive Defog": {"level": 5, "evs": {"df": 236, "hp": 116, "sa": 120}, "nature": "Bold", "ability": "Contrary", "item": "Eviolite", "moves": ["Leaf Storm", "Defog", "Synthesis", "Hidden Power Fire"]},
 	},
 	"Foongus": {
 		"LC Defensive": {"level": 5, "evs": {"sd": 160, "df": 160, "hp": 124}, "nature": "Bold", "ability": "Regenerator", "item": "Eviolite", "moves": ["Spore", "Sludge Bomb", "Giga Drain", "Synthesis"]},
 	},
 	"Forretress": {
 		"RU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Overcoat", "item": "Leftovers", "moves": ["Gyro Ball", "Spikes", "Volt Switch", "Rapid Spin"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Relaxed", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Gyro Ball", "Volt Switch", "Spikes"]},
+		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Relaxed", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Stealth Rock", "Gyro Ball", "Spikes"]},
 		"Monotype Defensive Spinner (Bug)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Sturdy", "item": "Leftovers", "moves": ["Rapid Spin", "Stealth Rock", "Volt Switch", "Gyro Ball"]},
 	},
 	"Frillish": {
@@ -976,6 +1017,9 @@ var SETDEX_SM = {
 		"LC Choice Scarf + Water Spout": {"level": 5, "evs": {"hp": 76, "sp": 196, "sa": 236}, "nature": "Timid", "ability": "Water Absorb", "item": "Choice Scarf", "moves": ["Water Spout", "Shadow Ball", "Ice Beam", "Trick"]},
 	},
 	"Froslass": {
+		"PU Bulky Spikes": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Leftovers", "moves": ["Spikes", "Taunt", "Will-O-Wisp", "Hex"]},
+		"PU Offensive Spikes": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Icium Z", "moves": ["Spikes", "Ice Beam", "Shadow Ball", "Taunt"]},
+		"PU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Choice Specs", "moves": ["Ice Beam", "Shadow Ball", "Trick", "Spikes"]},
 		"NU Offensive Spikes": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "ivs": {"hp": 29}, "nature": "Timid", "ability": "Cursed Body", "item": "Life Orb", "moves": ["Spikes", "Ice Beam", "Shadow Ball", "Taunt"]},
 		"NU Lead": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Focus Sash", "moves": ["Spikes", "Taunt", "Ice Beam", "Destiny Bond"]},
 		"RU Spikes": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Focus Sash", "moves": ["Spikes", "Taunt", "Icy Wind", "Will-O-Wisp"]},
@@ -988,7 +1032,8 @@ var SETDEX_SM = {
 		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Frisk", "item": "Choice Scarf", "moves": ["U-turn", "Trick", "Knock Off", "Double-Edge"]},
 	},
 	"Gallade": {
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Psychium Z", "moves": ["Swords Dance", "Close Combat", "Zen Headbutt", "Knock Off"]},
+		"NU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Psycho Cut", "Leaf Blade"]},
+		"NU Substitute + Bulk Up": {"level": 100, "evs": {"sd": 92, "hp": 236, "sp": 180}, "nature": "Careful", "ability": "Justified", "item": "Leftovers", "moves": ["Substitute", "Bulk Up", "Drain Punch", "Psycho Cut"]},
 		"OU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Galladite", "moves": ["Swords Dance", "Close Combat", "Zen Headbutt", "Knock Off"]},
 		"Monotype Swords Dance (Fighting)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Galladite", "moves": ["Swords Dance", "Close Combat", "Zen Headbutt", "Knock Off"]},
 		"Monotype Swords Dance (Psychic)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Galladite", "moves": ["Swords Dance", "Close Combat", "Zen Headbutt", "Knock Off"]},
@@ -1000,17 +1045,15 @@ var SETDEX_SM = {
 	},
 	"Galvantula": {
 		"RU Sticky Web": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Compound Eyes", "item": "Life Orb", "moves": ["Sticky Web", "Thunder", "Bug Buzz", "Hidden Power Ice"]},
-		"UU Life Orb Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Compound Eyes", "item": "Life Orb", "moves": ["Sticky Web", "Thunder", "Bug Buzz", "Energy Ball"]},
 		"Monotype Sticky Web Suicide Lead (Bug)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Compound Eyes", "item": "Focus Sash", "moves": ["Sticky Web", "Thunder", "Hidden Power Ice", "Energy Ball"]},
 	},
 	"Garbodor": {
-		"NU Defensive": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Impish", "ability": "Aftermath", "item": "Rocky Helmet", "moves": ["Spikes", "Toxic Spikes", "Gunk Shot", "Seed Bomb"]},
+		"NU Defensive": {"level": 100, "evs": {"sd": 200, "hp": 252, "sp": 56}, "nature": "Careful", "ability": "Aftermath", "item": "Black Sludge", "moves": ["Spikes", "Toxic Spikes", "Gunk Shot", "Seed Bomb"]},
 		"NU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Aftermath", "item": "Poison Barb", "moves": ["Gunk Shot", "Spikes", "Toxic Spikes", "Explosion"]},
 	},
 	"Garchomp": {
 		"OU Offensive Stealth Rock": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Dragonium Z", "moves": ["Stealth Rock", "Earthquake", "Outrage", "Swords Dance"]},
 		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Life Orb", "moves": ["Swords Dance", "Earthquake", "Dragon Claw", "Fire Fang"]},
-		"OU Choice Scarf": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Choice Scarf", "moves": ["Earthquake", "Outrage", "Stone Edge", "Dragon Claw"]},
 		"OU Mega Garchomp": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Garchompite", "moves": ["Earthquake", "Dragon Claw", "Fire Fang", "Swords Dance"]},
 		"VGC17 Groundium Z": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Groundium Z", "moves": ["Earthquake", "Dragon Claw", "Poison Jab", "Protect"]},
 		"VGC17 Choice Scarf": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Rough Skin", "item": "Choice Scarf", "moves": ["Earthquake", "Dragon Claw", "Poison Jab", "Rock Slide"]},
@@ -1019,6 +1062,7 @@ var SETDEX_SM = {
 		"Battle Spot Singles Choice Attacker": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Choice Scarf", "moves": ["Earthquake", "Outrage", "Rock Slide", "Poison Jab"]},
 		"Monotype Swords Dance (Ground)": {"level": 100, "evs": {"df": 16, "at": 236, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Dragonium Z", "moves": ["Swords Dance", "Earthquake", "Outrage", "Fire Fang"]},
 		"Monotype Mixed Wallbreaker (Ground)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Rough Skin", "item": "Garchompite", "moves": ["Draco Meteor", "Earthquake", "Fire Blast", "Stone Edge"]},
+		"Monotype Stealth Rock Lead (Dragon)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Naive", "ability": "Rough Skin", "item": "Focus Sash", "moves": ["Stealth Rock", "Earthquake", "Outrage", "Fire Blast"]},
 	},
 	"Garchomp-Mega": {
 		"OU Mega Garchomp": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Rough Skin", "item": "Garchompite", "moves": ["Earthquake", "Dragon Claw", "Fire Fang", "Swords Dance"]},
@@ -1027,32 +1071,33 @@ var SETDEX_SM = {
 	"Gardevoir": {
 		"RU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Choice Scarf", "moves": ["Psyshock", "Moonblast", "Trick", "Healing Wish"]},
 		"RU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Choice Specs", "moves": ["Psyshock", "Moonblast", "Shadow Ball", "Trick"]},
-		"Doubles Trick Room": {"level": 100, "evs": {"df": 60, "hp": 220, "sa": 228}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psychic", "Trick Room", "Protect"]},
+		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Will-O-Wisp", "Psyshock", "Hyper Voice", "Focus Blast"]},
+		"Doubles Trick Room": {"level": 100, "evs": {"df": 152, "hp": 244, "sa": 112}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psychic", "Trick Room", "Protect"]},
 		"Monotype Wallbreaker (Psychic)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psyshock", "Focus Blast", "Will-O-Wisp"]},
 		"Monotype Mega Wallbreaker (Fairy)": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psyshock", "Focus Blast", "Will-O-Wisp"]},
 	},
 	"Gardevoir-Mega": {
-		"Doubles Trick Room": {"level": 100, "evs": {"df": 60, "hp": 220, "sa": 228}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psychic", "Trick Room", "Protect"]},
+		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Will-O-Wisp", "Psyshock", "Hyper Voice", "Focus Blast"]},
+		"Doubles Trick Room": {"level": 100, "evs": {"df": 152, "hp": 244, "sa": 112}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psychic", "Trick Room", "Protect"]},
 		"Monotype Wallbreaker (Psychic)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psyshock", "Focus Blast", "Will-O-Wisp"]},
 		"Monotype Mega Wallbreaker (Fairy)": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Trace", "item": "Gardevoirite", "moves": ["Hyper Voice", "Psyshock", "Focus Blast", "Will-O-Wisp"]},
 	},
 	"Gastly": {
-		"LC Hex": {"level": 5, "evs": {"sd": 76, "df": 36, "hp": 36, "sp": 196, "sa": 116}, "nature": "Timid", "ability": "Levitate", "item": "Berry Juice", "moves": ["Hex", "Will-O-Wisp", "Substitute", "Sludge Bomb"]},
 		"LC Life Orb": {"level": 5, "evs": {"sd": 80, "sp": 200, "sa": 200}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Shadow Ball", "Sludge Bomb", "Hidden Power Fighting", "Substitute"]},
+		"LC Hex": {"level": 5, "evs": {"sd": 76, "df": 36, "hp": 36, "sp": 196, "sa": 116}, "nature": "Timid", "ability": "Levitate", "item": "Berry Juice", "moves": ["Hex", "Will-O-Wisp", "Substitute", "Sludge Bomb"]},
 		"LC Lure": {"level": 5, "evs": {"sd": 76, "df": 36, "sp": 196, "sa": 196}, "nature": "Timid", "ability": "Levitate", "item": "Fairium Z", "moves": ["Dazzling Gleam", "Sludge Bomb", "Shadow Ball", "Substitute"]},
 		"LC Choice Scarf": {"level": 5, "evs": {"sd": 76, "df": 36, "sp": 196, "sa": 196}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Shadow Ball", "Sludge Bomb", "Thunderbolt", "Dazzling Gleam"]},
 	},
 	"Gastrodon": {
-		"PU Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Recover", "Scald", "Toxic", "Earth Power"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 144, "df": 100, "hp": 252, "sp": 12}, "nature": "Sassy", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Recover", "Scald", "Toxic", "Earthquake"]},
-		"UU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Scald", "Earth Power", "Recover", "Toxic"]},
 		"OU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Sassy", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Scald", "Recover", "Toxic", "Earthquake"]},
+		"Doubles Bulky Storm Drain": {"level": 100, "evs": {"sd": 84, "df": 152, "hp": 236, "sa": 36}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Storm Drain", "item": "Groundium Z", "moves": ["Earth Power", "Ice Beam", "Recover", "Protect"]},
 		"Monotype Defensive (Ground)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Scald", "Earthquake", "Recover", "Toxic"]},
 		"Monotype Mixed Wall (Water)": {"level": 100, "evs": {"sd": 236, "df": 20, "hp": 252}, "nature": "Calm", "ability": "Sticky Hold", "item": "Leftovers", "moves": ["Scald", "Earth Power", "Recover", "Toxic"]},
 	},
 	"Genesect": {
 		"Uber Special Attacker": {"level": 100, "evs": {"hp": 68, "sp": 252, "sa": 188}, "nature": "Timid", "ability": "Download", "item": "Choice Specs", "moves": ["Techno Blast", "Flamethrower", "Flash Cannon", "U-turn"]},
-		"Doubles Choice Scarf": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Hasty", "ability": "Download", "item": "Choice Scarf", "moves": ["U-turn", "Iron Head", "Ice Beam", "Explosion"]},
+		"Doubles Choice Scarf": {"level": 100, "evs": {"at": 164, "sp": 252, "sa": 92}, "nature": "Hasty", "ability": "Download", "item": "Choice Scarf", "moves": ["U-turn", "Iron Head", "Ice Beam", "Flamethrower"]},
+		"Doubles Assault Vest": {"level": 100, "evs": {"at": 192, "sp": 224, "sa": 92}, "nature": "Hasty", "ability": "Download", "item": "Assault Vest", "moves": ["U-turn", "Iron Head", "Ice Beam", "Flamethrower"]},
 	},
 	"Gengar": {
 		"UU Choice Specs": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Choice Specs", "moves": ["Shadow Ball", "Sludge Wave", "Focus Blast", "Trick"]},
@@ -1063,19 +1108,20 @@ var SETDEX_SM = {
 		"Uber Hex": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Hex", "Will-O-Wisp", "Sludge Wave", "Taunt"]},
 		"Uber Utility Trapper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Taunt", "Destiny Bond", "Sludge Wave", "Shadow Ball"]},
 		"Uber Offensive Trapper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Shadow Ball", "Sludge Wave", "Icy Wind", "Taunt"]},
-		"Doubles Special Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Sludge Bomb", "Shadow Ball", "Substitute", "Protect"]},
 		"VGC17 Standard Attacker": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Focus Sash", "moves": ["Sludge Bomb", "Shadow Ball", "Taunt", "Protect"]},
 		"Battle Spot Singles Bulky Trapper": {"level": 50, "evs": {"sd": 4, "df": 4, "hp": 236, "sp": 252, "sa": 12}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Will-O-Wisp", "Sludge Bomb", "Hex", "Destiny Bond"]},
 		"Battle Spot Singles Offensive Trapper": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Shadow Ball", "Sludge Bomb", "Destiny Bond", "Icy Wind"]},
 		"Battle Spot Singles Perish Trapper": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Perish Song", "Protect", "Substitute", "Shadow Ball"]},
 		"Battle Spot Singles Casinogar (Sleep Trapper)": {"level": 50, "evs": {"sd": 4, "df": 4, "hp": 236, "sp": 252, "sa": 12}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Hypnosis", "Substitute", "Hex", "Focus Blast"]},
+		"Monotype Choice Scarf (Ghost)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Choice Scarf", "moves": ["Shadow Ball", "Sludge Wave", "Focus Blast", "Trick"]},
+		"Monotype All-out Attacker (Ghost)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Life Orb", "moves": ["Shadow Ball", "Sludge Wave", "Focus Blast", "Taunt"]},
 		"Monotype Choice Scarf Attacker (Poison)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Choice Scarf", "moves": ["Shadow Ball", "Sludge Wave", "Focus Blast", "Trick"]},
 	},
 	"Gengar-Mega": {
 		"Uber Hex": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Hex", "Will-O-Wisp", "Sludge Wave", "Taunt"]},
 		"Uber Utility Trapper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Taunt", "Destiny Bond", "Sludge Wave", "Shadow Ball"]},
 		"Uber Offensive Trapper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Shadow Ball", "Sludge Wave", "Icy Wind", "Taunt"]},
-		"Doubles Special Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Cursed Body", "item": "Gengarite", "moves": ["Sludge Bomb", "Shadow Ball", "Substitute", "Protect"]},
+		"Doubles Showdown Usage": {"level": 100, "evs": {"df": 4, "hp": 104, "sp": 252, "sa": 148}, "nature": "Timid", "ability": "Shadow Tag", "item": "Gengarite", "moves": ["Protect", "Shadow Ball", "Sludge Bomb", "Substitute"]},
 		"Battle Spot Singles Bulky Trapper": {"level": 50, "evs": {"sd": 4, "df": 4, "hp": 236, "sp": 252, "sa": 12}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Will-O-Wisp", "Sludge Bomb", "Hex", "Destiny Bond"]},
 		"Battle Spot Singles Offensive Trapper": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Shadow Ball", "Sludge Bomb", "Destiny Bond", "Icy Wind"]},
 		"Battle Spot Singles Perish Trapper": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Gengarite", "moves": ["Perish Song", "Protect", "Substitute", "Shadow Ball"]},
@@ -1091,19 +1137,18 @@ var SETDEX_SM = {
 		"LC Stealth Rock": {"level": 5, "evs": {"sd": 156, "df": 156, "hp": 52, "sp": 20, "sa": 116}, "nature": "Bold", "ability": "Rough Skin", "item": "Berry Juice", "moves": ["Stealth Rock", "Draco Meteor", "Earth Power", "Fire Blast"]},
 	},
 	"Gigalith": {
-		"NU Specially Defensive": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Careful", "ability": "Sand Stream", "item": "Leftovers", "moves": ["Stealth Rock", "Rock Blast", "Earthquake", "Toxic"]},
-		"NU Offensive": {"level": 100, "evs": {"at": 252, "hp": 108, "sp": 148}, "nature": "Adamant", "ability": "Sand Stream", "item": "Rockium Z", "moves": ["Stone Edge", "Earthquake", "Superpower", "Stealth Rock"]},
 		"RU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sand Stream", "item": "Leftovers", "moves": ["Stealth Rock", "Stone Edge", "Earthquake", "Toxic"]},
-		"UU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sand Stream", "item": "Leftovers", "moves": ["Stone Edge", "Earthquake", "Stealth Rock", "Toxic"]},
 		"VGC17 Offensive": {"level": 50, "evs": {"sd": 100, "df": 92, "at": 84, "hp": 228}, "nature": "Brave", "ability": "Sand Stream", "item": "Rockium Z", "moves": ["Rock Slide", "Heavy Slam", "Stone Edge", "Protect"]},
 		"VGC17 Assault Vest": {"level": 50, "evs": {"df": 92, "at": 188, "hp": 228}, "nature": "Brave", "ability": "Sand Stream", "item": "Assault Vest", "moves": ["Rock Slide", "Stone Edge", "Heavy Slam", "Earthquake"]},
 		"Battle Spot Singles Sand Support": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sand Stream", "item": "Smooth Rock", "moves": ["Rock Blast", "Stealth Rock", "Explosion", "Gravity"]},
 	},
 	"Girafarig": {
-		"PU Calm Mind": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Early Bird", "item": "Leftovers", "moves": ["Calm Mind", "Rest", "Psyshock", "Dazzling Gleam"]},
+		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sap Sipper", "item": "Choice Band", "moves": ["Frustration", "Psychic Fangs", "Earthquake", "Trick"]},
 	},
 	"Giratina": {
 		"Uber Defog": {"level": 100, "evs": {"sd": 52, "df": 208, "hp": 248}, "ivs": {"sp": 30}, "nature": "Relaxed", "ability": "Pressure", "item": "Leftovers", "moves": ["Defog", "Rest", "Toxic", "Will-O-Wisp"]},
+		"BH Defensive Utility": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Magic Bounce", "item": "Griseous Orb", "moves": ["Core Enforcer", "Shore Up", "U-turn", "Spectral Thief"]},
+		"BH Poison Heal": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Core Enforcer", "Shore Up", "Will-O-Wisp", "U-turn"]},
 	},
 	"Giratina-Origin": {
 		"Uber Utility Attacker": {"level": 100, "evs": {"sd": 4, "df": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Griseous Orb", "moves": ["Hex", "Draco Meteor", "Will-O-Wisp", "Defog"]},
@@ -1113,43 +1158,44 @@ var SETDEX_SM = {
 		"PU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Ice Body", "item": "Choice Specs", "moves": ["Ice Beam", "Shadow Ball", "Hidden Power Fighting", "Frost Breath"]},
 	},
 	"Glalie": {
+		"PU Suicide Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Focus Sash", "moves": ["Spikes", "Taunt", "Icicle Crash", "Explosion"]},
 		"RU Wallbreaker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Glalitite", "moves": ["Double-Edge", "Ice Shard", "Earthquake", "Spikes"]},
+		"UU Offensive Spiker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Inner Focus", "item": "Glalitite", "moves": ["Spikes", "Return", "Freeze-Dry", "Earthquake"]},
 	},
 	"Glalie-Mega": {
 		"RU Wallbreaker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Glalitite", "moves": ["Double-Edge", "Ice Shard", "Earthquake", "Spikes"]},
+		"UU Offensive Spiker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Inner Focus", "item": "Glalitite", "moves": ["Spikes", "Return", "Freeze-Dry", "Earthquake"]},
 	},
 	"Gligar": {
 		"RU Defensive Utility": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Impish", "ability": "Immunity", "item": "Eviolite", "moves": ["Roost", "Defog", "Earthquake", "Toxic"]},
 		"RU Stallbreaker": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Impish", "ability": "Immunity", "item": "Eviolite", "moves": ["Taunt", "Toxic", "Earthquake", "Roost"]},
+		"UU Defensive Utility": {"level": 100, "evs": {"sd": 100, "df": 156, "hp": 252}, "nature": "Impish", "ability": "Immunity", "item": "Eviolite", "moves": ["Earthquake", "Roost", "Defog", "U-turn"]},
 	},
 	"Gliscor": {
-		"UU Swords Dance Stallbreaker": {"level": 100, "evs": {"at": 68, "hp": 252, "sp": 188}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Swords Dance", "Earthquake", "Roost", "Facade"]},
-		"UU Stealth Rock": {"level": 100, "evs": {"sd": 196, "hp": 252, "sp": 60}, "nature": "Careful", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Stealth Rock", "Earthquake", "Roost", "U-turn"]},
-		"UU SubToxic": {"level": 100, "evs": {"sd": 76, "hp": 244, "sp": 188}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Earthquake", "Toxic", "Substitute", "Protect"]},
-		"UU Defog": {"level": 100, "evs": {"sd": 196, "hp": 252, "sp": 60}, "nature": "Careful", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Defog", "Earthquake", "Roost", "Toxic"]},
-		"UU Double Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Hyper Cutter", "item": "Groundium Z", "moves": ["Earthquake", "Ice Fang", "Swords Dance", "Rock Polish"]},
 		"OU Swords Dance": {"level": 100, "evs": {"sd": 68, "df": 44, "hp": 244, "sp": 152}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Swords Dance", "Roost", "Earthquake", "Facade"]},
-		"OU Stealth Rock": {"level": 100, "evs": {"sd": 108, "df": 44, "hp": 244, "sp": 112}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Stealth Rock", "Earthquake", "U-turn", "Roost"]},
+		"OU Stealth Rock": {"level": 100, "evs": {"sd": 108, "df": 44, "hp": 244, "sp": 112}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Stealth Rock", "Earthquake", "Toxic", "Roost"]},
 		"OU Defog": {"level": 100, "evs": {"sd": 152, "hp": 244, "sp": 112}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Earthquake", "Defog", "Roost", "Knock Off"]},
 		"OU Stallbreaker": {"level": 100, "evs": {"sd": 68, "df": 44, "hp": 244, "sp": 152}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Earthquake", "Knock Off", "Roost", "Taunt"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"sd": 132, "at": 76, "hp": 252, "sp": 48}, "nature": "Careful", "ability": "Hyper Cutter", "item": "Misty Seed", "moves": ["Tailwind", "Roost", "Swords Dance", "Acrobatics"]},
 	},
 	"Gogoat": {
 		"PU Bulk Up": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Sap Sipper", "item": "Leftovers", "moves": ["Bulk Up", "Horn Leech", "Earthquake", "Milk Drink"]},
 	},
 	"Golbat": {
-		"NU Defensive": {"level": 100, "evs": {"df": 172, "hp": 240, "sp": 96}, "nature": "Impish", "ability": "Infiltrator", "item": "Eviolite", "moves": ["Roost", "Brave Bird", "Defog", "Taunt"]},
+		"NU Defensive": {"level": 100, "evs": {"sd": 80, "hp": 252, "sp": 176}, "nature": "Jolly", "ability": "Infiltrator", "item": "Eviolite", "moves": ["Brave Bird", "Toxic", "Defog", "Roost"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Infiltrator", "item": "Eviolite", "moves": ["Roost", "Defog", "Brave Bird", "Toxic"]},
 	},
 	"Goldeen": {
 		"LC Supersonic Skystrike": {"level": 5, "evs": {"sd": 36, "at": 220, "sp": 252}, "nature": "Jolly", "ability": "Lightning Rod", "item": "Flyinium Z", "moves": ["Bounce", "Waterfall", "Drill Run", "Knock Off"]},
 	},
 	"Golduck": {
+		"PU Rain Sweeper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Rain Dance", "Hydro Pump", "Ice Beam", "Hidden Power Grass"]},
 		"VGC17 Swift Swim Attacker": {"level": 50, "evs": {"hp": 132, "sp": 124, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Waterium Z", "moves": ["Hydro Pump", "Scald", "Ice Beam", "Protect"]},
 	},
 	"Golem": {
-		"PU Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Weakness Policy", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Sucker Punch"]},
+		"PU Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Weakness Policy", "moves": ["Stealth Rock", "Earthquake", "Stone Edge", "Explosion"]},
 	},
 	"Golem-Alola": {
+		"RU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 84, "sp": 172}, "nature": "Adamant", "ability": "Magnet Pull", "item": "Choice Band", "moves": ["Wild Charge", "Stone Edge", "Explosion", "Fire Punch"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Wild Charge", "Earthquake", "Fire Punch", "Explosion"]},
 		"Monotype Suicide Lead (Electric)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Galvanize", "item": "Focus Sash", "moves": ["Stealth Rock", "Return", "Stone Edge", "Explosion"]},
 		"Monotype Specially Defensive (Electric)": {"level": 100, "evs": {"sd": 56, "hp": 248, "sp": 204}, "nature": "Careful", "ability": "Galvanize", "item": "Leftovers", "moves": ["Stealth Rock", "Return", "Stone Edge", "Earthquake"]},
@@ -1189,17 +1235,12 @@ var SETDEX_SM = {
 	},
 	"Gourgeist-Super": {
 		"PU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Frisk", "item": "Colbur Berry", "moves": ["Will-O-Wisp", "Synthesis", "Foul Play", "Leech Seed"]},
-		"NU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Frisk", "item": "Colbur Berry", "moves": ["Will-O-Wisp", "Synthesis", "Leech Seed", "Foul Play"]},
-	},
-	"Granbull": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Leftovers", "moves": ["Play Rough", "Earthquake", "Heal Bell", "Fire Punch"]},
-		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Normalium Z", "moves": ["Play Rough", "Earthquake", "Heal Bell", "Thunder Wave"]},
 	},
 	"Greninja": {
-		"OU Spikes": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Protean", "item": "Waterium Z", "moves": ["Spikes", "Hydro Pump", "Gunk Shot", "Hidden Power Fire"]},
-		"OU Choice Scarf": {"level": 100, "evs": {"at": 176, "sp": 252, "sa": 80}, "nature": "Naive", "ability": "Protean", "item": "Choice Scarf", "moves": ["Rock Slide", "U-turn", "Ice Beam", "Spikes"]},
+		"OU Specially Based Protean": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Protean", "item": "Waterium Z", "moves": ["Hydro Pump", "Ice Beam", "Hidden Power Fire", "Spikes"]},
+		"OU Physically Based Protean": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Hasty", "ability": "Protean", "item": "Fightinium Z", "moves": ["Low Kick", "Gunk Shot", "Ice Beam", "Spikes"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"at": 176, "sp": 252, "sa": 80}, "nature": "Hasty", "ability": "Protean", "item": "Choice Scarf", "moves": ["Rock Slide", "U-turn", "Ice Beam", "Spikes"]},
 		"OU Dual Hazards": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Protean", "item": "Focus Sash", "moves": ["Spikes", "Toxic Spikes", "Taunt", "Ice Beam"]},
-		"OU All-out Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Protean", "item": "Life Orb", "moves": ["Hydro Pump", "Extrasensory", "Gunk Shot", "Hidden Power Fire"]},
 		"Battle Spot Singles Sweeper": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Protean", "item": "Life Orb", "moves": ["Ice Beam", "Gunk Shot", "Water Shuriken", "Dark Pulse"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Protean", "item": "Choice Scarf", "moves": ["Ice Beam", "Gunk Shot", "Rock Slide", "Dark Pulse"]},
 		"Battle Spot Singles Z-Happy Hour": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Protean", "item": "Normalium Z", "moves": ["Happy Hour", "Ice Beam", "Gunk Shot", "Dark Pulse"]},
@@ -1211,6 +1252,10 @@ var SETDEX_SM = {
 	},
 	"Greninja-Ash": {
 		"OU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Battle Bond", "item": "Choice Specs", "moves": ["Hydro Pump", "Dark Pulse", "Water Shuriken", "Spikes"]},
+		"CAP Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Battle Bond", "item": "Choice Specs", "moves": ["Hydro Pump", "Dark Pulse", "Water Shuriken", "Spikes"]},
+	},
+	"Grimer": {
+		"LC Tank": {"level": 5, "evs": {"sd": 36, "df": 196, "at": 196, "hp": 36, "sa": 36}, "nature": "Brave", "ability": "Sticky Hold", "item": "Berry Juice", "moves": ["Gunk Shot", "Fire Punch", "Giga Drain", "Thief"]},
 	},
 	"Grimer-Alola": {
 		"LC Pursuit Trap": {"level": 5, "evs": {"sd": 36, "df": 196, "at": 196, "hp": 36}, "nature": "Adamant", "ability": "Poison Touch", "item": "Eviolite", "moves": ["Pursuit", "Knock Off", "Poison Jab", "Shadow Sneak"]},
@@ -1236,14 +1281,14 @@ var SETDEX_SM = {
 		"PU Calm Mind": {"level": 100, "evs": {"hp": 80, "sp": 176, "sa": 252}, "nature": "Timid", "ability": "Thick Fat", "item": "Fightinium Z", "moves": ["Calm Mind", "Psychic", "Focus Blast", "Thunder Wave"]},
 	},
 	"Gumshoos": {
-		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Adaptability", "item": "Choice Band", "moves": ["Return", "Earthquake", "Crunch", "Facade"]},
+		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Stakeout", "item": "Choice Band", "moves": ["Return", "Earthquake", "U-turn", "Crunch"]},
 	},
 	"Gurdurr": {
 		"PU Bulky Attacker": {"level": 100, "evs": {"df": 64, "at": 192, "hp": 252}, "nature": "Adamant", "ability": "Guts", "item": "Eviolite", "moves": ["Drain Punch", "Mach Punch", "Knock Off", "Bulk Up"]},
-		"NU Bulky Physical Attacker": {"level": 100, "evs": {"df": 32, "at": 224, "hp": 252}, "nature": "Adamant", "ability": "Iron Fist", "item": "Eviolite", "moves": ["Drain Punch", "Ice Punch", "Mach Punch", "Knock Off"]},
 	},
 	"Guzzlord": {
-		"NU Wallbreaker": {"level": 100, "evs": {"sd": 196, "sp": 60, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Choice Specs", "moves": ["Draco Meteor", "Dark Pulse", "Fire Blast", "Sludge Bomb"]},
+		"NU Choice Specs": {"level": 100, "evs": {"df": 196, "sp": 60, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Choice Specs", "moves": ["Draco Meteor", "Dark Pulse", "Fire Blast", "Hidden Power Steel"]},
+		"NU Dragonium Z": {"level": 100, "evs": {"df": 196, "sp": 60, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Dragonium Z", "moves": ["Draco Meteor", "Dark Pulse", "Fire Blast", "Heavy Slam"]},
 	},
 	"Gyarados": {
 		"OU Dragon Dance Sweeper": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Flyinium Z", "moves": ["Dragon Dance", "Bounce", "Waterfall", "Earthquake"]},
@@ -1267,7 +1312,7 @@ var SETDEX_SM = {
 		"PU Life Orb": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Shadow Ball", "Sludge Bomb", "Hidden Power Ground", "Destiny Bond"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Shadow Ball", "Sludge Wave", "Destiny Bond", "Trick"]},
 		"NU SubSplit": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Sludge Bomb", "Shadow Ball", "Substitute", "Pain Split"]},
-		"NU All Out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Sludge Bomb", "Shadow Ball", "Dazzling Gleam", "Destiny Bond"]},
+		"NU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Sludge Wave", "Shadow Ball", "Dazzling Gleam", "Destiny Bond"]},
 	},
 	"Hawlucha": {
 		"OU Terrain Seed Sweeper": {"level": 100, "evs": {"sd": 36, "at": 252, "hp": 96, "sp": 124}, "nature": "Adamant", "ability": "Unburden", "item": "Electric Seed", "moves": ["Acrobatics", "Swords Dance", "High Jump Kick", "Roost"]},
@@ -1275,19 +1320,16 @@ var SETDEX_SM = {
 		"Monotype Substitute + Swords Dance": {"level": 100, "evs": {"at": 244, "hp": 12, "sp": 252}, "nature": "Jolly", "ability": "Unburden", "item": "Sitrus Berry", "moves": ["Substitute", "Swords Dance", "Acrobatics", "High Jump Kick"]},
 	},
 	"Haxorus": {
-		"UU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Life Orb", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Poison Jab"]},
-		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Lum Berry", "moves": ["Swords Dance", "Outrage", "Earthquake", "Poison Jab"]},
-		"UU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Band", "moves": ["Outrage", "Earthquake", "Poison Jab", "Superpower"]},
+		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Dragonium Z", "moves": ["Swords Dance", "Outrage", "Earthquake", "Poison Jab"]},
+		"UU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Poison Jab"]},
 	},
 	"Heatmor": {
 		"PU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Flash Fire", "item": "Life Orb", "moves": ["Fire Lash", "Sucker Punch", "Giga Drain", "Knock Off"]},
 	},
 	"Heatran": {
-		"OU Steelium Z": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Steelium Z", "moves": ["Flash Cannon", "Lava Plume", "Earth Power", "Stealth Rock"]},
-		"OU Utility": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Magma Storm", "Earth Power", "Taunt", "Toxic"]},
-		"OU Z-Move Trapper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Firium Z", "moves": ["Magma Storm", "Earth Power", "Taunt", "Toxic"]},
-		"OU Specially Defensive": {"level": 100, "evs": {"sd": 132, "hp": 248, "sp": 128}, "nature": "Calm", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Magma Storm", "Toxic", "Protect", "Taunt"]},
-		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Scarf", "moves": ["Fire Blast", "Flash Cannon", "Earth Power", "Stone Edge"]},
+		"OU Z-Move Trapper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Firium Z", "moves": ["Magma Storm", "Earth Power", "Taunt", "Toxic"]},
+		"OU Specially Defensive": {"level": 100, "evs": {"sd": 128, "hp": 252, "sp": 128}, "nature": "Calm", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Lava Plume", "Earth Power", "Stealth Rock", "Toxic"]},
+		"OU Steelium Z": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Steelium Z", "moves": ["Flash Cannon", "Lava Plume", "Earth Power", "Stealth Rock"]},
 		"Doubles Protect + 3 Attacks": {"level": 100, "evs": {"df": 4, "hp": 8, "sp": 252, "sa": 244}, "nature": "Modest", "ability": "Flash Fire", "item": "Shuca Berry", "moves": ["Heat Wave", "Earth Power", "Hidden Power Ice", "Protect"]},
 		"Doubles Eruption": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 7}, "nature": "Quiet", "ability": "Flash Fire", "item": "Firium Z", "moves": ["Eruption", "Earth Power", "Heat Wave", "Protect"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Choice Specs", "moves": ["Flamethrower", "Flash Cannon", "Earth Power", "Ancient Power"]},
@@ -1296,20 +1338,24 @@ var SETDEX_SM = {
 		"Battle Spot Doubles Standard Heatran": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Flash Fire", "item": "Shuca Berry", "moves": ["Heat Wave", "Earth Power", "Flash Cannon", "Protect"]},
 		"Monotype Trapper (Steel)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Air Balloon", "moves": ["Magma Storm", "Earth Power", "Taunt", "Stealth Rock"]},
 		"Monotype Defensive (Steel)": {"level": 100, "evs": {"sd": 184, "at": 28, "hp": 252, "sp": 44}, "nature": "Calm", "ability": "Flash Fire", "item": "Leftovers", "moves": ["Lava Plume", "Earth Power", "Stone Edge", "Stealth Rock"]},
+		"Monotype Utility Attacker (Fire)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Air Balloon", "moves": ["Magma Storm", "Earth Power", "Taunt", "Flash Cannon"]},
 	},
 	"Heliolisk": {
-		"NU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Volt Switch", "Hyper Voice", "Dark Pulse", "Surf"]},
-		"RU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Volt Switch", "Surf", "Thunderbolt", "Hyper Voice"]},
+		"NU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Choice Specs", "moves": ["Volt Switch", "Hyper Voice", "Thunderbolt", "Surf"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Electrium Z", "moves": ["Volt Switch", "Hyper Voice", "Thunderbolt", "Surf"]},
+	},
+	"Helioptile": {
+		"LC Life Orb": {"level": 5, "evs": {"sd": 16, "df": 92, "sp": 196, "sa": 192}, "ivs": {"hp": 11}, "nature": "Timid", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Thunderbolt", "Surf", "Glare", "U-turn"]},
 	},
 	"Heracross": {
 		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Flame Orb", "moves": ["Swords Dance", "Close Combat", "Knock Off", "Facade"]},
-		"OU Wallbreaker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Heracronite", "moves": ["Close Combat", "Pin Missile", "Rock Blast", "Swords Dance"]},
+		"OU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Heracronite", "moves": ["Swords Dance", "Close Combat", "Rock Blast", "Pin Missile"]},
 		"Battle Spot Singles Mega Wallbreaker": {"level": 50, "evs": {"at": 252, "hp": 20, "sp": 236}, "nature": "Adamant", "ability": "Guts", "item": "Heracronite", "moves": ["Pin Missile", "Rock Blast", "Bullet Seed", "Close Combat"]},
 		"Monotype Choice Scarf (Fighting)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Choice Scarf", "moves": ["Megahorn", "Close Combat", "Knock Off", "Stone Edge"]},
 		"Monotype Moxie Choice Scarf (Bug)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Choice Scarf", "moves": ["Close Combat", "Megahorn", "Stone Edge", "Pursuit"]},
 	},
 	"Heracross-Mega": {
-		"OU Wallbreaker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Heracronite", "moves": ["Close Combat", "Pin Missile", "Rock Blast", "Swords Dance"]},
+		"OU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Heracronite", "moves": ["Swords Dance", "Close Combat", "Rock Blast", "Pin Missile"]},
 		"Battle Spot Singles Mega Wallbreaker": {"level": 50, "evs": {"at": 252, "hp": 20, "sp": 236}, "nature": "Adamant", "ability": "Guts", "item": "Heracronite", "moves": ["Pin Missile", "Rock Blast", "Bullet Seed", "Close Combat"]},
 	},
 	"Hippopotas": {
@@ -1321,19 +1367,21 @@ var SETDEX_SM = {
 		"Monotype Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Sand Stream", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Slack Off", "Whirlwind"]},
 	},
 	"Hitmonchan": {
-		"PU Assault Vest": {"level": 100, "evs": {"at": 152, "hp": 244, "sp": 112}, "nature": "Adamant", "ability": "Iron Fist", "item": "Assault Vest", "moves": ["Drain Punch", "Mach Punch", "Ice Punch", "Rapid Spin"]},
-		"PU Physical Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Iron Fist", "item": "Life Orb", "moves": ["Drain Punch", "Mach Punch", "Ice Punch", "Rapid Spin"]},
+		"PU Assault Vest": {"level": 100, "evs": {"at": 136, "hp": 244, "sp": 128}, "nature": "Adamant", "ability": "Iron Fist", "item": "Assault Vest", "moves": ["Drain Punch", "Mach Punch", "Thunder Punch", "Rapid Spin"]},
+		"PU Physical Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Iron Fist", "item": "Life Orb", "moves": ["Drain Punch", "Mach Punch", "Thunder Punch", "Rapid Spin"]},
 	},
 	"Hitmonlee": {
 		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Life Orb", "moves": ["High Jump Kick", "Mach Punch", "Knock Off", "Rapid Spin"]},
 		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Scarf", "moves": ["High Jump Kick", "Knock Off", "Rapid Spin", "Stone Edge"]},
 		"NU Unburden": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Unburden", "item": "White Herb", "moves": ["Curse", "Close Combat", "Stone Edge", "Blaze Kick"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Fist Plate", "moves": ["Knock Off", "High Jump Kick", "Bulk Up", "Foresight"]},
 	},
 	"Hitmontop": {
 		"NU Rapid Spin": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Rapid Spin", "Close Combat", "Toxic", "Foresight"]},
 	},
 	"Ho-Oh": {
 		"Uber Defensive": {"level": 100, "evs": {"sd": 52, "df": 204, "hp": 252}, "nature": "Impish", "ability": "Regenerator", "item": "Leftovers", "moves": ["Sacred Fire", "Recover", "Toxic", "Defog"]},
+		"Uber Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Regenerator", "item": "Choice Scarf", "moves": ["Brave Bird", "Sacred Fire", "Toxic", "Defog"]},
 		"Uber Tank": {"level": 100, "evs": {"at": 252, "hp": 104, "sp": 152}, "nature": "Adamant", "ability": "Regenerator", "item": "Life Orb", "moves": ["Sacred Fire", "Brave Bird", "Recover", "Toxic"]},
 		"Uber Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Regenerator", "item": "Choice Band", "moves": ["Sacred Fire", "Brave Bird", "Earthquake", "Toxic"]},
 	},
@@ -1358,7 +1406,8 @@ var SETDEX_SM = {
 		"LC Bulky Support": {"level": 5, "evs": {"sd": 156, "df": 196, "hp": 156}, "nature": "Impish", "ability": "Infiltrator", "item": "Eviolite", "moves": ["Strength Sap", "Sleep Powder", "Bullet Seed", "U-turn"]},
 	},
 	"Houndoom": {
-		"NU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Darkinium Z", "moves": ["Nasty Plot", "Fire Blast", "Dark Pulse", "Flame Charge"]},
+		"NU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Darkinium Z", "moves": ["Nasty Plot", "Fire Blast", "Dark Pulse", "Hidden Power Steel"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Darkinium Z", "moves": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Taunt"]},
 		"UU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Houndoominite", "moves": ["Nasty Plot", "Fire Blast", "Dark Pulse", "Sludge Bomb"]},
 	},
 	"Houndoom-Mega": {
@@ -1373,11 +1422,11 @@ var SETDEX_SM = {
 	},
 	"Hydreigon": {
 		"UU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Dark Pulse", "U-turn", "Fire Blast"]},
+		"UU Defog": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Defog", "Dark Pulse", "Roost", "Draco Meteor"]},
+		"UU Taunt": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Taunt", "Dark Pulse", "Roost", "Draco Meteor"]},
 		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Specs", "moves": ["Draco Meteor", "Dark Pulse", "Flash Cannon", "Fire Blast"]},
 		"UU Life Orb Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Draco Meteor", "Dark Pulse", "Roost", "Fire Blast"]},
-		"UU Taunt": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Taunt", "Dark Pulse", "Roost", "Draco Meteor"]},
-		"UU Offensive Defog": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Defog", "Draco Meteor", "Roost", "Dark Pulse"]},
-		"OU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Specs", "moves": ["Draco Meteor", "Dark Pulse", "Flash Cannon", "Fire Blast"]},
+		"OU Darkinium Z": {"level": 100, "evs": {"sd": 32, "sp": 232, "sa": 244}, "nature": "Timid", "ability": "Levitate", "item": "Darkinium Z", "moves": ["Dark Pulse", "Earth Power", "Flash Cannon", "Roost"]},
 		"Doubles Special Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Draco Meteor", "Dark Pulse", "Tailwind", "Protect"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Dark Pulse", "Draco Meteor", "Fire Blast", "U-turn"]},
 		"Battle Spot Singles Choice Specs": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Specs", "moves": ["Dark Pulse", "Draco Meteor", "Fire Blast", "U-turn"]},
@@ -1388,22 +1437,22 @@ var SETDEX_SM = {
 		"Monotype Choice Scarf (Dragon)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Dark Pulse", "Draco Meteor", "Fire Blast", "U-turn"]},
 	},
 	"Hypno": {
-		"PU Specially Defensive": {"level": 100, "evs": {"sd": 204, "df": 52, "hp": 252}, "nature": "Calm", "ability": "Insomnia", "item": "Leftovers", "moves": ["Wish", "Protect", "Toxic", "Foul Play"]},
+		"PU Z-Hypnosis Belly Drum": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Insomnia", "item": "Psychium Z", "moves": ["Hypnosis", "Belly Drum", "Zen Headbutt", "Drain Punch"]},
 	},
 	"Illumise": {
-		"PU Weather Setter": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Prankster", "item": "Damp Rock", "moves": ["Sunny Day", "U-turn", "Encore", "Thunder Wave"]},
+		"PU Weather Setter": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Prankster", "item": "Heat Rock", "moves": ["Sunny Day", "U-turn", "Thunder Wave", "Encore"]},
 	},
 	"Incineroar": {
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Incinium Z", "moves": ["Swords Dance", "Flare Blitz", "Darkest Lariat", "Earthquake"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Assault Vest", "moves": ["Knock Off", "U-turn", "Flare Blitz", "Fake Out"]},
-		"Doubles Intimidate Support": {"level": 100, "evs": {"sd": 24, "df": 16, "at": 216, "hp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Assault Vest", "moves": ["Fake Out", "Flare Blitz", "Knock Off", "U-turn"]},
+		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Incinium Z", "moves": ["Swords Dance", "Darkest Lariat", "Earthquake", "Flare Blitz"]},
+		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 132, "df": 132, "hp": 244}, "nature": "Sassy", "ability": "Intimidate", "item": "Iapapa Berry", "moves": ["Knock Off", "U-turn", "Fire Blast", "Earthquake"]},
+		"Doubles Utility Attacker": {"level": 100, "evs": {"sd": 116, "df": 20, "at": 108, "hp": 252, "sp": 12}, "nature": "Adamant", "ability": "Intimidate", "item": "Figy Berry", "moves": ["Fake Out", "Flare Blitz", "Knock Off", "U-turn"]},
 	},
 	"Infernape": {
+		"UU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Fightinium Z", "moves": ["Nasty Plot", "Fire Blast", "Focus Blast", "Vacuum Wave"]},
 		"UU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Choice Scarf", "moves": ["Flare Blitz", "U-turn", "Close Combat", "Gunk Shot"]},
+		"UU Mixed Attacker": {"level": 100, "evs": {"at": 168, "sp": 252, "sa": 88}, "nature": "Naive", "ability": "Blaze", "item": "Life Orb", "moves": ["Overheat", "Close Combat", "Slack Off", "Grass Knot"]},
 		"UU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Choice Band", "moves": ["Flare Blitz", "U-turn", "Close Combat", "Mach Punch"]},
-		"UU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Fightinium Z", "moves": ["Nasty Plot", "Fire Blast", "Vacuum Wave", "Focus Blast"]},
-		"UU Mixed Attacker": {"level": 100, "evs": {"at": 168, "sp": 252, "sa": 88}, "nature": "Naive", "ability": "Blaze", "item": "Life Orb", "moves": ["Overheat", "Close Combat", "Grass Knot", "Gunk Shot"]},
-		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Electrium Z", "moves": ["Swords Dance", "Flare Blitz", "Close Combat", "Thunder Punch"]},
+		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Fightinium Z", "moves": ["Swords Dance", "Close Combat", "Flare Blitz", "Mach Punch"]},
 		"Monotype Choice Band (Fire)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Choice Band", "moves": ["Flare Blitz", "Close Combat", "U-turn", "Mach Punch"]},
 		"Monotype Choice Scarf (Fire)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Blaze", "item": "Choice Scarf", "moves": ["Flare Blitz", "Close Combat", "U-turn", "Stone Edge"]},
 	},
@@ -1414,15 +1463,17 @@ var SETDEX_SM = {
 		"LC Dragon Dance": {"level": 5, "evs": {"at": 236, "sp": 236}, "nature": "Adamant", "ability": "Bulletproof", "item": "Berry Juice", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Brick Break"]},
 	},
 	"Jellicent": {
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "hp": 252, "sa": 4}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Recover", "Scald", "Will-O-Wisp", "Taunt"]},
+		"PU Wallbreaker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Water Spout", "Hydro Pump", "Shadow Ball", "Ice Beam"]},
+		"PU Utility": {"level": 100, "evs": {"df": 224, "hp": 252, "sp": 32}, "nature": "Bold", "ability": "Water Absorb", "item": "Colbur Berry", "moves": ["Scald", "Taunt", "Recover", "Will-O-Wisp"]},
+		"NU Utility": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Water Absorb", "item": "Colbur Berry", "moves": ["Taunt", "Will-O-Wisp", "Scald", "Recover"]},
 		"RU Physically Defensive": {"level": 100, "evs": {"df": 176, "hp": 248, "sp": 84}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Taunt", "Will-O-Wisp", "Recover"]},
-		"UU Physically Defensive": {"level": 100, "evs": {"df": 176, "hp": 248, "sp": 84}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Taunt", "Will-O-Wisp", "Recover"]},
+		"UU Physically Defensive": {"level": 100, "evs": {"df": 172, "hp": 252, "sp": 84}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Hex", "Taunt", "Will-O-Wisp", "Recover"]},
 		"Battle Spot Singles Wall": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Cursed Body", "item": "Sitrus Berry", "moves": ["Scald", "Recover", "Will-O-Wisp", "Taunt"]},
 		"Monotype Utility (Ghost)": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Taunt", "Scald", "Toxic", "Recover"]},
 	},
 	"Jirachi": {
 		"OU Wish": {"level": 100, "evs": {"sd": 196, "hp": 248, "sp": 64}, "nature": "Careful", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Wish", "Protect", "Iron Head", "U-turn"]},
-		"OU Stealth Rock": {"level": 100, "evs": {"sd": 108, "hp": 248, "sp": 152}, "nature": "Careful", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Stealth Rock", "Iron Head", "U-turn", "Healing Wish"]},
+		"OU Stealth Rock": {"level": 100, "evs": {"sd": 196, "hp": 248, "sp": 64}, "nature": "Careful", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Stealth Rock", "Iron Head", "U-turn", "Healing Wish"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Serene Grace", "item": "Choice Scarf", "moves": ["Iron Head", "U-turn", "Healing Wish", "Fire Punch"]},
 		"Monotype Specially Defensive (Psychic)": {"level": 100, "evs": {"sd": 176, "hp": 252, "sp": 80}, "nature": "Careful", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Iron Head", "Stealth Rock", "Toxic", "U-turn"]},
 		"Monotype Z-Happy Hour (Steel)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Serene Grace", "item": "Normalium Z", "moves": ["Happy Hour", "Psychic", "Thunderbolt", "Iron Head"]},
@@ -1431,47 +1482,51 @@ var SETDEX_SM = {
 		"RU Special Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Volt Absorb", "item": "Life Orb", "moves": ["Thunderbolt", "Volt Switch", "Hidden Power Ice", "Shadow Ball"]},
 	},
 	"Jumpluff": {
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Infiltrator", "moves": ["Swords Dance", "Strength Sap", "Sleep Powder", "Acrobatics"]},
 		"PU Fast Pivot": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Infiltrator", "moves": ["U-turn", "Acrobatics", "Sleep Powder", "Memento"]},
 	},
 	"Jynx": {
 		"PU Nasty Thot (Z-Lovely Kiss)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Normalium Z", "moves": ["Lovely Kiss", "Nasty Plot", "Ice Beam", "Psyshock"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Choice Scarf", "moves": ["Ice Beam", "Psychic", "Focus Blast", "Lovely Kiss"]},
 		"PU Substitute + Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Normalium Z", "moves": ["Substitute", "Nasty Plot", "Lovely Kiss", "Ice Beam"]},
-		"NU Lovely Kiss": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Normalium Z", "moves": ["Lovely Kiss", "Psyshock", "Ice Beam", "Nasty Plot"]},
 	},
 	"Kabuto": {
 		"LC Offensive Support": {"level": 5, "evs": {"sd": 156, "df": 36, "at": 36, "hp": 116, "sp": 156}, "nature": "Careful", "ability": "Weak Armor", "item": "Eviolite", "moves": ["Rapid Spin", "Stealth Rock", "Knock Off", "Rock Slide"]},
 	},
 	"Kabutops": {
-		"PU Rain Sweeper": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Swift Swim", "item": "Rockium Z", "moves": ["Waterfall", "Stone Edge", "Swords Dance", "Superpower"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Weak Armor", "item": "Rockium Z", "moves": ["Stone Edge", "Rapid Spin", "Waterfall", "Swords Dance"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Swift Swim", "item": "Choice Scarf", "moves": ["Liquidation", "Stone Edge", "Knock Off", "Rapid Spin"]},
+		"PU Rain Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Rockium Z", "moves": ["Swords Dance", "Stone Edge", "Liquidation", "Superpower"]},
 		"UU Suicide Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Weak Armor", "item": "Focus Sash", "moves": ["Stealth Rock", "Rapid Spin", "Rock Tomb", "Toxic"]},
 	},
 	"Kadabra": {
 		"PU Focus Sash Revenge Killer": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Focus Sash", "moves": ["Psychic", "Counter", "Taunt", "Dazzling Gleam"]},
-		"NU Focus Sash": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Focus Sash", "moves": ["Psychic", "Dazzling Gleam", "Thunder Wave", "Counter"]},
 	},
 	"Kangaskhan": {
-		"PU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Silk Scarf", "moves": ["Fake Out", "Double-Edge", "Earthquake", "Sucker Punch"]},
+		"PU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Silk Scarf", "moves": ["Fake Out", "Double-Edge", "Earthquake", "Sucker Punch"]},
+		"PU Power-Up Punch + Z-Move": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Fightinium Z", "moves": ["Power-Up Punch", "Double-Edge", "Sucker Punch", "Focus Punch"]},
 		"Uber Utility Attacker": {"level": 100, "evs": {"at": 148, "hp": 108, "sp": 252}, "nature": "Jolly", "ability": "Scrappy", "item": "Kangaskhanite", "moves": ["Fake Out", "Seismic Toss", "Crunch", "Body Slam"]},
 		"Battle Spot Singles Sweeper": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Kangaskhanite", "moves": ["Power-Up Punch", "Double-Edge", "Earthquake", "Sucker Punch"]},
+		"BH Wallbreaker": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Jolly", "ability": "Misty Surge", "item": "Kangaskhanite", "moves": ["Nature\u0027s Madness", "Night Shade", "Strength Sap", "Extreme Speed"]},
 	},
 	"Kangaskhan-Mega": {
 		"Uber Utility Attacker": {"level": 100, "evs": {"at": 148, "hp": 108, "sp": 252}, "nature": "Jolly", "ability": "Scrappy", "item": "Kangaskhanite", "moves": ["Fake Out", "Seismic Toss", "Crunch", "Body Slam"]},
 		"Battle Spot Singles Sweeper": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Kangaskhanite", "moves": ["Power-Up Punch", "Double-Edge", "Earthquake", "Sucker Punch"]},
+		"BH Wallbreaker": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Jolly", "ability": "Misty Surge", "item": "Kangaskhanite", "moves": ["Nature\u0027s Madness", "Night Shade", "Strength Sap", "Extreme Speed"]},
 	},
 	"Karrablast": {
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 76, "at": 236, "sp": 196}, "nature": "Jolly", "ability": "No Guard", "item": "Choice Scarf", "moves": ["Megahorn", "Knock Off", "Drill Run", "Poison Jab"]},
 	},
 	"Kartana": {
-		"OU Paper Cut (Swords Dance)": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Fightinium Z", "moves": ["Swords Dance", "Leaf Blade", "Sacred Sword", "Smart Strike"]},
-		"OU Paper Press (Choice Band)": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Band", "moves": ["Leaf Blade", "Knock Off", "Sacred Sword", "Smart Strike"]},
 		"OU Paper Plane (Choice Scarf)": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Leaf Blade", "Sacred Sword", "Smart Strike", "Knock Off"]},
-		"Doubles All-out Attacker": {"level": 100, "evs": {"sd": 112, "at": 248, "hp": 36, "sp": 112}, "nature": "Adamant", "ability": "Beast Boost", "item": "Flyinium Z", "moves": ["Leaf Blade", "Smart Strike", "Tailwind", "Protect"]},
+		"OU Paper Press (Choice Band)": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Band", "moves": ["Leaf Blade", "Knock Off", "Sacred Sword", "Smart Strike"]},
+		"OU Paper Cut (Swords Dance)": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Fightinium Z", "moves": ["Swords Dance", "Leaf Blade", "Sacred Sword", "Smart Strike"]},
+		"Doubles All-out Attacker": {"level": 100, "evs": {"sd": 112, "at": 248, "hp": 36, "sp": 112}, "nature": "Adamant", "ability": "Beast Boost", "item": "Flyinium Z", "moves": ["Leaf Blade", "Sacred Sword", "Tailwind", "Protect"]},
 		"VGC17 Sash Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Focus Sash", "moves": ["Leaf Blade", "Smart Strike", "Sacred Sword", "Detect"]},
 		"VGC17 Assault Vest": {"level": 50, "evs": {"sd": 164, "hp": 92, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Assault Vest", "moves": ["Leaf Blade", "Smart Strike", "Sacred Sword", "Night Slash"]},
 		"Battle Spot Singles Swords Dance": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Fightinium Z", "moves": ["Swords Dance", "Leaf Blade", "Sacred Sword", "Smart Strike"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Leaf Blade", "Sacred Sword", "Smart Strike", "Knock Off"]},
+		"BH Wallbreaker": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252}, "nature": "Adamant", "ability": "Steelworker", "item": "Choice Band", "moves": ["Sunsteel Strike", "Power Whip", "V-create", "Bullet Punch"]},
+		"BH Belly Drum Sweeper": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252}, "nature": "Adamant", "ability": "Unburden", "item": "Sitrus Berry", "moves": ["Belly Drum", "Sunsteel Strike", "Close Combat", "Power Whip"]},
 	},
 	"Kecleon": {
 		"PU Assault Vest": {"level": 100, "evs": {"at": 252, "hp": 172, "sp": 84}, "nature": "Adamant", "ability": "Protean", "item": "Assault Vest", "moves": ["Knock Off", "Drain Punch", "Shadow Sneak", "Sucker Punch"]},
@@ -1482,6 +1537,7 @@ var SETDEX_SM = {
 		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Justified", "item": "Choice Scarf", "moves": ["Hydro Pump", "Secret Sword", "Stone Edge", "Scald"]},
 		"Monotype Choice Scarf (Water)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Justified", "item": "Choice Scarf", "moves": ["Scald", "Secret Sword", "Hydro Pump", "Icy Wind"]},
 		"Monotype Choice Specs (Water)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Justified", "item": "Choice Specs", "moves": ["Scald", "Secret Sword", "Hidden Power Electric", "Icy Wind"]},
+		"Monotype Calm Mind + Waterium Z (Water)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Justified", "item": "Waterium Z", "moves": ["Hydro Pump", "Secret Sword", "Calm Mind", "Taunt"]},
 		"Monotype Choice Specs (Fighting)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Justified", "item": "Choice Specs", "moves": ["Scald", "Secret Sword", "Hidden Power Electric", "Icy Wind"]},
 	},
 	"Kingdra": {
@@ -1493,19 +1549,18 @@ var SETDEX_SM = {
 		"Monotype Rain Sweeper (Water)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Choice Specs", "moves": ["Hydro Pump", "Draco Meteor", "Ice Beam", "Surf"]},
 	},
 	"Kingler": {
-		"PU Agility": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Agility", "Liquidation", "Superpower", "Swords Dance"]},
+		"NU Double Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Swords Dance", "Liquidation", "Knock Off", "Agility"]},
 	},
 	"Klefki": {
 		"UU Support": {"level": 100, "evs": {"sd": 252, "hp": 248, "sp": 8}, "nature": "Careful", "ability": "Prankster", "item": "Leftovers", "moves": ["Spikes", "Thunder Wave", "Toxic", "Play Rough"]},
 		"Uber Support": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Prankster", "item": "Leftovers", "moves": ["Spikes", "Thunder Wave", "Toxic", "Play Rough"]},
-		"Monotype Dual Screens (Fairy)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Prankster", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Thunder Wave", "Spikes"]},
+		"Monotype Dual Screens (Fairy)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Prankster", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Spikes", "Foul Play"]},
 	},
 	"Klink": {
 		"LC Shift Gear": {"level": 5, "evs": {"sd": 116, "df": 36, "at": 236, "sp": 116}, "nature": "Adamant", "ability": "Clear Body", "item": "Eviolite", "moves": ["Shift Gear", "Gear Grind", "Wild Charge", "Return"]},
 	},
 	"Klinklang": {
-		"NU Shift Gear": {"level": 100, "evs": {"at": 252, "hp": 88, "sp": 168}, "nature": "Adamant", "ability": "Clear Body", "item": "Steelium Z", "moves": ["Shift Gear", "Gear Grind", "Return", "Magnet Rise"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"at": 252, "hp": 132, "sp": 124}, "nature": "Adamant", "ability": "Clear Body", "item": "Electrium Z", "moves": ["Gear Grind", "Shift Gear", "Wild Charge", "Substitute"]},
+		"NU Shift Gear": {"level": 100, "evs": {"at": 252, "hp": 88, "sp": 168}, "nature": "Adamant", "ability": "Clear Body", "item": "Steelium Z", "moves": ["Shift Gear", "Gear Grind", "Wild Charge", "Magnet Rise"]},
 	},
 	"Koffing": {
 		"LC Defensive": {"level": 5, "evs": {"sd": 236, "df": 236, "hp": 36}, "nature": "Bold", "ability": "Levitate", "item": "Eviolite", "moves": ["Will-O-Wisp", "Pain Split", "Sludge Bomb", "Fire Blast"]},
@@ -1514,9 +1569,9 @@ var SETDEX_SM = {
 		"PU Bulky Spinner": {"level": 100, "evs": {"at": 232, "hp": 252, "sp": 24}, "nature": "Adamant", "ability": "Comatose", "item": "Assault Vest", "moves": ["Rapid Spin", "Return", "U-turn", "Sucker Punch"]},
 	},
 	"Kommo-o": {
-		"RU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Soundproof", "item": "Choice Specs", "moves": ["Clanging Scales", "Focus Blast", "Flamethrower", "Flash Cannon"]},
-		"RU Autotomize": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Soundproof", "item": "Life Orb", "moves": ["Autotomize", "Clanging Scales", "Focus Blast", "Flamethrower"]},
-		"UU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Soundproof", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Close Combat", "Ice Punch"]},
+		"UU Dragon Dance Sweeper": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Bulletproof", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Close Combat", "Poison Jab"]},
+		"UU Mixed Wallbreaker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Bulletproof", "item": "Life Orb", "moves": ["Clanging Scales", "Close Combat", "Poison Jab", "Flamethrower"]},
+		"UU Offensive Stealth Rock": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Bulletproof", "item": "Dragonium Z", "moves": ["Stealth Rock", "Swords Dance", "Close Combat", "Outrage"]},
 		"Doubles The Clanger": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Bulletproof", "item": "Kommonium Z", "moves": ["Clanging Scales", "Flamethrower", "Poison Jab", "Protect"]},
 		"VGC17 Fightinium Z": {"level": 50, "evs": {"hp": 244, "sp": 12, "sa": 252}, "nature": "Modest", "ability": "Bulletproof", "item": "Fightinium Z", "moves": ["Focus Blast", "Clanging Scales", "Flamethrower", "Protect"]},
 		"Monotype Mixed Setup Sweeper (Dragon)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Soundproof", "item": "Kommonium Z", "moves": ["Clanging Scales", "Close Combat", "Flamethrower", "Flash Cannon"]},
@@ -1527,6 +1582,9 @@ var SETDEX_SM = {
 	},
 	"Kricketune": {
 		"PU Sticky Web": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Swarm", "item": "Focus Sash", "moves": ["Sticky Web", "Taunt", "Endeavor", "Knock Off"]},
+	},
+	"Krilowatt": {
+		"CAP All-Out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magic Guard", "item": "Life Orb", "moves": ["Volt Switch", "Ice Beam", "Thunderbolt", "Earth Power"]},
 	},
 	"Krookodile": {
 		"UU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Knock Off", "Earthquake", "Pursuit", "Stone Edge"]},
@@ -1552,9 +1610,9 @@ var SETDEX_SM = {
 	"Kyurem-Black": {
 		"OU Z-Move": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Teravolt", "item": "Icium Z", "moves": ["Freeze Shock", "Fusion Bolt", "Ice Beam", "Earth Power"]},
 		"OU LO KB": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Teravolt", "item": "Life Orb", "moves": ["Ice Beam", "Fusion Bolt", "Hidden Power Fire", "Roost"]},
-		"Doubles All-out Attacker": {"level": 100, "evs": {"at": 96, "sp": 252, "sa": 160}, "nature": "Hasty", "ability": "Teravolt", "item": "Life Orb", "moves": ["Ice Beam", "Fusion Bolt", "Earth Power", "Protect"]},
+		"Doubles All-out Attacker": {"level": 100, "evs": {"at": 112, "sp": 252, "sa": 144}, "nature": "Hasty", "ability": "Teravolt", "item": "Life Orb", "moves": ["Ice Beam", "Fusion Bolt", "Earth Power", "Protect"]},
 		"Doubles Icium Z": {"level": 100, "evs": {"at": 204, "sp": 252, "sa": 52}, "nature": "Hasty", "ability": "Teravolt", "item": "Icium Z", "moves": ["Freeze Shock", "Fusion Bolt", "Ice Beam", "Protect"]},
-		"Doubles Assault Vest": {"level": 100, "evs": {"df": 56, "at": 56, "hp": 248, "sp": 80, "sa": 68}, "nature": "Relaxed", "ability": "Teravolt", "item": "Assault Vest", "moves": ["Ice Beam", "Earth Power", "Fusion Bolt", "Icy Wind"]},
+		"Doubles Assault Vest": {"level": 100, "evs": {"df": 76, "at": 96, "hp": 248, "sp": 80, "sa": 8}, "nature": "Quiet", "ability": "Teravolt", "item": "Assault Vest", "moves": ["Ice Beam", "Fusion Bolt", "Earth Power", "Icy Wind"]},
 		"Monotype Life Orb Wallbreaker (Dragon)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Teravolt", "item": "Life Orb", "moves": ["Ice Beam", "Fusion Bolt", "Earth Power", "Roost"]},
 		"Monotype Mixed Wallbreaker (Ice)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Teravolt", "item": "Life Orb", "moves": ["Fusion Bolt", "Ice Beam", "Earth Power", "Roost"]},
 		"Monotype Choice Scarf (Ice)": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Teravolt", "item": "Choice Scarf", "moves": ["Fusion Bolt", "Ice Beam", "Iron Head", "Outrage"]},
@@ -1569,10 +1627,9 @@ var SETDEX_SM = {
 		"Monotype Special Wallbreaker (Ground)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Earth Power", "Sludge Wave", "Gravity", "Focus Blast"]},
 	},
 	"Landorus-Therian": {
-		"OU Choice Scarf": {"level": 100, "evs": {"df": 84, "at": 148, "hp": 80, "sp": 196}, "nature": "Naive", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "U-turn", "Hidden Power Ice", "Defog"]},
-		"OU Defensive": {"level": 100, "evs": {"df": 240, "hp": 252, "sp": 16}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Hidden Power Ice", "U-turn"]},
-		"OU Rockium Z": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Rockium Z", "moves": ["Swords Dance", "Earthquake", "Stone Edge", "Stealth Rock"]},
-		"OU Flyinium Z": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Flyinium Z", "moves": ["Earthquake", "Fly", "Gravity", "Stealth Rock"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"df": 68, "at": 244, "sp": 196}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "U-turn", "Hidden Power Ice", "Defog"]},
+		"OU Offensive Z-Move": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Flyinium Z", "moves": ["Stealth Rock", "Swords Dance", "Earthquake", "Fly"]},
+		"OU Defensive": {"level": 100, "evs": {"df": 112, "hp": 252, "sp": 144}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Hidden Power Ice", "U-turn"]},
 		"OU Suicide Lead": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Focus Sash", "moves": ["Stealth Rock", "Earthquake", "Explosion", "Swords Dance"]},
 		"Uber Physically Defensive": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Earthquake", "U-turn", "Stealth Rock", "Stone Edge"]},
 		"Uber Z-Move Stealth Rock": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Flyinium Z", "moves": ["Earthquake", "Fly", "Stealth Rock", "Swords Dance"]},
@@ -1582,19 +1639,19 @@ var SETDEX_SM = {
 		"Battle Spot Singles Assault Vest": {"level": 50, "evs": {"sd": 220, "df": 4, "at": 44, "hp": 212, "sp": 28}, "nature": "Adamant", "ability": "Intimidate", "item": "Assault Vest", "moves": ["Earthquake", "U-turn", "Rock Tomb", "Knock Off"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "U-turn", "Rock Slide", "Knock Off"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 244, "hp": 236, "sp": 28}, "nature": "Impish", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Earthquake", "U-turn", "Stealth Rock", "Knock Off"]},
-		"Monotype Double Dance (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Rockium Z", "moves": ["Earthquake", "Stone Edge", "Swords Dance", "Rock Polish"]},
-		"Monotype Defensive Pivot (Flying)": {"level": 100, "evs": {"sd": 28, "df": 228, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "U-turn", "Knock Off"]},
-		"Monotype Choice Scarf (Flying)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "Stone Edge", "U-turn", "Knock Off"]},
+		"Monotype Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "U-turn", "Knock Off", "Stealth Rock"]},
+		"Monotype Rockium Z": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Rockium Z", "moves": ["Earthquake", "Stone Edge", "Swords Dance", "Rock Polish"]},
 	},
 	"Lanturn": {
-		"PU Assault Vest": {"level": 100, "evs": {"sd": 72, "sp": 184, "sa": 252}, "nature": "Modest", "ability": "Volt Absorb", "item": "Assault Vest", "moves": ["Scald", "Volt Switch", "Ice Beam", "Hidden Power Grass"]},
+		"PU Assault Vest": {"level": 100, "evs": {"sd": 136, "sp": 200, "sa": 172}, "nature": "Modest", "ability": "Volt Absorb", "item": "Assault Vest", "moves": ["Scald", "Volt Switch", "Ice Beam", "Discharge"]},
 		"PU Bulky Pivot": {"level": 100, "evs": {"sd": 248, "df": 220, "hp": 40}, "nature": "Calm", "ability": "Volt Absorb", "item": "Leftovers", "moves": ["Volt Switch", "Scald", "Toxic", "Heal Bell"]},
-		"PU Choice Specs": {"level": 100, "evs": {"sd": 72, "sp": 184, "sa": 252}, "nature": "Modest", "ability": "Volt Absorb", "item": "Choice Specs", "moves": ["Hydro Pump", "Volt Switch", "Ice Beam", "Hidden Power Grass"]},
+		"PU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Volt Absorb", "item": "Choice Specs", "moves": ["Hydro Pump", "Volt Switch", "Ice Beam", "Hidden Power Grass"]},
 		"Monotype Support / Pivot (Water)": {"level": 100, "evs": {"sd": 252, "df": 128, "hp": 128}, "nature": "Calm", "ability": "Volt Absorb", "item": "Leftovers", "moves": ["Volt Switch", "Toxic", "Heal Bell", "Scald"]},
 	},
 	"Lapras": {
 		"PU Choice Specs": {"level": 100, "evs": {"hp": 120, "sp": 136, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Freeze-Dry", "Hydro Pump", "Ice Beam", "Hidden Power Fire"]},
-		"Battle Spot Singles It's a OHKO!": {"level": 50, "evs": {"at": 4, "hp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Assault Vest", "moves": ["Sheer Cold", "Freeze-Dry", "Ice Shard", "Surf"]},
+		"Battle Spot Singles It's an OHKO!": {"level": 50, "evs": {"at": 4, "hp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Assault Vest", "moves": ["Sheer Cold", "Freeze-Dry", "Ice Shard", "Surf"]},
+		"Monotype Choice Specs (Ice)": {"level": 100, "evs": {"hp": 80, "sp": 176, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Hydro Pump", "Freeze-Dry", "Hidden Power Fire", "Surf"]},
 	},
 	"Larvesta": {
 		"LC Bulky Pivot": {"level": 5, "evs": {"sd": 156, "df": 236, "hp": 76, "sp": 36}, "nature": "Impish", "ability": "Flame Body", "item": "Eviolite", "moves": ["Flare Blitz", "Morning Sun", "U-turn", "Will-O-Wisp"]},
@@ -1603,17 +1660,21 @@ var SETDEX_SM = {
 		"LC Dragon Dance": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 244, "sp": 188}, "nature": "Jolly", "ability": "Guts", "item": "Eviolite", "moves": ["Dragon Dance", "Earthquake", "Rock Slide", "Superpower"]},
 	},
 	"Latias": {
-		"UU Calm Mind": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Calm Mind", "Draco Meteor", "Psychic", "Recover"]},
-		"UU Life Orb": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Draco Meteor", "Psychic", "Hidden Power Fire", "Recover"]},
-		"UU Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psychic", "Healing Wish", "Trick"]},
+		"UU Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Calm Mind", "Draco Meteor", "Psyshock", "Roost"]},
+		"UU Electrium Z": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Electrium Z", "moves": ["Thunder", "Calm Mind", "Draco Meteor", "Psyshock"]},
+		"UU 3 Attacks + Roost": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Life Orb", "moves": ["Draco Meteor", "Psychic", "Hidden Power Fire", "Roost"]},
+		"UU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psychic", "Trick", "Healing Wish"]},
 		"OU Mega Calm Mind": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Substitute"]},
 		"OU Roost + 3 Attacks": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Ice Beam", "Surf", "Hidden Power Fire", "Roost"]},
 		"OU Offensive Support": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psyshock", "Healing Wish", "Defog"]},
 		"Uber Support": {"level": 100, "evs": {"sd": 4, "df": 76, "hp": 252, "sp": 176}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Defog", "Toxic", "Healing Wish", "Draco Meteor"]},
+		"Doubles Utility Attacker": {"level": 100, "evs": {"hp": 84, "sp": 252, "sa": 172}, "nature": "Timid", "ability": "Levitate", "item": "Psychium Z", "moves": ["Psychic", "Ice Beam", "Tailwind", "Ally Switch"]},
 		"Battle Spot Singles Bulky Calm Mind": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Roost", "Psyshock", "Shadow Ball"]},
 		"Battle Spot Singles Offensive Calm Mind": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Psyshock", "Draco Meteor", "Shadow Ball"]},
 		"Battle Spot Singles Choice Attacker": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Specs", "moves": ["Draco Meteor", "Psyshock", "Shadow Ball", "Healing Wish"]},
 		"Monotype Calm Mind (Dragon)": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Refresh"]},
+		"Monotype Mega Calm Mind (Psychic)": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Thunderbolt"]},
+		"Monotype Choice Scarf Support (Psychic)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psychic", "Defog", "Healing Wish"]},
 	},
 	"Latias-Mega": {
 		"OU Mega Calm Mind": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Substitute"]},
@@ -1622,16 +1683,16 @@ var SETDEX_SM = {
 		"Battle Spot Singles Bulky Calm Mind": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Roost", "Psyshock", "Shadow Ball"]},
 		"Battle Spot Singles Offensive Calm Mind": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Psyshock", "Draco Meteor", "Shadow Ball"]},
 		"Monotype Calm Mind (Dragon)": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Refresh"]},
+		"Monotype Mega Calm Mind (Psychic)": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Latiasite", "moves": ["Calm Mind", "Recover", "Stored Power", "Thunderbolt"]},
 	},
 	"Latios": {
 		"OU Mega Mixed Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Levitate", "item": "Latiosite", "moves": ["Psychic", "Earthquake", "Ice Beam", "Roost"]},
-		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psyshock", "Defog", "Trick"]},
 		"OU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Psychium Z", "moves": ["Draco Meteor", "Psyshock", "Recover", "Calm Mind"]},
 		"Doubles Fast Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Soul Dew", "moves": ["Draco Meteor", "Psychic", "Tailwind", "Protect"]},
 		"Battle Spot Singles Offensive": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Specs", "moves": ["Draco Meteor", "Psychic", "Shadow Ball", "Thunderbolt"]},
 		"Battle Spot Singles Calm Mind": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Dragonium Z", "moves": ["Calm Mind", "Psyshock", "Draco Meteor", "Shadow Ball"]},
 		"Battle Spot Singles Dual Screen Support": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Draco Meteor", "Memento"]},
-		"Monotype Choice Scarf (Dragon)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psychic", "Defog", "Trick"]},
+		"Monotype Revenge Killer (Dragon)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Draco Meteor", "Psyshock", "Defog", "Trick"]},
 		"Monotype Offensive (Psychic)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Soul Dew", "moves": ["Draco Meteor", "Psyshock", "Defog", "Roost"]},
 		"Monotype Mega All-out Attacker (Psychic)": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Levitate", "item": "Latiosite", "moves": ["Psychic", "Earthquake", "Hidden Power Fire", "Recover"]},
 	},
@@ -1648,7 +1709,7 @@ var SETDEX_SM = {
 		"PU Sticky Web": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Swarm", "item": "Focus Sash", "moves": ["Sticky Web", "Leaf Blade", "X-Scissor", "Knock Off"]},
 	},
 	"Ledian": {
-		"PU Dual Screens": {"level": 100, "evs": {"at": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Early Bird", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Encore", "U-turn"]},
+		"PU Falcon PUNCH (All-out Attacker)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Life Orb", "moves": ["Power-Up Punch", "Drain Punch", "Ice Punch", "Thunder Punch"]},
 	},
 	"Lickilicky": {
 		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 168, "sp": 84}, "nature": "Adamant", "ability": "Oblivious", "item": "Lum Berry", "moves": ["Swords Dance", "Return", "Earthquake", "Knock Off"]},
@@ -1666,45 +1727,47 @@ var SETDEX_SM = {
 		"LC Tank": {"level": 5, "evs": {"sd": 60, "df": 220, "hp": 68, "sp": 12, "sa": 108}, "nature": "Bold", "ability": "Storm Drain", "item": "Eviolite", "moves": ["Recover", "Giga Drain", "Stealth Rock", "Ancient Power"]},
 	},
 	"Lilligant": {
-		"PU Quiver Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Quiver Dance", "Sleep Powder", "Giga Drain", "Hidden Power Fire"]},
+		"PU Quiver Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Grassium Z", "moves": ["Quiver Dance", "Sleep Powder", "Giga Drain", "Hidden Power Rock"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Choice Scarf", "moves": ["Leaf Storm", "Energy Ball", "Healing Wish", "Hidden Power Rock"]},
-		"NU Quiver Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Quiver Dance", "Giga Drain", "Sleep Powder", "Hyper Beam"]},
 		"VGC17 Sun Utility": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Focus Sash", "moves": ["Leaf Storm", "Sleep Powder", "After You", "Protect"]},
 	},
 	"Linoone": {
 		"RU Belly Drum": {"level": 100, "evs": {"at": 252, "hp": 148, "sp": 108}, "nature": "Adamant", "ability": "Gluttony", "item": "Figy Berry", "moves": ["Belly Drum", "Extreme Speed", "Stomping Tantrum", "Seed Bomb"]},
 		"UU Belly Drum Sweeper": {"level": 100, "evs": {"sd": 88, "df": 8, "at": 248, "hp": 148, "sp": 16}, "nature": "Adamant", "ability": "Gluttony", "item": "Figy Berry", "moves": ["Belly Drum", "Extreme Speed", "Stomping Tantrum", "Seed Bomb"]},
 	},
+	"Litten": {
+		"LC Intimidate Pivot": {"level": 5, "evs": {"sd": 36, "df": 116, "at": 156, "sp": 196}, "nature": "Jolly", "ability": "Intimidate", "item": "Berry Juice", "moves": ["U-turn", "Flare Blitz", "Will-O-Wisp", "Fake Out"]},
+	},
 	"Lopunny": {
 		"PU Healing Wish": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Klutz", "item": "Flame Orb", "moves": ["Healing Wish", "Return", "High Jump Kick", "Switcheroo"]},
-		"OU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Power-Up Punch", "Encore"]},
+		"OU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Fake Out", "Ice Punch"]},
 		"Battle Spot Singles Mega Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Fake Out", "High Jump Kick", "Return", "Ice Punch"]},
 		"Monotype Power-Up Punch + Encore": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Power-Up Punch", "Encore"]},
 	},
 	"Lopunny-Mega": {
-		"OU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Power-Up Punch", "Encore"]},
+		"OU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Fake Out", "Ice Punch"]},
 		"Battle Spot Singles Mega Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Fake Out", "High Jump Kick", "Return", "Ice Punch"]},
 		"Monotype Power-Up Punch + Encore": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Lopunnite", "moves": ["Return", "High Jump Kick", "Power-Up Punch", "Encore"]},
 	},
 	"Lucario": {
-		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Extreme Speed", "Meteor Mash"]},
 		"UU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Inner Focus", "item": "Life Orb", "moves": ["Nasty Plot", "Aura Sphere", "Flash Cannon", "Vacuum Wave"]},
+		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Extreme Speed", "Meteor Mash"]},
 		"Uber Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Lucarionite", "moves": ["Swords Dance", "Meteor Mash", "Close Combat", "Bullet Punch"]},
-		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Close Combat", "Iron Tail", "Extreme Speed", "Swords Dance"]},
+		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Close Combat", "Meteor Mash", "Extreme Speed", "Swords Dance"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Nasty Plot", "Aura Sphere", "Flash Cannon", "Vacuum Wave"]},
+		"Monotype Swords Dance (Steel)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Close Combat", "Extreme Speed", "Earthquake"]},
 	},
 	"Lucario-Mega": {
 		"Uber Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Lucarionite", "moves": ["Swords Dance", "Meteor Mash", "Close Combat", "Bullet Punch"]},
-		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Close Combat", "Iron Tail", "Extreme Speed", "Swords Dance"]},
+		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Close Combat", "Meteor Mash", "Extreme Speed", "Swords Dance"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Inner Focus", "item": "Lucarionite", "moves": ["Nasty Plot", "Aura Sphere", "Flash Cannon", "Vacuum Wave"]},
 	},
 	"Ludicolo": {
 		"PU Rain Sweeper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "ivs": {"hp": 29}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Rain Dance", "Hydro Pump", "Giga Drain", "Ice Beam"]},
-		"NU Swift Swim": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "ivs": {"hp": 29}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Hydro Pump", "Giga Drain", "Ice Beam", "Rain Dance"]},
 		"Doubles Rain Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Hydro Pump", "Giga Drain", "Ice Beam", "Protect"]},
 	},
 	"Lugia": {
-		"Uber The Wall": {"level": 100, "evs": {"df": 160, "hp": 252, "sp": 96}, "nature": "Bold", "ability": "Multiscale", "item": "Leftovers", "moves": ["Toxic", "Roost", "Whirlwind", "Substitute"]},
+		"Uber Wall": {"level": 100, "evs": {"df": 160, "hp": 252, "sp": 96}, "nature": "Bold", "ability": "Multiscale", "item": "Leftovers", "moves": ["Roost", "Toxic", "Whirlwind", "Psychic"]},
 	},
 	"Lumineon": {
 		"PU Defog": {"level": 100, "evs": {"df": 248, "hp": 252, "sp": 8}, "nature": "Bold", "ability": "Storm Drain", "item": "Leftovers", "moves": ["Defog", "Scald", "Toxic", "U-turn"]},
@@ -1717,8 +1780,9 @@ var SETDEX_SM = {
 		"PU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Life Orb", "moves": ["Psychic", "Ancient Power", "Earth Power", "Rock Polish"]},
 	},
 	"Lurantis": {
-		"PU Defog": {"level": 100, "evs": {"df": 252, "hp": 248, "sp": 8}, "nature": "Bold", "ability": "Contrary", "item": "Leftovers", "moves": ["Defog", "Leaf Storm", "Superpower", "Synthesis"]},
+		"PU Defog": {"level": 100, "evs": {"df": 252, "hp": 248, "sa": 8}, "nature": "Bold", "ability": "Contrary", "item": "Leftovers", "moves": ["Defog", "Leaf Storm", "Superpower", "Synthesis"]},
 		"NU Defogger": {"level": 100, "evs": {"sd": 112, "df": 144, "hp": 252}, "nature": "Calm", "ability": "Contrary", "item": "Leftovers", "moves": ["Leaf Storm", "Defog", "Synthesis", "Hidden Power Ice"]},
+		"Doubles Contrary Attacker": {"level": 100, "evs": {"sd": 20, "at": 236, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Contrary", "item": "Figy Berry", "moves": ["Leaf Blade", "Superpower", "Knock Off", "Protect"]},
 	},
 	"Luvdisc": {
 		"PU Rain Sweeper": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Rain Dance", "Hydro Pump", "Ice Beam", "Hidden Power Grass"]},
@@ -1727,14 +1791,14 @@ var SETDEX_SM = {
 		"PU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Guts", "item": "Flame Orb", "moves": ["Wild Charge", "Ice Fang", "Superpower", "Volt Switch"]},
 	},
 	"Lycanroc": {
-		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Steadfast", "item": "Lycanium Z", "moves": ["Swords Dance", "Stone Edge", "Drill Run", "Accelerock"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "", "moves": ["Stone Edge", "Swords Dance", "Accelerock", "Drill Run"]},
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Steadfast", "item": "Lycanium Z", "moves": ["Swords Dance", "Stone Edge", "Drill Run", "Sucker Punch"]},
 	},
 	"Lycanroc-Dusk": {
 		"RU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Tough Claws", "item": "Life Orb", "moves": ["Swords Dance", "Stone Edge", "Fire Fang", "Sucker Punch"]},
 	},
 	"Lycanroc-Midnight": {
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "No Guard", "item": "Choice Scarf", "moves": ["Stone Edge", "Fire Punch", "Stomping Tantrum", "Toxic"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"df": 16, "at": 252, "sp": 240}, "nature": "Jolly", "ability": "No Guard", "item": "Choice Scarf", "moves": ["Stone Edge", "Iron Tail", "Toxic", "Stomping Tantrum"]},
 	},
 	"Machamp": {
 		"RU Guts Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Guts", "item": "Flame Orb", "moves": ["Close Combat", "Knock Off", "Facade", "Bullet Punch"]},
@@ -1769,8 +1833,9 @@ var SETDEX_SM = {
 		"UU Choice Specs": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magnet Pull", "item": "Choice Specs", "moves": ["Volt Switch", "Thunderbolt", "Flash Cannon", "Hidden Power Fire"]},
 	},
 	"Magnezone": {
-		"OU Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Thunderbolt", "Hidden Power Fire", "Flash Cannon", "Volt Switch"]},
 		"OU Substitute Z": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Magnet Pull", "item": "Electrium Z", "moves": ["Substitute", "Thunderbolt", "Flash Cannon", "Hidden Power Fire"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"df": 4, "hp": 8, "sp": 252, "sa": 244}, "nature": "Timid", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Thunderbolt", "Hidden Power Fire", "Flash Cannon", "Volt Switch"]},
+		"OU Choice Specs": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Magnet Pull", "item": "Choice Specs", "moves": ["Thunderbolt", "Hidden Power Fire", "Flash Cannon", "Volt Switch"]},
 		"VGC17 Bulky Attacker": {"level": 50, "evs": {"hp": 252, "sp": 20, "sa": 236}, "nature": "Modest", "ability": "Sturdy", "item": "Leftovers", "moves": ["Thunderbolt", "Flash Cannon", "Substitute", "Protect"]},
 		"VGC17 Choice Specs": {"level": 50, "evs": {"hp": 236, "sp": 20, "sa": 252}, "nature": "Modest", "ability": "Sturdy", "item": "Choice Specs", "moves": ["Thunderbolt", "Volt Switch", "Flash Cannon", "Hidden Power Ground"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Analytic", "item": "Assault Vest", "moves": ["Thunderbolt", "Volt Switch", "Flash Cannon", "Hidden Power Ice"]},
@@ -1778,13 +1843,16 @@ var SETDEX_SM = {
 		"Monotype Choice Specs (Electric)": {"level": 100, "evs": {"hp": 76, "sp": 180, "sa": 252}, "nature": "Modest", "ability": "Magnet Pull", "item": "Choice Specs", "moves": ["Thunderbolt", "Flash Cannon", "Volt Switch", "Hidden Power Fire"]},
 		"Monotype Choice Scarf (Steel)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Magnet Pull", "item": "Choice Scarf", "moves": ["Volt Switch", "Thunderbolt", "Flash Cannon", "Hidden Power Fire"]},
 	},
+	"Malaconda": {
+		"CAP Black Glasses": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Infiltrator", "item": "Black Glasses", "moves": ["Pursuit", "Sucker Punch", "Glare", "Synthesis"]},
+	},
 	"Malamar": {
 		"NU RestTalk": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Contrary", "item": "Leftovers", "moves": ["Knock Off", "Superpower", "Rest", "Sleep Talk"]},
 		"NU Z-Happy Hour": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Contrary", "item": "Normalium Z", "moves": ["Happy Hour", "Knock Off", "Superpower", "Psycho Cut"]},
 	},
 	"Mamoswine": {
 		"UU Life Orb": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Thick Fat", "item": "Life Orb", "moves": ["Ice Shard", "Earthquake", "Icicle Crash", "Knock Off"]},
-		"OU Physical Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Thick Fat", "item": "Life Orb", "moves": ["Earthquake", "Ice Shard", "Icicle Crash", "Stealth Rock"]},
+		"OU Physical Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Thick Fat", "item": "Metronome", "moves": ["Earthquake", "Ice Shard", "Icicle Crash", "Stealth Rock"]},
 		"Battle Spot Singles Focus Sash": {"level": 50, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Thick Fat", "item": "Focus Sash", "moves": ["Stealth Rock", "Earthquake", "Ice Shard", "Icicle Spear"]},
 		"Battle Spot Singles Assault Vest": {"level": 50, "evs": {"sd": 252, "at": 212, "hp": 44}, "nature": "Adamant", "ability": "Thick Fat", "item": "Assault Vest", "moves": ["Earthquake", "Ice Shard", "Icicle Spear", "Fissure"]},
 		"Monotype Wallbreaker (Ground)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Thick Fat", "item": "Choice Band", "moves": ["Icicle Crash", "Ice Shard", "Earthquake", "Superpower"]},
@@ -1801,6 +1869,7 @@ var SETDEX_SM = {
 	"Mandibuzz": {
 		"RU Taunt + Toxic": {"level": 100, "evs": {"df": 76, "hp": 248, "sp": 184}, "nature": "Impish", "ability": "Overcoat", "item": "Leftovers", "moves": ["Taunt", "Toxic", "Roost", "Foul Play"]},
 		"RU Defog": {"level": 100, "evs": {"sd": 240, "df": 20, "hp": 248}, "nature": "Careful", "ability": "Overcoat", "item": "Leftovers", "moves": ["Defog", "Taunt", "Roost", "Foul Play"]},
+		"UU Showdown Usage": {"level": 100, "evs": {"sd": 204, "hp": 248, "sp": 56}, "nature": "Careful", "ability": "Overcoat", "item": "Leftovers", "moves": ["Roost", "Defog", "Foul Play", "Knock Off"]},
 		"VGC17 Tailwind Support": {"level": 50, "evs": {"sd": 244, "hp": 252, "sp": 12}, "nature": "Calm", "ability": "Overcoat", "item": "Misty Seed", "moves": ["Tailwind", "Roost", "Taunt", "Foul Play"]},
 		"Monotype Defensive Utility (Dark)": {"level": 100, "evs": {"df": 244, "hp": 248, "sp": 16}, "nature": "Impish", "ability": "Overcoat", "item": "Rocky Helmet", "moves": ["Roost", "Defog", "Foul Play", "U-turn"]},
 	},
@@ -1808,14 +1877,14 @@ var SETDEX_SM = {
 		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Choice Scarf", "moves": ["Thunderbolt", "Volt Switch", "Overheat", "Hidden Power Grass"]},
 		"UU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Overheat", "Thunderbolt", "Hidden Power Ice"]},
 		"OU Offensive Pivot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Thunderbolt", "Overheat", "Hidden Power Ice"]},
-		"Doubles Fast Pivot": {"level": 100, "evs": {"sd": 4, "df": 44, "hp": 128, "sp": 232, "sa": 100}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Overheat", "Snarl", "Protect"]},
+		"Doubles Offensive Pivot": {"level": 100, "evs": {"sd": 4, "df": 44, "hp": 128, "sp": 252, "sa": 80}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Snarl", "Overheat", "Protect"]},
 		"Battle Spot Singles Offensive Pivot": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Thunderbolt", "Overheat", "Hidden Power Ice", "Volt Switch"]},
 		"Monotype Offensive Pivot (Electric)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Thunderbolt", "Hidden Power Ice", "Overheat"]},
 	},
 	"Manectric-Mega": {
 		"UU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Overheat", "Thunderbolt", "Hidden Power Ice"]},
 		"OU Offensive Pivot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Thunderbolt", "Overheat", "Hidden Power Ice"]},
-		"Doubles Fast Pivot": {"level": 100, "evs": {"sd": 4, "df": 44, "hp": 128, "sp": 232, "sa": 100}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Overheat", "Snarl", "Protect"]},
+		"Doubles Offensive Pivot": {"level": 100, "evs": {"sd": 4, "df": 44, "hp": 128, "sp": 252, "sa": 80}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Snarl", "Overheat", "Protect"]},
 		"Battle Spot Singles Offensive Pivot": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Thunderbolt", "Overheat", "Hidden Power Ice", "Volt Switch"]},
 		"Monotype Offensive Pivot (Electric)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Manectite", "moves": ["Volt Switch", "Thunderbolt", "Hidden Power Ice", "Overheat"]},
 	},
@@ -1823,9 +1892,10 @@ var SETDEX_SM = {
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 76, "at": 196, "hp": 36, "sp": 196}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Scarf", "moves": ["Close Combat", "Gunk Shot", "U-turn", "Earthquake"]},
 	},
 	"Mantine": {
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Roost", "Defog", "Scald", "Haze"]},
 		"UU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Roost", "Defog", "Haze"]},
 		"OU Mixed Wall": {"level": 100, "evs": {"sd": 220, "df": 36, "hp": 252}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Roost", "Scald", "Defog", "Toxic"]},
-		"Monotype Support (Water)": {"level": 100, "evs": {"sd": 16, "df": 240, "hp": 252}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Defog", "Roost", "Haze"]},
+		"Monotype Support (Water)": {"level": 100, "evs": {"sd": 160, "hp": 252, "sp": 96}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Defog", "Roost", "Haze"]},
 		"Monotype Support (Flying)": {"level": 100, "evs": {"sd": 160, "hp": 252, "sp": 96}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Defog", "Scald", "Roost", "Haze"]},
 	},
 	"Mantyke": {
@@ -1838,11 +1908,12 @@ var SETDEX_SM = {
 		"LC Defensive Pivot": {"level": 5, "evs": {"sd": 100, "df": 100, "at": 12, "hp": 196, "sa": 92}, "nature": "Calm", "ability": "Regenerator", "item": "Eviolite", "moves": ["Scald", "Sludge Bomb", "Recover", "Knock Off"]},
 	},
 	"Marowak": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Brave", "ability": "Rock Head", "item": "Thick Club", "moves": ["Knock Off", "Swords Dance", "Earthquake", "Bonemerang"]},
 		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Thick Club", "moves": ["Bonemerang", "Knock Off", "Double-Edge", "Substitute"]},
 	},
 	"Marowak-Alola": {
-		"UU Showdown Usage": {"level": 100, "evs": {"sd": 8, "at": 252, "hp": 248}, "nature": "Brave", "ability": "Lightning Rod", "item": "Thick Club", "moves": ["Shadow Bone", "Flare Blitz", "Swords Dance", "Bonemerang"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 8, "at": 252, "hp": 248}, "nature": "Adamant", "ability": "Rock Head", "item": "Thick Club", "moves": ["Shadow Bone", "Flare Blitz", "Earthquake", "Swords Dance"]},
+		"UU Trick Room Wallbreaker": {"level": 100, "evs": {"sd": 8, "at": 252, "hp": 248}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Rock Head", "item": "Thick Club", "moves": ["Flare Blitz", "Shadow Bone", "Swords Dance", "Low Kick"]},
+		"UU Offensive Wallbreaker": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Lightning Rod", "item": "Thick Club", "moves": ["Shadow Bone", "Fire Punch", "Stealth Rock", "Low Kick"]},
 		"OU Offensive": {"level": 100, "evs": {"sd": 8, "at": 252, "hp": 248}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Rock Head", "item": "Thick Club", "moves": ["Shadow Bone", "Flare Blitz", "Swords Dance", "Bonemerang"]},
 		"Doubles Trick Room Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Lightning Rod", "item": "Thick Club", "moves": ["Shadow Bone", "Flare Blitz", "Low Kick", "Protect"]},
 		"VGC17 Offensive": {"level": 50, "evs": {"sd": 68, "df": 4, "at": 180, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Lightning Rod", "item": "Thick Club", "moves": ["Flare Blitz", "Shadow Bone", "Bonemerang", "Detect"]},
@@ -1858,19 +1929,19 @@ var SETDEX_SM = {
 	"Mawile": {
 		"PU Wallbreaker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naughty", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Play Rough", "Iron Head", "Sucker Punch", "Fire Blast"]},
 		"PU Physical Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Stealth Rock", "Play Rough", "Super Fang", "Toxic"]},
-		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 40, "sp": 216}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Swords Dance", "Play Rough", "Sucker Punch", "Knock Off"]},
-		"OU All-out Attacker": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Hyper Cutter", "item": "Mawilite", "moves": ["Play Rough", "Sucker Punch", "Thunder Punch", "Fire Fang"]},
+		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Swords Dance", "Play Rough", "Sucker Punch", "Knock Off"]},
+		"OU All-out Attacker": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Play Rough", "Thunder Punch", "Ice Punch", "Fire Fang"]},
 		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Play Rough", "Sucker Punch", "Swords Dance", "Fire Fang"]},
 	},
 	"Mawile-Mega": {
-		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 40, "sp": 216}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Swords Dance", "Play Rough", "Sucker Punch", "Knock Off"]},
-		"OU All-out Attacker": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Hyper Cutter", "item": "Mawilite", "moves": ["Play Rough", "Sucker Punch", "Thunder Punch", "Fire Fang"]},
+		"OU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Swords Dance", "Play Rough", "Sucker Punch", "Knock Off"]},
+		"OU All-out Attacker": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Play Rough", "Thunder Punch", "Ice Punch", "Fire Fang"]},
 		"Battle Spot Singles Physical Attacker": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Mawilite", "moves": ["Play Rough", "Sucker Punch", "Swords Dance", "Fire Fang"]},
 	},
 	"Medicham": {
 		"NU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pure Power", "item": "Life Orb", "moves": ["High Jump Kick", "Zen Headbutt", "Thunder Punch", "Bulk Up"]},
 		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pure Power", "item": "Choice Scarf", "moves": ["High Jump Kick", "Zen Headbutt", "Thunder Punch", "Trick"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pure Power", "item": "Life Orb", "moves": ["High Jump Kick", "Ice Punch", "Zen Headbutt", "Bullet Punch"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pure Power", "item": "Fightinium Z", "moves": ["High Jump Kick", "Ice Punch", "Bullet Punch", "Bulk Up"]},
 		"OU All-out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Telepathy", "item": "Medichamite", "moves": ["Fake Out", "High Jump Kick", "Ice Punch", "Zen Headbutt"]},
 	},
 	"Medicham-Mega": {
@@ -1888,10 +1959,10 @@ var SETDEX_SM = {
 	"Meloetta-Pirouette": {
 	},
 	"Meowstic": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 252, "hp": 248, "sa": 8}, "nature": "Calm", "ability": "Prankster", "item": "Light Clay", "moves": ["Light Screen", "Reflect", "Yawn", "Mean Look"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 140, "df": 120, "hp": 248}, "nature": "Bold", "ability": "Prankster", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Yawn", "Safeguard"]},
 	},
 	"Meowstic-F": {
-		"PU Competitive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Competitive", "item": "Life Orb", "moves": ["Psychic", "Hidden Power Fighting", "Shadow Ball", "Substitute"]},
+		"PU Calm Mind": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Competitive", "item": "Life Orb", "moves": ["Calm Mind", "Psychic", "Shadow Ball", "Hidden Power Ground"]},
 	},
 	"Meowstic-M": {
 		"PU Dual Screens": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Prankster", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Yawn", "Psychic"]},
@@ -1907,11 +1978,11 @@ var SETDEX_SM = {
 		"PU Defensive Stealth Rock": {"level": 100, "evs": {"df": 240, "hp": 252, "sp": 16}, "nature": "Bold", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Stealth Rock", "Psychic", "U-turn", "Healing Wish"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Psychic", "U-turn", "Healing Wish", "Dazzling Gleam"]},
 		"PU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Specs", "moves": ["Psychic", "Dazzling Gleam", "Ice Beam", "Healing Wish"]},
-		"PU Calm Mind + 3 Attacks": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Calm Mind", "Psyshock", "Dazzling Gleam", "Hidden Power Fire"]},
+		"PU Calm Mind + 3 Attacks": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Calm Mind", "Psyshock", "Dazzling Gleam", "Hidden Power Ground"]},
 		"PU Offensive Stealth Rock": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Stealth Rock", "Psychic", "Dazzling Gleam", "Healing Wish"]},
 		"PU Substitute + Calm Mind": {"level": 100, "evs": {"hp": 208, "sp": 252, "sa": 48}, "nature": "Timid", "ability": "Levitate", "item": "Leftovers", "moves": ["Substitute", "Calm Mind", "Psyshock", "Ice Beam"]},
 		"PU Weather Setter": {"level": 100, "evs": {"df": 244, "hp": 248, "sp": 16}, "nature": "Bold", "ability": "Levitate", "item": "Damp Rock", "moves": ["Rain Dance", "Stealth Rock", "Psychic", "U-turn"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Psychic", "Healing Wish", "U-turn", "Stealth Rock"]},
+		"NU Offensive Support": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Stealth Rock", "Psyshock", "Ice Beam", "Healing Wish"]},
 	},
 	"Metagross": {
 		"UU Offensive Stealth Rock": {"level": 100, "evs": {"at": 96, "hp": 236, "sp": 176}, "nature": "Adamant", "ability": "Clear Body", "item": "Shuca Berry", "moves": ["Stealth Rock", "Meteor Mash", "Earthquake", "Pursuit"]},
@@ -1920,31 +1991,31 @@ var SETDEX_SM = {
 		"Doubles Mega Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Iron Head", "Ice Punch", "Stomping Tantrum", "Protect"]},
 		"VGC17 Bulky Attacker": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Clear Body", "item": "Assault Vest", "moves": ["Meteor Mash", "Bullet Punch", "Zen Headbutt", "Hammer Arm"]},
 		"VGC17 Psychium Z": {"level": 50, "evs": {"at": 252, "hp": 132, "sp": 124}, "nature": "Jolly", "ability": "Clear Body", "item": "Psychium Z", "moves": ["Zen Headbutt", "Meteor Mash", "Bullet Punch", "Protect"]},
-		"Battle Spot Singles AoA (All Out Attacker)": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Zen Headbutt", "Bullet Punch", "Earthquake", "Ice Punch"]},
+		"Battle Spot Singles All Out Attacker": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Zen Headbutt", "Bullet Punch", "Earthquake", "Ice Punch"]},
 		"Battle Spot Singles Substitute Hone Claws": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Substitute", "Hone Claws", "Earthquake", "Zen Headbutt"]},
 	},
 	"Metagross-Mega": {
 		"Uber All-Out Attacker": {"level": 100, "evs": {"at": 148, "hp": 184, "sp": 176}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Meteor Mash", "Bullet Punch", "Ice Punch", "Toxic"]},
 		"Doubles Mega Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Iron Head", "Ice Punch", "Stomping Tantrum", "Protect"]},
-		"Battle Spot Singles AoA (All Out Attacker)": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Zen Headbutt", "Bullet Punch", "Earthquake", "Ice Punch"]},
+		"Battle Spot Singles All Out Attacker": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Zen Headbutt", "Bullet Punch", "Earthquake", "Ice Punch"]},
 		"Battle Spot Singles Substitute Hone Claws": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Clear Body", "item": "Metagrossite", "moves": ["Substitute", "Hone Claws", "Earthquake", "Zen Headbutt"]},
 	},
 	"Mew": {
-		"OU Defensive": {"level": 100, "evs": {"df": 156, "hp": 240, "sp": 112}, "nature": "Timid", "ability": "Synchronize", "item": "Leftovers", "moves": ["Ice Beam", "Will-O-Wisp", "Soft-Boiled", "Defog"]},
-		"OU Double Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Synchronize", "item": "Mewnium Z", "moves": ["Psychic", "Fire Blast", "Nasty Plot", "Rock Polish"]},
+		"OU Defensive": {"level": 100, "evs": {"df": 52, "hp": 240, "sp": 216}, "nature": "Timid", "ability": "Synchronize", "item": "Leftovers", "moves": ["Ice Beam", "Will-O-Wisp", "Soft-Boiled", "Stealth Rock"]},
+		"OU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Synchronize", "item": "Mewnium Z", "moves": ["Nasty Plot", "Psychic", "Fire Blast", "Rock Polish"]},
 		"Doubles Transform Support": {"level": 100, "evs": {"sd": 12, "hp": 252, "sp": 216, "sa": 28}, "nature": "Timid", "ability": "Synchronize", "item": "Aguav Berry", "moves": ["Transform", "Fake Out", "Tailwind", "Ice Beam"]},
 		"Monotype Mewnium Z": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Synchronize", "item": "Mewnium Z", "moves": ["Psychic", "Nasty Plot", "Focus Blast", "Rock Polish"]},
 		"Monotype Stallbreaker": {"level": 100, "evs": {"sd": 148, "hp": 252, "sp": 108}, "nature": "Careful", "ability": "Synchronize", "item": "Leftovers", "moves": ["Taunt", "Roost", "Knock Off", "Will-O-Wisp"]},
 	},
 	"Mewtwo": {
-		"Uber Special Attacker": {"level": 100, "evs": {"df": 80, "hp": 8, "sp": 192, "sa": 228}, "nature": "Timid", "ability": "Unnerve", "item": "Mewtwonite Y", "moves": ["Psystrike", "Ice Beam", "Fire Blast", "Focus Blast"]},
+		"Uber Special Attacker": {"level": 100, "evs": {"df": 40, "sp": 252, "sa": 216}, "nature": "Timid", "ability": "Unnerve", "item": "Mewtwonite Y", "moves": ["Psystrike", "Ice Beam", "Fire Blast", "Focus Blast"]},
 		"Uber Physical Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pressure", "item": "Mewtwonite X", "moves": ["Low Kick", "Taunt", "Ice Beam", "Stone Edge"]},
 	},
 	"Mewtwo-Mega-X": {
 		"Uber Physical Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Pressure", "item": "Mewtwonite X", "moves": ["Low Kick", "Taunt", "Ice Beam", "Stone Edge"]},
 	},
 	"Mewtwo-Mega-Y": {
-		"Uber Special Attacker": {"level": 100, "evs": {"df": 80, "hp": 8, "sp": 192, "sa": 228}, "nature": "Timid", "ability": "Unnerve", "item": "Mewtwonite Y", "moves": ["Psystrike", "Ice Beam", "Fire Blast", "Focus Blast"]},
+		"Uber Special Attacker": {"level": 100, "evs": {"df": 40, "sp": 252, "sa": 216}, "nature": "Timid", "ability": "Unnerve", "item": "Mewtwonite Y", "moves": ["Psystrike", "Ice Beam", "Fire Blast", "Focus Blast"]},
 	},
 	"Mienfoo": {
 		"LC Bulky Attacker": {"level": 5, "evs": {"sd": 36, "df": 196, "sp": 236}, "nature": "Jolly", "ability": "Regenerator", "item": "Eviolite", "moves": ["High Jump Kick", "U-turn", "Knock Off", "Fake Out"]},
@@ -1953,32 +2024,31 @@ var SETDEX_SM = {
 		"LC Baton Pass": {"level": 5, "evs": {"sd": 116, "df": 196, "hp": 156}, "nature": "Careful", "ability": "Regenerator", "item": "Eviolite", "moves": ["Swords Dance", "Baton Pass", "Drain Punch", "Knock Off"]},
 	},
 	"Mienshao": {
-		"UU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Scarf", "moves": ["High Jump Kick", "U-turn", "Knock Off", "Poison Jab"]},
+		"UU Assault Vest": {"level": 100, "evs": {"sd": 156, "hp": 100, "sp": 252}, "nature": "Jolly", "ability": "Regenerator", "item": "Assault Vest", "moves": ["High Jump Kick", "Knock Off", "U-turn", "Fake Out"]},
 	},
 	"Mightyena": {
-		"PU Moxie": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Life Orb", "moves": ["Sucker Punch", "Crunch", "Play Rough", "Iron Tail"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Life Orb", "moves": ["Crunch", "Sucker Punch", "Play Rough", "Iron Tail"]},
 	},
 	"Milotic": {
 		"RU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Marvel Scale", "item": "Leftovers", "moves": ["Scald", "Recover", "Haze", "Refresh"]},
-		"Doubles Defensive": {"level": 100, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "ability": "Competitive", "item": "Psychic Seed", "moves": ["Scald", "Icy Wind", "Recover", "Protect"]},
+		"Doubles Defensive": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Bold", "ability": "Competitive", "item": "Psychic Seed", "moves": ["Scald", "Icy Wind", "Recover", "Protect"]},
 		"Doubles Coil": {"level": 100, "evs": {"sd": 88, "df": 104, "hp": 252, "sp": 64}, "nature": "Calm", "ability": "Competitive", "item": "Psychic Seed", "moves": ["Scald", "Coil", "Hypnosis", "Recover"]},
 		"VGC17 Anti-Intimidate Tank": {"level": 50, "evs": {"sd": 4, "df": 76, "hp": 252, "sp": 4, "sa": 172}, "nature": "Calm", "ability": "Competitive", "item": "Sitrus Berry", "moves": ["Scald", "Ice Beam", "Recover", "Protect"]},
 	},
 	"Miltank": {
-		"PU Specially Defensive": {"level": 100, "evs": {"sd": 240, "hp": 248, "sp": 20}, "nature": "Calm", "ability": "Thick Fat", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Seismic Toss", "Milk Drink"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 240, "hp": 252, "sp": 16}, "nature": "Calm", "ability": "Thick Fat", "item": "Leftovers", "moves": ["Milk Drink", "Seismic Toss", "Toxic", "Stealth Rock"]},
+		"NU Specially Defensive Stealth Rock": {"level": 100, "evs": {"sd": 236, "hp": 252, "sp": 20}, "nature": "Calm", "ability": "Thick Fat", "item": "Leftovers", "moves": ["Stealth Rock", "Seismic Toss", "Milk Drink", "Toxic"]},
 	},
 	"Mime Jr.": {
 		"LC Baton Pass": {"level": 5, "evs": {"sd": 36, "df": 236, "hp": 196, "sp": 36}, "nature": "Bold", "ability": "Soundproof", "item": "Berry Juice", "moves": ["Barrier", "Baton Pass", "Calm Mind", "Encore"]},
 	},
 	"Mimikyu": {
 		"OU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Disguise", "item": "Life Orb", "moves": ["Swords Dance", "Shadow Sneak", "Play Rough", "Shadow Claw"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Adamant", "ability": "Disguise", "item": "", "moves": ["Trick Room", "Play Rough", "Shadow Sneak", "Wood Hammer"]},
 		"Battle Spot Singles Offensive Swords Dance": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Disguise", "item": "Mimikium Z", "moves": ["Swords Dance", "Play Rough", "Shadow Sneak", "Shadow Claw"]},
 		"Battle Spot Singles Bulky Utility": {"level": 50, "evs": {"sd": 4, "df": 196, "at": 140, "hp": 164, "sp": 4}, "nature": "Adamant", "ability": "Disguise", "item": "Mimikium Z", "moves": ["Swords Dance", "Play Rough", "Shadow Sneak", "Curse"]},
 		"Battle Spot Singles Curse + Pain Split": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Disguise", "item": "Mimikium Z", "moves": ["Curse", "Substitute", "Pain Split", "Play Rough"]},
-		"Monotype Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Disguise", "item": "Ghostium Z", "moves": ["Swords Dance", "Shadow Claw", "Play Rough", "Shadow Sneak"]},
-		"Monotype Trick Room": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Disguise", "item": "Red Card", "moves": ["Trick Room", "Shadow Sneak", "Play Rough", "Destiny Bond"]},
+		"Monotype Swords Dance (Ghost)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Disguise", "item": "Ghostium Z", "moves": ["Swords Dance", "Shadow Claw", "Play Rough", "Shadow Sneak"]},
+		"Monotype Trick Room (Ghost)": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Disguise", "item": "Red Card", "moves": ["Trick Room", "Shadow Sneak", "Play Rough", "Destiny Bond"]},
+		"Monotype Utility Attacker (Fairy)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Disguise", "item": "Life Orb", "moves": ["Play Rough", "Shadow Claw", "Shadow Sneak", "Swords Dance"]},
 	},
 	"Minior": {
 		"NU Shell Smash": {"level": 100, "evs": {"at": 244, "hp": 12, "sp": 252}, "nature": "Adamant", "ability": "Shields Down", "item": "White Herb", "moves": ["Shell Smash", "Acrobatics", "Earthquake", "Substitute"]},
@@ -1989,10 +2059,10 @@ var SETDEX_SM = {
 		"RU Shell Smash": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Shields Down", "item": "White Herb", "moves": ["Shell Smash", "Acrobatics", "Substitute", "Earthquake"]},
 	},
 	"Minun": {
-		"PU Support": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Minus", "item": "Focus Sash", "moves": ["Nuzzle", "Encore", "Volt Switch", "Counter"]},
+		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Volt Absorb", "item": "Life Orb", "moves": ["Nasty Plot", "Thunderbolt", "Hidden Power Ice", "Substitute"]},
 	},
 	"Misdreavus": {
-		"PU Utility": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Eviolite", "moves": ["Hex", "Will-O-Wisp", "Taunt", "Memento"]},
+		"PU Utility": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Eviolite", "moves": ["Hex", "Will-O-Wisp", "Taunt", "Pain Split"]},
 	},
 	"Mismagius": {
 		"NU Nasty Plot + 2 Attacks": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Ghostium Z", "moves": ["Nasty Plot", "Shadow Ball", "Dazzling Gleam", "Taunt"]},
@@ -2000,12 +2070,9 @@ var SETDEX_SM = {
 		"RU Nasty Plot + Ghostium Z": {"level": 100, "evs": {"df": 8, "sp": 252, "sa": 248}, "nature": "Timid", "ability": "Levitate", "item": "Ghostium Z", "moves": ["Nasty Plot", "Shadow Ball", "Dazzling Gleam", "Taunt"]},
 	},
 	"Moltres": {
-		"RU Wallbreaker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Life Orb", "moves": ["Hurricane", "Fire Blast", "Roost", "U-turn"]},
-		"RU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Scarf", "moves": ["Fire Blast", "Hurricane", "U-turn", "Flamethrower"]},
-		"RU Substitute + Toxic": {"level": 100, "evs": {"sd": 80, "hp": 252, "sp": 176}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Roost", "Flamethrower"]},
 		"UU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Flyinium Z", "moves": ["Hurricane", "Fire Blast", "Roost", "U-turn"]},
-		"UU Defensive": {"level": 100, "evs": {"df": 44, "hp": 248, "sp": 216}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Roost", "Defog", "Flamethrower", "Toxic"]},
-		"UU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Specs", "moves": ["Hurricane", "Flamethrower", "Hidden Power Ice", "Sleep Talk"]},
+		"UU Defensive": {"level": 100, "evs": {"df": 36, "hp": 248, "sp": 224}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Roost", "Defog", "Flamethrower", "Toxic"]},
+		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Specs", "moves": ["Hurricane", "Fire Blast", "Flamethrower", "Air Slash"]},
 	},
 	"Morelull": {
 		"LC Defensive Pivot": {"level": 5, "evs": {"sd": 156, "df": 236, "hp": 36, "sa": 76}, "nature": "Bold", "ability": "Effect Spore", "item": "Eviolite", "moves": ["Spore", "Moonblast", "Giga Drain", "Strength Sap"]},
@@ -2021,7 +2088,11 @@ var SETDEX_SM = {
 		"LC RestTalk": {"level": 5, "evs": {"sd": 236, "df": 36, "at": 116, "hp": 116}, "nature": "Careful", "ability": "Stamina", "item": "Eviolite", "moves": ["Earthquake", "Rest", "Sleep Talk", "Heavy Slam"]},
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 36, "at": 196, "hp": 36, "sp": 236}, "nature": "Adamant", "ability": "Stamina", "item": "Choice Scarf", "moves": ["Earthquake", "Heavy Slam", "Rock Slide", "Close Combat"]},
 	},
+	"Mudkip": {
+		"LC Bulky Attacker": {"level": 5, "evs": {"sd": 196, "df": 116, "at": 196}, "nature": "Impish", "ability": "Torrent", "item": "Eviolite", "moves": ["Waterfall", "Ice Beam", "Superpower", "Double-Edge"]},
+	},
 	"Mudsdale": {
+		"PU Stealth Rock": {"level": 100, "evs": {"sd": 156, "df": 44, "at": 56, "hp": 252}, "nature": "Adamant", "ability": "Stamina", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Toxic", "Protect"]},
 		"PU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 132, "sp": 124}, "nature": "Adamant", "ability": "Stamina", "item": "Choice Band", "moves": ["Earthquake", "Heavy Slam", "Rock Slide", "Close Combat"]},
 		"PU RestTalk": {"level": 100, "evs": {"sd": 152, "df": 104, "hp": 252}, "nature": "Careful", "ability": "Stamina", "item": "Leftovers", "moves": ["Earthquake", "Toxic", "Rest", "Sleep Talk"]},
 	},
@@ -2036,6 +2107,7 @@ var SETDEX_SM = {
 		"VGC17 Setup Sludge (Setup Attacker)": {"level": 50, "evs": {"sd": 40, "df": 172, "at": 44, "hp": 252}, "nature": "Brave", "ability": "Gluttony", "item": "Figy Berry", "moves": ["Knock Off", "Poison Jab", "Curse", "Protect"]},
 		"Battle Spot Singles Assault Vest": {"level": 50, "evs": {"sd": 252, "at": 116, "hp": 140}, "nature": "Adamant", "ability": "Poison Touch", "item": "Assault Vest", "moves": ["Pursuit", "Knock Off", "Poison Jab", "Fire Punch"]},
 		"Monotype Assault Vest (Poison)": {"level": 100, "evs": {"sd": 248, "df": 12, "hp": 248}, "nature": "Sassy", "ability": "Poison Touch", "item": "Assault Vest", "moves": ["Pursuit", "Knock Off", "Poison Jab", "Fire Blast"]},
+		"Monotype Curse (Dark)": {"level": 100, "evs": {"sd": 248, "df": 12, "hp": 248}, "nature": "Careful", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Knock Off", "Poison Jab", "Curse", "Recycle"]},
 		"Monotype Assault Vest (Dark)": {"level": 100, "evs": {"sd": 248, "df": 12, "hp": 248}, "nature": "Careful", "ability": "Poison Touch", "item": "Assault Vest", "moves": ["Knock Off", "Poison Jab", "Rock Slide", "Fire Punch"]},
 	},
 	"Munchlax": {
@@ -2053,18 +2125,22 @@ var SETDEX_SM = {
 		"Uber Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Dragonium Z", "moves": ["Draco Meteor", "Sludge Wave", "Nasty Plot", "Fire Blast"]},
 		"Doubles Fast Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Life Orb", "moves": ["Sludge Bomb", "Draco Meteor", "Fire Blast", "Tailwind"]},
 		"Battle Spot Singles Sweeper": {"level": 50, "evs": {"sd": 4, "hp": 20, "sp": 252, "sa": 228}, "nature": "Timid", "ability": "Beast Boost", "item": "Dragonium Z", "moves": ["Nasty Plot", "Sludge Wave", "Draco Meteor", "Fire Blast"]},
-		"Battle Spot Singles Choiced Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Sludge Wave", "Draco Meteor", "Fire Blast", "Hidden Power Ground"]},
+		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Sludge Wave", "Draco Meteor", "Fire Blast", "Hidden Power Ground"]},
 	},
 	"Natu": {
 		"LC Life Orb": {"level": 5, "evs": {"at": 116, "sp": 196, "sa": 196}, "nature": "Naive", "ability": "Magic Bounce", "item": "Life Orb", "moves": ["Psychic", "Heat Wave", "U-turn", "Roost"]},
 		"LC Defensive": {"level": 5, "evs": {"sd": 76, "df": 76, "hp": 196, "sp": 36, "sa": 116}, "nature": "Bold", "ability": "Magic Bounce", "item": "Eviolite", "moves": ["Psychic", "Roost", "Heat Wave", "U-turn"]},
 		"PU Defensive Magic Bounce": {"level": 100, "evs": {"df": 244, "hp": 248, "sp": 16}, "ivs": {"at": 0}, "nature": "Bold", "ability": "Magic Bounce", "item": "Eviolite", "moves": ["Night Shade", "U-turn", "Reflect", "Roost"]},
 	},
+	"Naviathan": {
+		"CAP Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Flame Orb", "moves": ["Dragon Dance", "Waterfall", "Facade", "Icicle Crash"]},
+	},
 	"Necrozma": {
 		"RU Stealth Rock": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prism Armor", "item": "Twisted Spoon", "moves": ["Stealth Rock", "Photon Geyser", "Heat Wave", "Power Gem"]},
 		"RU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Prism Armor", "item": "Groundium Z", "moves": ["Swords Dance", "Photon Geyser", "Earthquake", "X-Scissor"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"sd": 112, "hp": 252, "sp": 144}, "nature": "Calm", "ability": "Prism Armor", "item": "Chesto Berry", "moves": ["Calm Mind", "", "Heat Wave", "Rest"]},
-		"Doubles Trick Room Setter": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Prism Armor", "item": "Leftovers", "moves": ["Stored Power", "Calm Mind", "Moonlight", "Trick Room"]},
+		"UU Stealth Rock": {"level": 100, "evs": {"hp": 108, "sp": 144, "sa": 252}, "nature": "Modest", "ability": "Prism Armor", "item": "Metronome", "moves": ["Stealth Rock", "Photon Geyser", "Heat Wave", "Signal Beam"]},
+		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "item": "Choice Specs", "moves": ["Photon Geyser", "Earth Power", "Heat Wave", "Signal Beam"]},
+		"Doubles Offensive Trick Room": {"level": 100, "evs": {"sd": 24, "df": 28, "hp": 252, "sa": 204}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Prism Armor", "item": "Psychium Z", "moves": ["Trick Room", "Photon Geyser", "Earth Power", "Protect"]},
 	},
 	"Necrozma-Dawn Wings": {
 		"Uber Ultra Swords Dance": {"level": 100, "evs": {"df": 32, "at": 252, "sp": 224}, "nature": "Jolly", "ability": "Prism Armor", "item": "Ultranecrozium Z", "moves": ["Swords Dance", "Photon Geyser", "Earthquake", "Stone Edge"]},
@@ -2098,7 +2174,7 @@ var SETDEX_SM = {
 	},
 	"Nidoqueen": {
 		"RU Stealth Rock": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Stealth Rock", "Earth Power", "Ice Beam", "Toxic"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 248, "sa": 8}, "nature": "Bold", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Earth Power", "Toxic Spikes", "Ice Beam", "Sludge Wave"]},
+		"UU Defensive": {"level": 100, "evs": {"df": 124, "hp": 252, "sp": 132}, "nature": "Bold", "ability": "Sheer Force", "item": "Black Sludge", "moves": ["Stealth Rock", "Toxic Spikes", "Earth Power", "Sludge Wave"]},
 	},
 	"Nihilego": {
 		"UU Offensive Entry Hazard Setter": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Electrium Z", "moves": ["Stealth Rock", "Sludge Wave", "Grass Knot", "Thunder"]},
@@ -2111,7 +2187,6 @@ var SETDEX_SM = {
 		"Monotype Choice Scarf (Rock)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Sludge Wave", "Hidden Power Ice", "Thunderbolt", "Power Gem"]},
 	},
 	"Ninetales": {
-		"PU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Firium Z", "moves": ["Nasty Plot", "Fire Blast", "Energy Ball", "Psyshock"]},
 		"RU Nasty Plot Wallbreaker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Drought", "item": "Firium Z", "moves": ["Nasty Plot", "Fire Blast", "Solar Beam", "Hidden Power Ice"]},
 		"RU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Drought", "item": "Choice Specs", "moves": ["Overheat", "Fire Blast", "Solar Beam", "Hidden Power Ice"]},
 	},
@@ -2122,10 +2197,10 @@ var SETDEX_SM = {
 		"Monotype Offensive Support (Ice)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Light Clay", "moves": ["Aurora Veil", "Freeze-Dry", "Moonblast", "Encore"]},
 	},
 	"Ninjask": {
-		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Speed Boost", "item": "Groundium Z", "moves": ["Swords Dance", "Leech Life", "Dig", "Aerial Ace"]},
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Groundium Z", "moves": ["Swords Dance", "Leech Life", "Dig", "Aerial Ace"]},
 	},
 	"Noctowl": {
-		"PU Defog": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Insomnia", "item": "Leftovers", "moves": ["Defog", "Roost", "Toxic", "Night Shade"]},
+		"PU Double Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Tinted Lens", "item": "Flyinium Z", "moves": ["Agility", "Work Up", "Hurricane", "Roost"]},
 	},
 	"Noivern": {
 		"RU Taunt + Roost": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Infiltrator", "item": "Flyinium Z", "moves": ["Hurricane", "Taunt", "Roost", "Flamethrower"]},
@@ -2133,14 +2208,23 @@ var SETDEX_SM = {
 	"Nosepass": {
 		"LC SturdyJuice Utility": {"level": 5, "evs": {"sd": 196, "df": 236, "at": 76}, "nature": "Relaxed", "ability": "Sturdy", "item": "Berry Juice", "moves": ["Stealth Rock", "Rock Blast", "Thunder Wave", "Volt Switch"]},
 	},
+	"Numel": {
+		"LC Sweeper": {"level": 5, "evs": {"hp": 36, "sp": 236, "sa": 236}, "nature": "Modest", "ability": "Simple", "item": "Eviolite", "moves": ["Flame Charge", "Fire Blast", "Earth Power", "Growth"]},
+	},
 	"Octillery": {
 		"PU All-Out Attacker": {"level": 100, "evs": {"hp": 212, "sp": 44, "sa": 252}, "nature": "Modest", "ability": "Sniper", "item": "Choice Specs", "moves": ["Hydro Pump", "Fire Blast", "Energy Ball", "Ice Beam"]},
+	},
+	"Oddish": {
+		"LC Defensive Pivot": {"level": 5, "evs": {"sd": 76, "df": 236, "hp": 156, "sp": 36}, "nature": "Bold", "ability": "Chlorophyll", "item": "Eviolite", "moves": ["Sleep Powder", "Strength Sap", "Sludge Bomb", "Giga Drain"]},
 	},
 	"Omanyte": {
 		"LC Shell Smash Sweeper": {"level": 5, "evs": {"hp": 76, "sp": 236, "sa": 196}, "nature": "Modest", "ability": "Shell Armor", "item": "Eviolite", "moves": ["Shell Smash", "Hydro Pump", "Ice Beam", "Earth Power"]},
 		"LC Support": {"level": 5, "evs": {"df": 116, "hp": 76, "sp": 156, "sa": 116}, "nature": "Modest", "ability": "Weak Armor", "item": "Eviolite", "moves": ["Spikes", "Hydro Pump", "Knock Off", "Stealth Rock"]},
 	},
 	"Omastar": {
+		"PU Shell Smash": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Weak Armor", "item": "Groundium Z", "moves": ["Shell Smash", "Hydro Pump", "Ice Beam", "Earth Power"]},
+		"PU Defensive Hazard Utility": {"level": 100, "evs": {"df": 236, "hp": 248, "sa": 24}, "nature": "Bold", "ability": "Shell Armor", "item": "Leftovers", "moves": ["Stealth Rock", "Spikes", "Scald", "Ice Beam"]},
+		"PU Lead": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Weak Armor", "item": "Focus Sash", "moves": ["Stealth Rock", "Spikes", "Scald", "Ice Beam"]},
 		"NU Lead": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Weak Armor", "item": "Focus Sash", "moves": ["Stealth Rock", "Spikes", "Surf", "Shell Smash"]},
 		"Monotype Shell Smash Sweeper (Rock)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Weak Armor", "item": "Air Balloon", "moves": ["Shell Smash", "Hydro Pump", "Ice Beam", "Hidden Power Grass"]},
 	},
@@ -2149,10 +2233,11 @@ var SETDEX_SM = {
 		"LC Weak Armor": {"level": 5, "evs": {"at": 236, "hp": 76, "sp": 196}, "nature": "Jolly", "ability": "Weak Armor", "item": "Eviolite", "moves": ["Stealth Rock", "Rock Blast", "Earthquake", "Explosion"]},
 	},
 	"Oranguru": {
-		"Doubles Trick Room": {"level": 100, "evs": {"sd": 96, "df": 172, "hp": 240}, "nature": "Sassy", "ability": "Inner Focus", "item": "Mental Herb", "moves": ["Psychic", "Trick Room", "Instruct", "Protect"]},
+		"PU Assault Vest": {"level": 100, "evs": {"sd": 8, "hp": 248, "sa": 252}, "nature": "Modest", "ability": "Inner Focus", "item": "Assault Vest", "moves": ["Psychic", "Future Sight", "Focus Blast", "Thunderbolt"]},
 		"VGC17 Trick Room": {"level": 50, "evs": {"sd": 92, "df": 140, "hp": 252, "sa": 20}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Inner Focus", "item": "Mental Herb", "moves": ["Trick Room", "Psychic", "Instruct", "Protect"]},
 	},
 	"Oricorio": {
+		"PU Offensive Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dancer", "item": "Flyinium Z", "moves": ["Calm Mind", "Hurricane", "Revelation Dance", "Roost"]},
 		"NU Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dancer", "item": "Flyinium Z", "moves": ["Calm Mind", "Hurricane", "Revelation Dance", "U-turn"]},
 	},
 	"Oricorio-Pa'u": {
@@ -2173,7 +2258,8 @@ var SETDEX_SM = {
 		"Uber All-out Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Pressure", "item": "Life Orb", "moves": ["Hydro Pump", "Spacial Rend", "Thunder", "Focus Punch"]},
 	},
 	"Palossand": {
-		"NU Defensive Stealth Rock": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Compaction", "item": "Leftovers", "moves": ["Stealth Rock", "Earth Power", "Shadow Ball", "Shore Up"]},
+		"NU Defensive Stealth Rock": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Compaction", "item": "Colbur Berry", "moves": ["Stealth Rock", "Earth Power", "Shadow Ball", "Shore Up"]},
+		"UU Stealth Rock": {"level": 100, "evs": {"sd": 92, "df": 164, "hp": 252}, "nature": "Bold", "ability": "Water Compaction", "item": "Leftovers", "moves": ["Stealth Rock", "Earth Power", "Shore Up", "Toxic"]},
 	},
 	"Pancham": {
 		"LC Parting Shot Pivot": {"level": 5, "evs": {"sd": 212, "df": 100, "at": 180, "sp": 12}, "nature": "Adamant", "ability": "Iron Fist", "item": "Eviolite", "moves": ["Parting Shot", "Drain Punch", "Knock Off", "Gunk Shot"]},
@@ -2183,14 +2269,18 @@ var SETDEX_SM = {
 		"RU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Mold Breaker", "item": "Lum Berry", "moves": ["Swords Dance", "Knock Off", "Drain Punch", "Gunk Shot"]},
 		"RU All-Out Attacker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Iron Fist", "item": "Choice Band", "moves": ["Knock Off", "Hammer Arm", "Gunk Shot", "Bullet Punch"]},
 	},
+	"Parasect": {
+		"PU Annoyer": {"level": 100, "evs": {"sd": 252, "at": 8, "hp": 248}, "nature": "Careful", "ability": "Dry Skin", "item": "Rocky Helmet", "moves": ["Spore", "Stun Spore", "Synthesis", "Leech Life"]},
+	},
 	"Passimian": {
-		"NU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Receiver", "item": "Choice Scarf", "moves": ["Close Combat", "Earthquake", "Knock Off", "U-turn"]},
+		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Receiver", "item": "Choice Scarf", "moves": ["Close Combat", "U-turn", "Knock Off", "Gunk Shot"]},
 	},
 	"Pawniard": {
 		"LC Bulky Attacker": {"level": 5, "evs": {"sd": 116, "df": 36, "at": 156, "sp": 196}, "nature": "Jolly", "ability": "Defiant", "item": "Eviolite", "moves": ["Knock Off", "Sucker Punch", "Iron Head", "Stealth Rock"]},
 		"LC Choice Scarf Attacker": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 236, "sp": 196}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Scarf", "moves": ["Knock Off", "Iron Head", "Brick Break", "Pursuit"]},
 		"LC Life Orb Attacker": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 236, "sp": 196}, "ivs": {"hp": 0}, "nature": "Jolly", "ability": "Defiant", "item": "Life Orb", "moves": ["Knock Off", "Sucker Punch", "Iron Head", "Low Sweep"]},
 		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Defiant", "item": "Eviolite", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Iron Head"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 192, "sp": 60}, "nature": "Adamant", "ability": "Defiant", "item": "Eviolite", "moves": ["Sucker Punch", "Knock Off", "Iron Head", "Swords Dance"]},
 	},
 	"Pelipper": {
 		"OU Defensive": {"level": 100, "evs": {"sd": 224, "df": 36, "hp": 248}, "nature": "Bold", "ability": "Drizzle", "item": "Damp Rock", "moves": ["Scald", "U-turn", "Roost", "Defog"]},
@@ -2207,18 +2297,26 @@ var SETDEX_SM = {
 	"Persian-Alola": {
 		"PU Bulky Pivot": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Fur Coat", "item": "Darkinium Z", "moves": ["Parting Shot", "Taunt", "Foul Play", "Toxic"]},
 		"RU Z-Parting Shot": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Fur Coat", "item": "Darkinium Z", "moves": ["Parting Shot", "Foul Play", "Toxic", "Taunt"]},
-		"Doubles Bulky Support": {"level": 100, "evs": {"sd": 44, "hp": 240, "sp": 224}, "nature": "Jolly", "ability": "Fur Coat", "item": "Mago Berry", "moves": ["Foul Play", "Fake Out", "Parting Shot", "Taunt"]},
 		"VGC17 Parting Shot": {"level": 50, "evs": {"sd": 100, "hp": 156, "sp": 252}, "nature": "Timid", "ability": "Fur Coat", "item": "Darkinium Z", "moves": ["Parting Shot", "Fake Out", "Foul Play", "Snarl"]},
 		"VGC17 Assault Vest": {"level": 50, "evs": {"sd": 36, "hp": 220, "sp": 252}, "nature": "Timid", "ability": "Fur Coat", "item": "Assault Vest", "moves": ["Fake Out", "Snarl", "Foul Play", "Feint"]},
 	},
+	"Petilil": {
+		"LC Sun Sweeper": {"level": 5, "evs": {"sd": 36, "df": 36, "sp": 200, "sa": 200}, "nature": "Timid", "ability": "Chlorophyll", "item": "Eviolite", "moves": ["Sunny Day", "Solar Beam", "Hidden Power Fire", "Sleep Powder"]},
+	},
+	"Phanpy": {
+		"LC Utility": {"level": 5, "evs": {"sd": 116, "df": 116, "at": 116, "hp": 116, "sp": 36}, "nature": "Careful", "ability": "Pickup", "item": "Eviolite", "moves": ["Stealth Rock", "Earthquake", "Knock Off", "Ice Shard"]},
+	},
 	"Pheromosa": {
-		"Uber All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naughty", "ability": "Beast Boost", "item": "Life Orb", "moves": ["Low Kick", "U-turn", "Ice Beam", "Rapid Spin"]},
+		"Uber Offensive Pivot": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Beast Boost", "item": "Life Orb", "moves": ["U-turn", "Low Kick", "Ice Beam", "Throat Chop"]},
 		"VGC17 All-out Attacker": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Naughty", "ability": "Beast Boost", "item": "Focus Sash", "moves": ["High Jump Kick", "Poison Jab", "Ice Beam", "Protect"]},
-		"Battle Spot Singles All Out Attacker": {"level": 50, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Naughty", "ability": "Beast Boost", "item": "Focus Sash", "moves": ["High Jump Kick", "U-turn", "Ice Beam", "Poison Jab"]},
-		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Focus Sash", "moves": ["Bug Buzz", "Ice Beam", "Focus Blast", "Hidden Power Ground"]},
+		"Battle Spot Singles Offensive Pivot": {"level": 50, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naughty", "ability": "Beast Boost", "item": "Life Orb", "moves": ["High Jump Kick", "U-turn", "Ice Beam", "Drill Run"]},
+		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Fightinium Z", "moves": ["Focus Blast", "Ice Beam", "Quiver Dance", "Bug Buzz"]},
 	},
 	"Phione": {
 		"PU Rain Dance": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Hydration", "item": "Damp Rock", "moves": ["Rain Dance", "Rest", "U-turn", "Scald"]},
+	},
+	"Pichu": {
+		"LC Life Orb Attacker": {"level": 5, "evs": {"at": 196, "hp": 36, "sp": 196, "sa": 76}, "nature": "Hasty", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Fake Out", "Volt Tackle", "Volt Switch", "Encore"]},
 	},
 	"Pidgeot": {
 		"UU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Big Pecks", "item": "Pidgeotite", "moves": ["Hurricane", "Heat Wave", "U-turn", "Roost"]},
@@ -2247,22 +2345,27 @@ var SETDEX_SM = {
 	},
 	"Pinsir": {
 		"PU Z-Me First": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Moxie", "item": "Normalium Z", "moves": ["Me First", "X-Scissor", "Earthquake", "Stone Edge"]},
-		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Life Orb", "moves": ["Swords Dance", "Earthquake", "X-Scissor", "Knock Off"]},
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Life Orb", "moves": ["Swords Dance", "X-Scissor", "Earthquake", "Stone Edge"]},
+		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Groundium Z", "moves": ["Swords Dance", "X-Scissor", "Earthquake", "Stone Edge"]},
 		"OU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hyper Cutter", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Earthquake", "Quick Attack"]},
-		"Monotype Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Quick Attack", "Close Combat"]},
+		"Monotype Swords Dance (Bug)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Quick Attack", "Close Combat"]},
 	},
 	"Pinsir-Mega": {
 		"OU Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hyper Cutter", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Earthquake", "Quick Attack"]},
-		"Monotype Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Quick Attack", "Close Combat"]},
+		"Monotype Swords Dance (Bug)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Pinsirite", "moves": ["Swords Dance", "Return", "Quick Attack", "Close Combat"]},
 	},
 	"Piplup": {
 		"LC Utility": {"level": 5, "evs": {"sd": 148, "df": 252, "hp": 92}, "nature": "Bold", "ability": "Torrent", "item": "Eviolite", "moves": ["Stealth Rock", "Defog", "Scald", "Ice Beam"]},
+	},
+	"Plasmanta": {
+		"CAP Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Storm Drain", "item": "Choice Scarf", "moves": ["Thunderbolt", "Sludge Bomb", "Hidden Power Ice", "Aura Sphere"]},
+		"CAP Life Orb": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Storm Drain", "item": "Life Orb", "moves": ["Thunderbolt", "Sludge Bomb", "Hidden Power Ice", "Aura Sphere"]},
 	},
 	"Plusle": {
 		"PU Support": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Plus", "item": "Focus Sash", "moves": ["Nuzzle", "Encore", "Volt Switch", "Counter"]},
 	},
 	"Politoed": {
-		"Doubles Rain Setter": {"level": 100, "evs": {"sd": 8, "df": 148, "hp": 252, "sa": 100}, "nature": "Bold", "ability": "Drizzle", "item": "Sitrus Berry", "moves": ["Scald", "Icy Wind", "Helping Hand", "Protect"]},
+		"PU PerishTrap": {"level": 100, "evs": {"sd": 8, "hp": 248, "sp": 252}, "nature": "Calm", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Whirlpool", "Perish Song", "Encore", "Protect"]},
 		"VGC17 Rain Support": {"level": 50, "evs": {"sd": 52, "df": 148, "hp": 220, "sp": 4, "sa": 84}, "nature": "Calm", "ability": "Drizzle", "item": "Sitrus Berry", "moves": ["Scald", "Ice Beam", "Encore", "Protect"]},
 		"VGC17 Choice Scarf": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Drizzle", "item": "Choice Scarf", "moves": ["Scald", "Hydro Pump", "Ice Beam", "Encore"]},
 	},
@@ -2270,15 +2373,17 @@ var SETDEX_SM = {
 		"LC Belly Drum": {"level": 5, "evs": {"at": 196, "hp": 116, "sp": 196}, "nature": "Jolly", "ability": "Water Absorb", "item": "Berry Juice", "moves": ["Belly Drum", "Waterfall", "Hypnosis", "Return"]},
 	},
 	"Poliwrath": {
-		"PU SubPunch": {"level": 100, "evs": {"at": 252, "hp": 112, "sp": 144}, "nature": "Adamant", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Waterfall", "Focus Punch", "Substitute", "Toxic"]},
+		"PU Special Tank": {"level": 100, "evs": {"hp": 252, "sp": 96, "sa": 160}, "nature": "Timid", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Focus Blast", "Toxic", "Protect"]},
+		"PU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Circle Throw", "Scald", "Rest", "Sleep Talk"]},
 	},
 	"Ponyta": {
 		"LC Physical Firium Z": {"level": 5, "evs": {"df": 76, "at": 236, "sp": 196}, "nature": "Jolly", "ability": "Flame Body", "item": "Firium Z", "moves": ["Flame Charge", "Flare Blitz", "High Horsepower", "Morning Sun"]},
-		"LC Bloom Doom": {"level": 5, "evs": {"df": 76, "sp": 196, "sa": 236}, "nature": "Timid", "ability": "Flash Fire", "item": "Grassium Z", "moves": ["Solar Beam", "Flamethrower", "Flame Charge", "Hypnosis"]},
 		"LC Physical Utility": {"level": 5, "evs": {"sd": 76, "df": 156, "at": 76, "sp": 196}, "nature": "Jolly", "ability": "Flame Body", "item": "Eviolite", "moves": ["Flare Blitz", "Wild Charge", "Will-O-Wisp", "Morning Sun"]},
+		"LC Bloom Doom": {"level": 5, "evs": {"df": 76, "sp": 196, "sa": 236}, "nature": "Timid", "ability": "Flash Fire", "item": "Grassium Z", "moves": ["Solar Beam", "Flamethrower", "Flame Charge", "Hypnosis"]},
 		"LC Sunny Day": {"level": 5, "evs": {"df": 156, "sp": 196, "sa": 156}, "nature": "Timid", "ability": "Flame Body", "item": "Eviolite", "moves": ["Fire Blast", "Solar Beam", "Sunny Day", "Morning Sun"]},
 	},
 	"Porygon-Z": {
+		"OU Z-Conversion": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Adaptability", "item": "Normalium Z", "moves": ["Thunderbolt", "Ice Beam", "Recover", "Conversion"]},
 		"Doubles Z-Conversion": {"level": 100, "evs": {"hp": 52, "sp": 204, "sa": 252}, "nature": "Modest", "ability": "Adaptability", "item": "Normalium Z", "moves": ["Thunderbolt", "Ice Beam", "Conversion", "Protect"]},
 		"Battle Spot Singles Z-Conversion Ghost": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Adaptability", "item": "Normalium Z", "moves": ["Shadow Ball", "Ice Beam", "Thunderbolt", "Conversion"]},
 		"Battle Spot Singles Z-Conversion Electric": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Adaptability", "item": "Normalium Z", "moves": ["Thunderbolt", "Ice Beam", "Shadow Ball", "Conversion"]},
@@ -2288,7 +2393,7 @@ var SETDEX_SM = {
 	"Porygon2": {
 		"RU Defensive Tank": {"level": 100, "evs": {"sd": 152, "df": 104, "hp": 252}, "nature": "Calm", "ability": "Trace", "item": "Eviolite", "moves": ["Recover", "Thunder Wave", "Ice Beam", "Foul Play"]},
 		"UU Defensive": {"level": 100, "evs": {"sd": 136, "df": 120, "hp": 252}, "nature": "Calm", "ability": "Trace", "item": "Eviolite", "moves": ["Recover", "Tri Attack", "Hidden Power Fire", "Toxic"]},
-		"Doubles Trick Room Setter": {"level": 100, "evs": {"sd": 152, "df": 88, "hp": 252, "sa": 16}, "ivs": {"at": 0, "sp": 0}, "nature": "Quiet", "ability": "Download", "item": "Eviolite", "moves": ["Trick Room", "Ice Beam", "Thunderbolt", "Recover"]},
+		"Doubles Trick Room Setter": {"level": 100, "evs": {"sd": 92, "df": 148, "hp": 252, "sa": 16}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Download", "item": "Eviolite", "moves": ["Trick Room", "Ice Beam", "Thunderbolt", "Recover"]},
 		"VGC17 Standard": {"level": 50, "evs": {"sd": 188, "df": 76, "hp": 244}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Download", "item": "Eviolite", "moves": ["Trick Room", "Ice Beam", "Thunderbolt", "Recover"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"sd": 100, "df": 164, "hp": 244}, "nature": "Bold", "ability": "Trace", "item": "Eviolite", "moves": ["Ice Beam", "Recover", "Foul Play", "Toxic"]},
 		"Battle Spot Singles Offensive": {"level": 50, "evs": {"df": 12, "hp": 244, "sa": 252}, "nature": "Modest", "ability": "Download", "item": "Eviolite", "moves": ["Ice Beam", "Shadow Ball", "Recover", "Tri Attack"]},
@@ -2296,6 +2401,7 @@ var SETDEX_SM = {
 	},
 	"Primarina": {
 		"UU Choice Specs": {"level": 100, "evs": {"hp": 92, "sp": 164, "sa": 252}, "nature": "Modest", "ability": "Torrent", "item": "Choice Specs", "moves": ["Hydro Pump", "Moonblast", "Sparkling Aria", "Psychic"]},
+		"UU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Torrent", "item": "Leftovers", "moves": ["Scald", "Moonblast", "Rest", "Sleep Talk"]},
 		"Battle Spot Singles Bulky Special Attacker": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Torrent", "item": "Primarium Z", "moves": ["Sparkling Aria", "Moonblast", "Aqua Jet", "Hidden Power Fire"]},
 		"Battle Spot Singles Fast Focus Sash": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Mild", "ability": "Torrent", "item": "Focus Sash", "moves": ["Sparkling Aria", "Moonblast", "Aqua Jet", "Hidden Power Fire"]},
 		"Monotype Wallbreaker (Fairy)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Torrent", "item": "Choice Specs", "moves": ["Hydro Pump", "Moonblast", "Psychic", "Hidden Power Fire"]},
@@ -2304,7 +2410,6 @@ var SETDEX_SM = {
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Scarf", "moves": ["Close Combat", "U-turn", "Stone Edge", "Gunk Shot"]},
 		"PU Non-Choiced Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Fist Plate", "moves": ["Close Combat", "Stone Edge", "U-turn", "Encore"]},
 		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Band", "moves": ["Close Combat", "U-turn", "Stone Edge", "Gunk Shot"]},
-		"NU Choiced Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Choice Band", "moves": ["Close Combat", "U-turn", "Stone Edge", "Earthquake"]},
 	},
 	"Prinplup": {
 		"PU Utility": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Torrent", "item": "Eviolite", "moves": ["Defog", "Stealth Rock", "Scald", "Toxic"]},
@@ -2312,6 +2417,9 @@ var SETDEX_SM = {
 	"Probopass": {
 		"PU Offensive Stealth Rock": {"level": 100, "evs": {"hp": 172, "sp": 84, "sa": 252}, "nature": "Modest", "ability": "Magnet Pull", "item": "Leftovers", "moves": ["Stealth Rock", "Flash Cannon", "Hidden Power Fire", "Taunt"]},
 		"NU Magnet Pull": {"level": 100, "evs": {"hp": 172, "sp": 84, "sa": 252}, "nature": "Modest", "ability": "Magnet Pull", "item": "Air Balloon", "moves": ["Earth Power", "Stealth Rock", "Magnet Rise", "Taunt"]},
+	},
+	"Psyduck": {
+		"LC Choice Scarf": {"level": 5, "evs": {"sp": 240, "sa": 240}, "nature": "Timid", "ability": "Cloud Nine", "item": "Choice Scarf", "moves": ["Hydro Pump", "Psychic", "Ice Beam", "Hidden Power Fire"]},
 	},
 	"Pumpkaboo-Small": {
 		"LC Z-Trick-or-Treat": {"level": 5, "evs": {"sd": 156, "df": 36, "hp": 4, "sp": 148, "sa": 164}, "nature": "Modest", "ability": "Frisk", "item": "Ghostium Z", "moves": ["Trick-or-Treat", "Shadow Ball", "Fire Blast", "Giga Drain"]},
@@ -2324,42 +2432,47 @@ var SETDEX_SM = {
 		"LC Utility": {"level": 5, "evs": {"sd": 60, "df": 140, "at": 36, "hp": 188, "sp": 68}, "nature": "Careful", "ability": "Prankster", "item": "Eviolite", "moves": ["Encore", "U-turn", "Knock Off", "Thunder Wave"]},
 	},
 	"Purugly": {
-		"PU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Silk Scarf", "moves": ["Fake Out", "Return", "Sucker Punch", "U-turn"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Life Orb", "moves": ["Return", "Fake Out", "Knock Off", "U-turn"]},
 	},
 	"Pyroar": {
-		"PU Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Unnerve", "item": "Choice Specs", "moves": ["Fire Blast", "Hyper Voice", "Hidden Power Grass", "Flamethrower"]},
-		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Unnerve", "item": "Choice Scarf", "moves": ["Fire Blast", "Hyper Voice", "Hidden Power Grass", "Toxic"]},
-		"PU Z-Sunny Day": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Unnerve", "item": "Firium Z", "moves": ["Sunny Day", "Fire Blast", "Hyper Voice", "Solar Beam"]},
+		"NU Endeavor": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Unnerve", "item": "Normalium Z", "moves": ["Substitute", "Flamethrower", "Hyper Voice", "Endeavor"]},
 	},
 	"Pyukumuku": {
 		"PU Unaware": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Toxic", "Soak", "Recover", "Block"]},
-		"NU Unaware Wall": {"level": 100, "evs": {"sd": 40, "df": 216, "hp": 252}, "ivs": {"at": 0}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Recover", "Toxic", "Soak", "Protect"]},
+		"NU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Recover", "Toxic", "Block", "Spite"]},
 		"RU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Recover", "Toxic", "Soak", "Block"]},
 		"UU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Toxic", "Soak", "Recover", "Block"]},
+		"OU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Leftovers", "moves": ["Block", "Recover", "Spite", "Rest"]},
 		"Battle Spot Singles Toxic Staller": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Rocky Helmet", "moves": ["Toxic", "Recover", "Soak", "Counter"]},
 		"Battle Spot Singles Baton Passer": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Unaware", "item": "Poisonium Z", "moves": ["Purify", "Recover", "Toxic", "Baton Pass"]},
 	},
 	"Quagsire": {
-		"NU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Unaware", "item": "Leftovers", "moves": ["Scald", "Earthquake", "Recover", "Curse"]},
+		"PU Defensive Wall": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Unaware", "item": "Leftovers", "moves": ["Earthquake", "Waterfall", "Recover", "Curse"]},
+		"NU Curse": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Unaware", "item": "Leftovers", "moves": ["Curse", "Earthquake", "Scald", "Recover"]},
 		"RU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Unaware", "item": "Leftovers", "moves": ["Scald", "Earthquake", "Recover", "Curse"]},
 		"UU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Unaware", "item": "Leftovers", "moves": ["Scald", "Earthquake", "Recover", "Toxic"]},
 		"OU Unaware Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Unaware", "item": "Leftovers", "moves": ["Scald", "Earthquake", "Recover", "Toxic"]},
 	},
 	"Qwilfish": {
-		"NU Showdown Usage": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Bold", "ability": "Intimidate", "item": "Black Sludge", "moves": ["Spikes", "Toxic Spikes", "Taunt", "Scald"]},
+		"PU Utility": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Spikes", "Scald", "Taunt", "Toxic Spikes"]},
+		"PU Rain Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Swords Dance", "Waterfall", "Poison Jab", "Explosion"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Spikes", "Liquidation", "Poison Jab", "Pain Split"]},
 		"RU Entry Hazard Setter": {"level": 100, "evs": {"df": 112, "hp": 252, "sp": 144}, "nature": "Bold", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Spikes", "Scald", "Taunt", "Haze"]},
 		"OU Rain Wallbreaker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Swords Dance", "Liquidation", "Explosion", "Poison Jab"]},
 	},
 	"Raichu": {
-		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Nasty Plot", "Thunderbolt", "Focus Blast", "Hidden Power Ice"]},
+		"PU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Nasty Plot", "Thunderbolt", "Grass Knot", "Focus Blast"]},
 	},
 	"Raichu-Alola": {
-		"PU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Surge Surfer", "item": "Fightinium Z", "moves": ["Nasty Plot", "Psyshock", "Thunderbolt", "Focus Blast"]},
+		"PU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Surge Surfer", "item": "Aloraichium Z", "moves": ["Nasty Plot", "Psyshock", "Thunderbolt", "Substitute"]},
 		"VGC17 Offensive Support": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Surge Surfer", "item": "Psychium Z", "moves": ["Fake Out", "Thunderbolt", "Psychic", "Protect"]},
 		"Monotype Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Surge Surfer", "item": "Life Orb", "moves": ["Thunderbolt", "Psychic", "Focus Blast", "Grass Knot"]},
 	},
 	"Raikou": {
 		"UU Calm Mind": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Pressure", "item": "Ghostium Z", "moves": ["Calm Mind", "Thunderbolt", "Hidden Power Ice", "Shadow Ball"]},
+	},
+	"Ralts": {
+		"LC Revenge Trapper": {"level": 5, "evs": {"hp": 52, "sp": 196, "sa": 236}, "nature": "Timid", "ability": "Trace", "item": "Choice Scarf", "moves": ["Psychic", "Dazzling Gleam", "Thunderbolt", "Memento"]},
 	},
 	"Rampardos": {
 		"PU Mixed Wallbreaker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Rock Slide", "Zen Headbutt", "Fire Blast", "Superpower"]},
@@ -2368,7 +2481,7 @@ var SETDEX_SM = {
 		"PU Offensive Utility": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Flash Fire", "item": "Firium Z", "moves": ["Flare Blitz", "Wild Charge", "Morning Sun", "Will-O-Wisp"]},
 	},
 	"Raticate": {
-		"PU Guts": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Flame Orb", "moves": ["Facade", "Sucker Punch", "Protect", "U-turn"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Flame Orb", "moves": ["Facade", "Stomping Tantrum", "Sucker Punch", "U-turn"]},
 	},
 	"Raticate-Alola": {
 		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Hustle", "item": "Normalium Z", "moves": ["Swords Dance", "Double-Edge", "Knock Off", "Sucker Punch"]},
@@ -2382,13 +2495,14 @@ var SETDEX_SM = {
 		"Uber Mixed Wallbreaker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Air Lock", "item": "Life Orb", "moves": ["Draco Meteor", "Dragon Ascent", "V-create", "Extreme Speed"]},
 	},
 	"Rayquaza-Mega": {
-		"AG Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Delta Stream", "item": "Life Orb", "moves": ["Dragon Ascent", "Extreme Speed", "V-create", "Earthquake"]},
+		"AG Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Delta Stream", "item": "Life Orb", "moves": ["Dragon Ascent", "Extreme Speed", "V-create", "Dragon Dance"]},
 	},
 	"Regice": {
 		"PU Rock Polish": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Clear Body", "item": "Fightinium Z", "moves": ["Rock Polish", "Ice Beam", "Focus Blast", "Thunderbolt"]},
 	},
 	"Regigigas": {
 		"PU Tank": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Slow Start", "item": "Leftovers", "moves": ["Return", "Knock Off", "Thunder Wave", "Drain Punch"]},
+		"BH Poison Heal": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Jolly", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Shift Gear", "Facade", "Spore", "Knock Off"]},
 	},
 	"Regirock": {
 		"PU Stealth Rock": {"level": 100, "evs": {"sd": 200, "df": 56, "hp": 252}, "nature": "Impish", "ability": "Clear Body", "item": "Leftovers", "moves": ["Stealth Rock", "Rock Slide", "Earthquake", "Toxic"]},
@@ -2396,6 +2510,7 @@ var SETDEX_SM = {
 	},
 	"Registeel": {
 		"RU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Clear Body", "item": "Leftovers", "moves": ["Seismic Toss", "Toxic", "Stealth Rock", "Protect"]},
+		"UU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Clear Body", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Seismic Toss", "Protect"]},
 	},
 	"Relicanth": {
 		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Waterfall", "Earthquake", "Zen Headbutt"]},
@@ -2404,76 +2519,81 @@ var SETDEX_SM = {
 		"LC Choice Scarf": {"level": 5, "evs": {"sp": 236, "sa": 236}, "nature": "Naive", "ability": "Hustle", "item": "Choice Scarf", "moves": ["Water Spout", "Hydro Pump", "Fire Blast", "Bullet Seed"]},
 	},
 	"Reshiram": {
-		"Uber Wallbreaker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Turboblaze", "item": "Grassium Z", "moves": ["Draco Meteor", "Blue Flare", "Solar Beam", "Stone Edge"]},
+		"Uber Life Orb": {"level": 100, "evs": {"hp": 104, "sp": 152, "sa": 252}, "nature": "Modest", "ability": "Turboblaze", "item": "Life Orb", "moves": ["Blue Flare", "Draco Meteor", "Roost", "Toxic"]},
 	},
 	"Reuniclus": {
 		"UU Defensive Calm Mind": {"level": 100, "evs": {"df": 252, "hp": 248, "sp": 8}, "nature": "Bold", "ability": "Magic Guard", "item": "Leftovers", "moves": ["Calm Mind", "Psyshock", "Focus Blast", "Recover"]},
 		"UU Offensive Trick Room": {"level": 100, "evs": {"df": 4, "hp": 252, "sa": 252}, "nature": "Quiet", "ability": "Magic Guard", "item": "Life Orb", "moves": ["Psychic", "Shadow Ball", "Focus Blast", "Trick Room"]},
-		"OU Calm Mind": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Magic Guard", "item": "Leftovers", "moves": ["Calm Mind", "Psyshock", "Shadow Ball", "Recover"]},
+		"OU Double Dance": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Magic Guard", "item": "Leftovers", "moves": ["Calm Mind", "Acid Armor", "Psychic", "Recover"]},
+	},
+	"Revenankh": {
+		"CAP Dual Status": {"level": 100, "evs": {"sd": 68, "df": 188, "hp": 252}, "nature": "Careful", "ability": "Triage", "item": "Leftovers", "moves": ["Drain Punch", "Moonlight", "Glare", "Toxic"]},
 	},
 	"Rhydon": {
-		"NU Tank": {"level": 100, "evs": {"sd": 240, "at": 16, "hp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Eviolite", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Swords Dance"]},
-		"NU Dancing Dino": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Rock Head", "item": "Eviolite", "moves": ["Rock Polish", "Earthquake", "Stone Edge", "Swords Dance"]},
+		"NU Tank": {"level": 100, "evs": {"sd": 240, "at": 16, "hp": 252}, "nature": "Adamant", "ability": "Reckless", "item": "Eviolite", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Swords Dance"]},
+	},
+	"Rhyhorn": {
+		"LC Rhyhorn": {"level": 5, "evs": {"sd": 116, "df": 156, "at": 156, "hp": 36}, "nature": "Careful", "ability": "Rock Head", "item": "Eviolite", "moves": ["Stealth Rock", "Rock Blast", "Earthquake", "Megahorn"]},
 	},
 	"Rhyperior": {
 		"RU Stealth Rock Tank": {"level": 100, "evs": {"sd": 244, "at": 16, "hp": 248}, "nature": "Adamant", "ability": "Solid Rock", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Ice Punch"]},
 		"RU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Solid Rock", "item": "Choice Band", "moves": ["Earthquake", "Stone Edge", "Megahorn", "Ice Punch"]},
-		"UU Tank": {"level": 100, "evs": {"sd": 240, "at": 16, "hp": 252}, "nature": "Adamant", "ability": "Solid Rock", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Ice Punch", "Toxic"]},
+		"UU Tank": {"level": 100, "evs": {"sd": 240, "at": 16, "hp": 252}, "nature": "Adamant", "ability": "Solid Rock", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Stone Edge", "Toxic"]},
 		"Monotype Physical Blanket Check (Rock)": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Solid Rock", "item": "Weakness Policy", "moves": ["Earthquake", "Fire Punch", "Ice Punch", "Rock Slide"]},
 	},
 	"Ribombee": {
-		"OU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Focus Sash", "moves": ["Sticky Web", "Moonblast", "Hidden Power Fire", "Stun Spore"]},
+		"RU Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Fairium Z", "moves": ["Quiver Dance", "Moonblast", "Psychic", "Hidden Power Fire"]},
+		"OU Sticky Web Lead": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Focus Sash", "moves": ["Sticky Web", "Moonblast", "Hidden Power Fire", "Stun Spore"]},
 		"Monotype Utility Lead (Fairy)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Focus Sash", "moves": ["Sticky Web", "Moonblast", "Hidden Power Fire", "Stun Spore"]},
 	},
 	"Riolu": {
 		"LC Bulky Swords Dance": {"level": 5, "evs": {"sd": 36, "df": 116, "at": 196, "hp": 116, "sp": 36}, "nature": "Adamant", "ability": "Prankster", "item": "Eviolite", "moves": ["Swords Dance", "Copycat", "High Jump Kick", "Protect"]},
 	},
 	"Roselia": {
-		"PU Offensive": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Spikes", "Leaf Storm", "Sludge Bomb", "Sleep Powder"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Giga Drain", "Synthesis", "Spikes", "Sludge Bomb"]},
+		"PU Specially Defensive": {"level": 100, "evs": {"sd": 236, "hp": 248, "sp": 24}, "nature": "Calm", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Spikes", "Synthesis", "Sludge Bomb", "Giga Drain"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Rest", "Spikes", "Sludge Bomb", "Giga Drain"]},
 	},
 	"Roserade": {
 		"RU Life Orb": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Technician", "item": "Life Orb", "moves": ["Leaf Storm", "Sludge Bomb", "Hidden Power Fire", "Synthesis"]},
 		"RU Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Technician", "item": "Choice Scarf", "moves": ["Leaf Storm", "Hidden Power Ground", "Sludge Bomb", "Spikes"]},
 	},
 	"Rotom": {
-		"NU Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Thunderbolt", "Shadow Ball", "Defog"]},
-		"NU Defog": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Defog", "Hex", "Volt Switch", "Will-O-Wisp"]},
+		"NU Defog": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Levitate", "item": "Colbur Berry", "moves": ["Defog", "Will-O-Wisp", "Hex", "Volt Switch"]},
+		"NU Z-Move": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Ghostium Z", "moves": ["Will-O-Wisp", "Hex", "Thunderbolt", "Volt Switch"]},
+		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Thunderbolt", "Shadow Ball", "Trick"]},
 	},
 	"Rotom-Fan": {
-		"PU Physically Defensive": {"level": 100, "evs": {"df": 252, "hp": 248, "sa": 8}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Air Slash", "Thunderbolt", "Will-O-Wisp", "Hidden Power Grass"]},
+		"PU Defensive Pivot": {"level": 100, "evs": {"df": 208, "hp": 252, "sp": 48}, "nature": "Bold", "ability": "Levitate", "item": "Iapapa Berry", "moves": ["Volt Switch", "Air Slash", "Will-O-Wisp", "Defog"]},
 	},
 	"Rotom-Frost": {
 		"PU SubSplit": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Icium Z", "moves": ["Substitute", "Pain Split", "Blizzard", "Thunderbolt"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Blizzard", "Volt Switch", "Thunderbolt", "Trick"]},
 		"RU Defog": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Icium Z", "moves": ["Defog", "Blizzard", "Thunderbolt", "Volt Switch"]},
 	},
 	"Rotom-Heat": {
 		"RU Offensive Defog": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Iapapa Berry", "moves": ["Defog", "Volt Switch", "Overheat", "Will-O-Wisp"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Overheat", "Defog", "Hidden Power Grass"]},
+		"UU Bulky Pivot": {"level": 100, "evs": {"hp": 236, "sp": 252, "sa": 20}, "nature": "Timid", "ability": "Levitate", "item": "Iapapa Berry", "moves": ["Volt Switch", "Overheat", "Toxic", "Defog"]},
 		"Battle Spot Singles Bulky Attacker": {"level": 50, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Calm", "ability": "Levitate", "item": "Sitrus Berry", "moves": ["Volt Switch", "Overheat", "Will-O-Wisp", "Hidden Power Ice"]},
 		"Battle Spot Singles Choice Specs": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Specs", "moves": ["Overheat", "Volt Switch", "Hidden Power Ice", "Trick"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Overheat", "Hidden Power Ice", "Trick"]},
 		"Monotype Dual Screens Pivot (Fire)": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Levitate", "item": "Light Clay", "moves": ["Reflect", "Light Screen", "Defog", "Volt Switch"]},
 	},
 	"Rotom-Mow": {
-		"NU Defog": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Grassium Z", "moves": ["Leaf Storm", "Volt Switch", "Will-O-Wisp", "Defog"]},
-		"NU Choice Scarf": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Leaf Storm", "Thunderbolt", "Trick"]},
 		"RU Offensive Support": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Grassium Z", "moves": ["Volt Switch", "Leaf Storm", "Defog", "Will-O-Wisp"]},
 		"UU Offensive Pivot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Grassium Z", "moves": ["Thunderbolt", "Volt Switch", "Leaf Storm", "Defog"]},
 		"Monotype Choice Scarf (Grass)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Thunderbolt", "Volt Switch", "Leaf Storm", "Hidden Power Ice"]},
 	},
 	"Rotom-Wash": {
-		"OU Defensive": {"level": 100, "evs": {"df": 204, "hp": 248, "sp": 56}, "nature": "Bold", "ability": "Levitate", "item": "Iapapa Berry", "moves": ["Hydro Pump", "Volt Switch", "Will-O-Wisp", "Defog"]},
+		"OU Defensive": {"level": 100, "evs": {"df": 200, "hp": 252, "sp": 56}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Hydro Pump", "Volt Switch", "Pain Split", "Will-O-Wisp"]},
 		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 68, "df": 112, "hp": 252, "sa": 76}, "nature": "Calm", "ability": "Levitate", "item": "Wiki Berry", "moves": ["Hydro Pump", "Volt Switch", "Will-O-Wisp", "Ally Switch"]},
 		"Battle Spot Singles Bulky": {"level": 50, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Levitate", "item": "Sitrus Berry", "moves": ["Hydro Pump", "Volt Switch", "Will-O-Wisp", "Thunderbolt"]},
 		"Battle Spot Singles Choice Specs": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Specs", "moves": ["Hydro Pump", "Volt Switch", "Trick", "Hidden Power Ice"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Levitate", "item": "Choice Scarf", "moves": ["Volt Switch", "Hydro Pump", "Trick", "Hidden Power Ice"]},
 		"Monotype Physically Defensive Pivot (Electric)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Volt Switch", "Hydro Pump", "Will-O-Wisp", "Pain Split"]},
+		"Monotype Defensive Pivot (Water)": {"level": 100, "evs": {"df": 216, "hp": 248, "sp": 44}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Volt Switch", "Hydro Pump", "Defog", "Will-O-Wisp"]},
 	},
 	"Rowlet": {
 		"LC Baton Pass": {"level": 5, "evs": {"sd": 196, "df": 156, "hp": 132}, "nature": "Sassy", "ability": "Overgrow", "item": "Eviolite", "moves": ["Baton Pass", "Swords Dance", "Roost", "Leaf Blade"]},
-		"LC Defensive Defog": {"level": 5, "evs": {"sd": 196, "df": 156, "hp": 132, "sp": 20}, "nature": "Careful", "ability": "Overgrow", "item": "Eviolite", "moves": ["Defog", "Roost", "Brave Bird", "Leaf Blade"]},
-		"LC Swords Dance": {"level": 5, "evs": {"sd": 36, "at": 236, "sp": 180}, "nature": "Jolly", "ability": "Overgrow", "item": "Life Orb", "moves": ["Swords Dance", "Brave Bird", "Leaf Blade", "Sucker Punch"]},
 	},
 	"Rufflet": {
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 36, "at": 252, "sp": 196}, "nature": "Jolly", "ability": "Hustle", "item": "Choice Scarf", "moves": ["Brave Bird", "Superpower", "U-turn", "Return"]},
@@ -2481,8 +2601,6 @@ var SETDEX_SM = {
 	},
 	"Sableye": {
 		"PU Physically Defensive": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Prankster", "item": "Leftovers", "moves": ["Taunt", "Will-O-Wisp", "Recover", "Knock Off"]},
-		"RU Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Prankster", "item": "Leftovers", "moves": ["Taunt", "Will-O-Wisp", "Recover", "Knock Off"]},
-		"RU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Prankster", "item": "Leftovers", "moves": ["Taunt", "Will-O-Wisp", "Recover", "Knock Off"]},
 		"OU Utility": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Prankster", "item": "Sablenite", "moves": ["Knock Off", "Will-O-Wisp", "Recover", "Protect"]},
 		"Uber Support": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Prankster", "item": "Sablenite", "moves": ["Fake Out", "Foul Play", "Toxic", "Recover"]},
 		"Monotype Utility (Dark)": {"level": 100, "evs": {"sd": 144, "df": 112, "hp": 252}, "nature": "Careful", "ability": "Prankster", "item": "Sablenite", "moves": ["Knock Off", "Will-O-Wisp", "Recover", "Foul Play"]},
@@ -2495,10 +2613,11 @@ var SETDEX_SM = {
 		"Monotype Utility (Ghost)": {"level": 100, "evs": {"sd": 156, "df": 104, "hp": 248}, "nature": "Careful", "ability": "Prankster", "item": "Sablenite", "moves": ["Recover", "Will-O-Wisp", "Knock Off", "Protect"]},
 	},
 	"Salamence": {
+		"OU Flyinium Z": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Flyinium Z", "moves": ["Dragon Dance", "Fly", "Earthquake", "Stone Edge"]},
 		"Uber Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 44, "sp": 212}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Dragon Dance", "Double-Edge", "Roost", "Facade"]},
 		"Uber Offensive Defog": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Salamencite", "moves": ["Defog", "Double-Edge", "Roost", "Toxic"]},
-		"Doubles Dragon Dance": {"level": 100, "evs": {"sd": 92, "df": 8, "at": 60, "hp": 252, "sp": 96}, "nature": "Jolly", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Dragon Dance", "Substitute", "Roost"]},
 		"Doubles Mixed Attacker": {"level": 100, "evs": {"at": 60, "sp": 252, "sa": 196}, "nature": "Hasty", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Hyper Voice", "Tailwind", "Protect"]},
+		"Doubles Dragon Dance": {"level": 100, "evs": {"sd": 20, "df": 4, "at": 8, "hp": 252, "sp": 224}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Return", "Dragon Dance", "Roost", "Protect"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Dragon Dance", "Double-Edge", "Earthquake", "Roost"]},
 		"Battle Spot Singles Mixed Attacker": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Draco Meteor", "Fire Blast", "Earthquake"]},
 		"Monotype Devastating Drake (Dragon)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Dragonium Z", "moves": ["Dragon Dance", "Outrage", "Earthquake", "Fire Fang"]},
@@ -2507,8 +2626,8 @@ var SETDEX_SM = {
 	"Salamence-Mega": {
 		"Uber Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 44, "sp": 212}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Dragon Dance", "Double-Edge", "Roost", "Facade"]},
 		"Uber Offensive Defog": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Salamencite", "moves": ["Defog", "Double-Edge", "Roost", "Toxic"]},
-		"Doubles Dragon Dance": {"level": 100, "evs": {"sd": 92, "df": 8, "at": 60, "hp": 252, "sp": 96}, "nature": "Jolly", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Dragon Dance", "Substitute", "Roost"]},
 		"Doubles Mixed Attacker": {"level": 100, "evs": {"at": 60, "sp": 252, "sa": 196}, "nature": "Hasty", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Hyper Voice", "Tailwind", "Protect"]},
+		"Doubles Dragon Dance": {"level": 100, "evs": {"sd": 20, "df": 4, "at": 8, "hp": 252, "sp": 224}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Return", "Dragon Dance", "Roost", "Protect"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Salamencite", "moves": ["Dragon Dance", "Double-Edge", "Earthquake", "Roost"]},
 		"Battle Spot Singles Mixed Attacker": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Intimidate", "item": "Salamencite", "moves": ["Double-Edge", "Draco Meteor", "Fire Blast", "Earthquake"]},
 	},
@@ -2520,6 +2639,7 @@ var SETDEX_SM = {
 		"RU Special Sweeper": {"level": 100, "evs": {"hp": 8, "sp": 252, "sa": 248}, "nature": "Timid", "ability": "Oblivious", "item": "Poisonium Z", "moves": ["Nasty Plot", "Fire Blast", "Sludge Wave", "Hidden Power Ice"]},
 		"RU Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Corrosion", "item": "Choice Scarf", "moves": ["Fire Blast", "Sludge Wave", "Hidden Power Grass", "Dragon Pulse"]},
 		"UU Nasty Plot": {"level": 100, "evs": {"df": 24, "sp": 252, "sa": 232}, "nature": "Timid", "ability": "Oblivious", "item": "Poisonium Z", "moves": ["Nasty Plot", "Sludge Wave", "Fire Blast", "Hidden Power Grass"]},
+		"UU Corrosion": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Corrosion", "item": "Black Sludge", "moves": ["Toxic", "Protect", "Flamethrower", "Substitute"]},
 		"VGC17 Offensive Support": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Oblivious", "item": "Focus Sash", "moves": ["Fake Out", "Flamethrower", "Sludge Bomb", "Protect"]},
 		"Monotype Nasty Plot Sweeper (Poison)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Corrosion", "item": "Life Orb", "moves": ["Nasty Plot", "Fire Blast", "Sludge Wave", "Hidden Power Ground"]},
 	},
@@ -2539,12 +2659,12 @@ var SETDEX_SM = {
 	},
 	"Sandslash": {
 		"PU Utility": {"level": 100, "evs": {"at": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Rush", "item": "Leftovers", "moves": ["Earthquake", "Knock Off", "Rapid Spin", "Stealth Rock"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Groundium Z", "moves": ["Earthquake", "Swords Dance", "Knock Off", "Stone Edge"]},
 	},
 	"Sandslash-Alola": {
+		"PU Specially Defensive": {"level": 100, "evs": {"sd": 208, "hp": 252, "sp": 48}, "nature": "Careful", "ability": "Slush Rush", "item": "Leftovers", "moves": ["Rapid Spin", "Stealth Rock", "Icicle Crash", "Earthquake"]},
 		"PU Hail Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Slush Rush", "item": "Icium Z", "moves": ["Swords Dance", "Icicle Crash", "Earthquake", "Substitute"]},
 		"PU Offensive Support": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Slush Rush", "item": "Shuca Berry", "moves": ["Rapid Spin", "Icicle Crash", "Knock Off", "Earthquake"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Careful", "ability": "Snow Cloak", "item": "Leftovers", "moves": ["Icicle Crash", "Rapid Spin", "Stealth Rock", "Toxic"]},
+		"NU Specially Defensive Utility": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Slush Rush", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Icicle Crash", "Knock Off"]},
 		"UU Aurora Veil Setter": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Slush Rush", "item": "Light Clay", "moves": ["Aurora Veil", "Rapid Spin", "Icicle Crash", "Earthquake"]},
 		"VGC17 Slush Rush": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Slush Rush", "item": "Groundium Z", "moves": ["Iron Head", "Icicle Crash", "Earthquake", "Protect"]},
 		"Monotype Hail Sweeper (Ice)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Slush Rush", "item": "Life Orb", "moves": ["Icicle Crash", "Iron Head", "Earthquake", "Rapid Spin"]},
@@ -2555,24 +2675,24 @@ var SETDEX_SM = {
 	"Sawk": {
 		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mold Breaker", "item": "Choice Scarf", "moves": ["Close Combat", "Knock Off", "Earthquake", "Ice Punch"]},
 		"NU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Choice Band", "moves": ["Close Combat", "Knock Off", "Poison Jab", "Zen Headbutt"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Choice Band", "moves": ["Close Combat", "Knock Off", "Ice Punch", "Earthquake"]},
 	},
 	"Sawsbuck": {
-		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Swords Dance", "Horn Leech", "Double-Edge", "Jump Kick"]},
+		"PU Sun Sweeper": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Swords Dance", "Double-Edge", "Horn Leech", "Jump Kick"]},
 	},
 	"Sceptile": {
-		"NU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Choice Specs", "moves": ["Leaf Storm", "Giga Drain", "Focus Blast", "Hidden Power Ice"]},
+		"NU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Life Orb", "moves": ["Leaf Storm", "Giga Drain", "Focus Blast", "Hidden Power Ice"]},
 		"UU All-out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Sceptilite", "moves": ["Leaf Storm", "Dragon Pulse", "Giga Drain", "Hidden Power Fire"]},
 	},
 	"Sceptile-Mega": {
 		"UU All-out Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Sceptilite", "moves": ["Leaf Storm", "Dragon Pulse", "Giga Drain", "Hidden Power Fire"]},
 	},
 	"Scizor": {
-		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Choice Band", "moves": ["Bullet Punch", "U-turn", "Superpower", "Knock Off"]},
+		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Choice Band", "moves": ["Bullet Punch", "U-turn", "Superpower", "Pursuit"]},
 		"UU Offensive Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Technician", "item": "Iron Plate", "moves": ["Swords Dance", "Bullet Punch", "Bug Bite", "Superpower"]},
 		"UU Bulky Swords Dance": {"level": 100, "evs": {"sd": 136, "df": 124, "hp": 248}, "nature": "Impish", "ability": "Technician", "item": "Leftovers", "moves": ["Swords Dance", "Bullet Punch", "U-turn", "Roost"]},
 		"UU Defog": {"level": 100, "evs": {"sd": 136, "df": 124, "hp": 248}, "nature": "Impish", "ability": "Technician", "item": "Leftovers", "moves": ["Defog", "Bullet Punch", "U-turn", "Roost"]},
-		"OU Swords Dance": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Swords Dance", "Bullet Punch", "U-turn", "Roost"]},
-		"OU Utility": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Defog", "U-turn", "Bullet Punch", "Roost"]},
+		"OU Sweeper": {"level": 100, "evs": {"sd": 16, "df": 244, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Curse", "Bullet Punch", "Roost", "Knock Off"]},
 		"Uber Bulky Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Sassy", "ability": "Light Metal", "item": "Scizorite", "moves": ["Bullet Punch", "Roost", "U-turn", "Toxic"]},
 		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 40, "at": 132, "hp": 252, "sp": 84}, "nature": "Adamant", "ability": "Light Metal", "item": "Scizorite", "moves": ["Bullet Punch", "Bug Bite", "Swords Dance", "Protect"]},
 		"Battle Spot Singles Swords Dance": {"level": 50, "evs": {"sd": 116, "df": 20, "at": 116, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Technician", "item": "Scizorite", "moves": ["Swords Dance", "Bullet Punch", "U-turn", "Roost"]},
@@ -2581,8 +2701,7 @@ var SETDEX_SM = {
 		"Monotype Defensive Swords Dance (Steel)": {"level": 100, "evs": {"sd": 212, "df": 48, "hp": 248}, "nature": "Careful", "ability": "Light Metal", "item": "Scizorite", "moves": ["Swords Dance", "Bullet Punch", "Roost", "U-turn"]},
 	},
 	"Scizor-Mega": {
-		"OU Swords Dance": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Swords Dance", "Bullet Punch", "U-turn", "Roost"]},
-		"OU Utility": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Defog", "U-turn", "Bullet Punch", "Roost"]},
+		"OU Sweeper": {"level": 100, "evs": {"sd": 16, "df": 244, "hp": 248}, "nature": "Impish", "ability": "Light Metal", "item": "Scizorite", "moves": ["Curse", "Bullet Punch", "Roost", "Knock Off"]},
 		"Uber Bulky Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Sassy", "ability": "Light Metal", "item": "Scizorite", "moves": ["Bullet Punch", "Roost", "U-turn", "Toxic"]},
 		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 40, "at": 132, "hp": 252, "sp": 84}, "nature": "Adamant", "ability": "Light Metal", "item": "Scizorite", "moves": ["Bullet Punch", "Bug Bite", "Swords Dance", "Protect"]},
 		"Battle Spot Singles Swords Dance": {"level": 50, "evs": {"sd": 116, "df": 20, "at": 116, "hp": 252, "sp": 4}, "nature": "Adamant", "ability": "Technician", "item": "Scizorite", "moves": ["Swords Dance", "Bullet Punch", "U-turn", "Roost"]},
@@ -2594,7 +2713,8 @@ var SETDEX_SM = {
 		"Monotype Sweeper (Poison)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Life Orb", "moves": ["Megahorn", "Earthquake", "Rock Slide", "Swords Dance"]},
 	},
 	"Scrafty": {
-		"NU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Moxie", "item": "Chople Berry", "moves": ["Dragon Dance", "Knock Off", "High Jump Kick", "Drain Punch"]},
+		"NU Bulk Up": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Shed Skin", "item": "Leftovers", "moves": ["Bulk Up", "Knock Off", "Drain Punch", "Rest"]},
+		"NU Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Shed Skin", "item": "Chople Berry", "moves": ["Dragon Dance", "Knock Off", "High Jump Kick", "Drain Punch"]},
 		"Doubles Assault Vest": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Intimidate", "item": "Assault Vest", "moves": ["Knock Off", "Low Kick", "Fake Out", "Ice Punch"]},
 	},
 	"Scraggy": {
@@ -2602,6 +2722,9 @@ var SETDEX_SM = {
 		"LC Choice Scarf": {"level": 5, "evs": {"at": 236, "hp": 36, "sp": 212}, "nature": "Jolly", "ability": "Moxie", "item": "Choice Scarf", "moves": ["High Jump Kick", "Knock Off", "Poison Jab", "Drain Punch"]},
 	},
 	"Scyther": {
+		"PU Swords Dance": {"level": 100, "evs": {"at": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Technician", "item": "Eviolite", "moves": ["Swords Dance", "Roost", "U-turn", "Aerial Ace"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Technician", "item": "Choice Scarf", "moves": ["U-turn", "Aerial Ace", "Brick Break", "Knock Off"]},
+		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Technician", "item": "Choice Band", "moves": ["U-turn", "Aerial Ace", "Brick Break", "Knock Off"]},
 		"NU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Technician", "item": "Choice Scarf", "moves": ["U-turn", "Aerial Ace", "Knock Off", "Pursuit"]},
 	},
 	"Seaking": {
@@ -2610,7 +2733,6 @@ var SETDEX_SM = {
 	"Seismitoad": {
 		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Stealth Rock", "Scald", "Earth Power", "Toxic"]},
 		"RU Physically Defensive": {"level": 100, "evs": {"df": 196, "hp": 252, "sp": 60}, "nature": "Impish", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Scald", "Toxic"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 244, "sp": 12}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Stealth Rock", "Scald", "Earth Power", "Toxic"]},
 		"Monotype Swift Swim Sweeper (Water)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Hydro Pump", "Earth Power", "Sludge Wave", "Stealth Rock"]},
 		"Monotype Special Tank (Ground)": {"level": 100, "evs": {"hp": 116, "sp": 140, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Assault Vest", "moves": ["Scald", "Earth Power", "Sludge Wave", "Knock Off"]},
 		"Monotype Choice Specs (Ground)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Hydro Pump", "Earth Power", "Sludge Wave", "Scald"]},
@@ -2618,7 +2740,8 @@ var SETDEX_SM = {
 	"Serperior": {
 		"UU SubSeed": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Contrary", "item": "Leftovers", "moves": ["Leaf Storm", "Leech Seed", "Substitute", "Hidden Power Fire"]},
 		"UU Offensive 3 Attacks": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Contrary", "item": "Normalium Z", "moves": ["Leaf Storm", "Hidden Power Fire", "Hyper Beam", "Glare"]},
-		"OU SubSeed": {"level": 100, "evs": {"hp": 56, "sp": 252, "sa": 200}, "nature": "Timid", "ability": "Contrary", "item": "Leftovers", "moves": ["Leaf Storm", "Hidden Power Fire", "Substitute", "Leech Seed"]},
+		"OU Substitute Attacker": {"level": 100, "evs": {"hp": 56, "sp": 252, "sa": 200}, "nature": "Timid", "ability": "Contrary", "item": "Leftovers", "moves": ["Leaf Storm", "Hidden Power Fire", "Substitute", "Glare"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Contrary", "item": "Choice Scarf", "moves": ["Leaf Storm", "Glare", "Defog", "Knock Off"]},
 		"Battle Spot Singles Focus Sash Lead": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Contrary", "item": "Focus Sash", "moves": ["Leaf Storm", "Hidden Power Fire", "Glare", "Taunt"]},
 		"Battle Spot Singles Bulky Attacker": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Contrary", "item": "Rocky Helmet", "moves": ["Leaf Storm", "Reflect", "Synthesis", "Hidden Power Fire"]},
 		"Battle Spot Singles SubSeed": {"level": 50, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Contrary", "item": "Leftovers", "moves": ["Leaf Storm", "Substitute", "Leech Seed", "Hidden Power Fire"]},
@@ -2631,14 +2754,14 @@ var SETDEX_SM = {
 		"PU Mixed Attacker": {"level": 100, "evs": {"at": 40, "sp": 216, "sa": 252}, "nature": "Rash", "ability": "Shed Skin", "item": "Life Orb", "moves": ["Sludge Wave", "Giga Drain", "Flamethrower", "Sucker Punch"]},
 	},
 	"Sharpedo": {
-		"UU Cleaner": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Crunch", "Psychic Fangs", "Ice Fang", "Protect"]},
+		"UU Cleaner": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Crunch", "Ice Fang", "Psychic Fangs", "Protect"]},
 		"Battle Spot Singles Mega Attacker": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Ice Fang", "Destiny Bond"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Speed Boost", "item": "Focus Sash", "moves": ["Protect", "Dark Pulse", "Ice Beam", "Destiny Bond"]},
 		"Monotype Mega Sharpedo (Dark)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Waterfall", "Psychic Fangs"]},
 		"Monotype Speed Boost Sweeper (Water)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Liquidation", "Psychic Fangs"]},
 	},
 	"Sharpedo-Mega": {
-		"UU Cleaner": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Crunch", "Psychic Fangs", "Ice Fang", "Protect"]},
+		"UU Cleaner": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Crunch", "Ice Fang", "Psychic Fangs", "Protect"]},
 		"Battle Spot Singles Mega Attacker": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Ice Fang", "Destiny Bond"]},
 		"Monotype Mega Sharpedo (Dark)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Waterfall", "Psychic Fangs"]},
 		"Monotype Speed Boost Sweeper (Water)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Speed Boost", "item": "Sharpedonite", "moves": ["Protect", "Crunch", "Liquidation", "Psychic Fangs"]},
@@ -2647,10 +2770,16 @@ var SETDEX_SM = {
 		"RU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Life Orb", "moves": ["Seed Flare", "Earth Power", "Psychic", "Synthesis"]},
 		"RU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Choice Scarf", "moves": ["Seed Flare", "Healing Wish", "Psychic", "Hidden Power Ice"]},
 		"RU Leech Seed": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Leftovers", "moves": ["Leech Seed", "Substitute", "Seed Flare", "Air Slash"]},
+		"RU Z-Celebrate": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Natural Cure", "item": "Normalium Z", "moves": ["Celebrate", "Seed Flare", "Air Slash", "Earth Power"]},
 	},
 	"Shaymin-Sky": {
 		"Uber Special Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Serene Grace", "item": "Life Orb", "moves": ["Seed Flare", "Air Slash", "Earth Power", "Healing Wish"]},
 		"Doubles Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Serene Grace", "item": "Focus Sash", "moves": ["Seed Flare", "Air Slash", "Earth Power", "Protect"]},
+	},
+	"Shedinja": {
+		"PU Swords Dance": {"level": 100, "evs": {"at": 252, "sp": 252}, "nature": "Adamant", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Swords Dance", "Shadow Sneak", "X-Scissor", "Will-O-Wisp"]},
+		"OU Showdown Usage": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Will-O-Wisp", "Shadow Sneak", "Protect", "Toxic"]},
+		"BH Pivot": {"level": 100, "evs": {"at": 252}, "ivs": {"sd": 0, "df": 0, "hp": 0, "sp": 0, "sa": 0}, "nature": "Brave", "ability": "Sturdy", "item": "Protective Pads", "moves": ["Endeavor", "Extreme Speed", "U-turn", "Foresight"]},
 	},
 	"Shellder": {
 		"LC SMASHING": {"level": 5, "evs": {"df": 36, "at": 236, "hp": 36, "sp": 196}, "nature": "Impish", "ability": "Skill Link", "item": "Eviolite", "moves": ["Shell Smash", "Icicle Spear", "Rock Blast", "Liquidation"]},
@@ -2661,22 +2790,24 @@ var SETDEX_SM = {
 	"Shelmet": {
 		"LC Spikes": {"level": 5, "evs": {"sd": 236, "df": 156, "hp": 116}, "nature": "Impish", "ability": "Overcoat", "item": "Eviolite", "moves": ["Spikes", "Recover", "Baton Pass", "Leech Life"]},
 	},
+	"Shieldon": {
+		"LC SturdyJuice": {"level": 5, "evs": {"sd": 212, "df": 52, "at": 100, "hp": 116}, "nature": "Adamant", "ability": "Sturdy", "item": "Berry Juice", "moves": ["Metal Burst", "Stealth Rock", "Rock Blast", "Endure"]},
+	},
 	"Shiftry": {
 		"PU Mixed Life Orb": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Lonely", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Knock Off", "Sucker Punch", "Leaf Storm", "Defog"]},
 		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Swords Dance", "Seed Bomb", "Knock Off", "Sucker Punch"]},
 		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Chlorophyll", "item": "Choice Scarf", "moves": ["Knock Off", "Leaf Blade", "Rock Slide", "Explosion"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"df": 28, "at": 252, "sp": 228}, "nature": "Adamant", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Knock Off", "Sucker Punch", "Leaf Blade", "Low Kick"]},
 	},
 	"Shiinotic": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "Effect Spore", "item": "Leftovers", "moves": ["Moonblast", "Spore", "Strength Sap", "Leech Seed"]},
-		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Effect Spore", "item": "Leftovers", "moves": ["Strength Sap", "Spore", "Leech Seed", "Moonblast"]},
+		"PU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Effect Spore", "item": "Leftovers", "moves": ["Strength Sap", "Spore", "Leech Seed", "Moonblast"]},
+	},
+	"Shinx": {
+		"LC Pivot": {"level": 5, "evs": {"sd": 4, "df": 244, "at": 76, "hp": 76, "sa": 36}, "nature": "Adamant", "ability": "Intimidate", "item": "Berry Juice", "moves": ["Volt Switch", "Wild Charge", "Thief", "Fire Fang"]},
 	},
 	"Shuckle": {
 		"PU Sticky Web Setter": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Stealth Rock", "Encore", "Toxic"]},
-		"NU Entry Hazard Setter": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Stealth Rock", "Sticky Web", "Encore", "Knock Off"]},
 		"OU Sticky Web Setter": {"level": 100, "evs": {"sd": 88, "df": 168, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Stealth Rock", "Encore", "Rock Tomb"]},
 		"Uber Sticky Web": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Rock Tomb", "Encore", "Toxic"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 6}, "nature": "Relaxed", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Stealth Rock", "Guard Split", "Acupressure"]},
 		"Battle Spot Singles Sticky Web Setter": {"level": 50, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Red Card", "moves": ["Sticky Web", "Stealth Rock", "Encore", "Rock Tomb"]},
 		"Monotype Entry Hazard Setter (Bug)": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Stealth Rock", "Encore", "Toxic"]},
 		"Monotype Utility (Rock)": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Impish", "ability": "Sturdy", "item": "Mental Herb", "moves": ["Sticky Web", "Stealth Rock", "Encore", "Knock Off"]},
@@ -2699,11 +2830,10 @@ var SETDEX_SM = {
 		"NU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Electric Memory", "moves": ["Thunderbolt", "Ice Beam", "Parting Shot", "Metal Sound"]},
 	},
 	"Silvally-Fairy": {
-		"PU Parting Shot Support": {"level": 100, "evs": {"at": 208, "hp": 48, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Fairy Memory", "moves": ["Multi-Attack", "Flamethrower", "Parting Shot", "Defog"]},
-		"NU Offensive": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "RKS System", "item": "Fairy Memory", "moves": ["Multi-Attack", "Parting Shot", "Flamethrower", "Rock Slide"]},
+		"PU Parting Shot Support": {"level": 100, "evs": {"at": 208, "hp": 48, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Fairy Memory", "moves": ["Multi-Attack", "Thunderbolt", "Parting Shot", "Defog"]},
 	},
 	"Silvally-Fighting": {
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Fighting Memory", "moves": ["Swords Dance", "Multi-Attack", "Crunch", "Rock Slide"]},
+		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Fighting Memory", "moves": ["Swords Dance", "Multi-Attack", "Shadow Claw", "U-turn"]},
 	},
 	"Silvally-Fire": {
 		"NU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Fire Memory", "moves": ["Flamethrower", "Thunderbolt", "Surf", "Parting Shot"]},
@@ -2712,7 +2842,7 @@ var SETDEX_SM = {
 		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Flying Memory", "moves": ["Swords Dance", "Multi-Attack", "Iron Head", "Fire Fang"]},
 	},
 	"Silvally-Ghost": {
-		"PU Offensive pivot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Ghost Memory", "moves": ["Parting Shot", "Shadow Ball", "Flamethrower", "Defog"]},
+		"PU Offensive Pivot": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Ghost Memory", "moves": ["Shadow Ball", "Parting Shot", "Defog", "Toxic"]},
 	},
 	"Silvally-Grass": {
 		"NU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Grass Memory", "moves": ["Parting Shot", "Thunderbolt", "Ice Beam", "Flamethrower"]},
@@ -2724,7 +2854,6 @@ var SETDEX_SM = {
 		"NU Offensive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "RKS System", "item": "Ice Memory", "moves": ["Ice Beam", "Thunderbolt", "Surf", "Parting Shot"]},
 	},
 	"Silvally-Poison": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Calm", "ability": "RKS System", "item": "Poison Memory", "moves": ["Defog", "Flamethrower", "Toxic", "Roar"]},
 		"NU RestTalk": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Relaxed", "ability": "RKS System", "item": "Poison Memory", "moves": ["Multi-Attack", "Flamethrower", "Rest", "Sleep Talk"]},
 	},
 	"Silvally-Psychic": {
@@ -2734,17 +2863,17 @@ var SETDEX_SM = {
 		"NU Offensive Utility": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "RKS System", "item": "Rock Memory", "moves": ["Rock Slide", "Iron Head", "Thunder Wave", "Parting Shot"]},
 	},
 	"Silvally-Steel": {
-		"NU Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "RKS System", "item": "Steel Memory", "moves": ["Flash Cannon", "Flamethrower", "Parting Shot", "Defog"]},
+		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 216, "hp": 232, "sp": 60}, "nature": "Calm", "ability": "RKS System", "item": "Steel Memory", "moves": ["Defog", "Flamethrower", "Toxic", "U-turn"]},
+		"UU Defog Pivot": {"level": 100, "evs": {"sd": 240, "hp": 252, "sp": 16}, "nature": "Calm", "ability": "RKS System", "item": "Steel Memory", "moves": ["Defog", "Parting Shot", "Toxic", "Flamethrower"]},
 	},
 	"Silvally-Water": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "RKS System", "item": "Water Memory", "moves": ["Surf", "Defog", "Parting Shot", "Grass Pledge"]},
-		"NU Physically Defensive Defog": {"level": 100, "evs": {"df": 240, "hp": 252, "sp": 16}, "nature": "Bold", "ability": "RKS System", "item": "Water Memory", "moves": ["Defog", "Surf", "Toxic", "Parting Shot"]},
+		"PU Defensive Defog": {"level": 100, "evs": {"df": 120, "hp": 252, "sp": 136}, "ivs": {"at": 0}, "nature": "Bold", "ability": "RKS System", "item": "Water Memory", "moves": ["Defog", "Surf", "Thunderbolt", "Parting Shot"]},
 	},
 	"Simipour": {
 		"PU All-Out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Torrent", "item": "Life Orb", "moves": ["Hydro Pump", "Knock Off", "Superpower", "Gunk Shot"]},
 	},
 	"Simisage": {
-		"PU All-Out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Overgrow", "item": "Life Orb", "moves": ["Leaf Storm", "Knock Off", "Superpower", "Gunk Shot"]},
+		"PU Mixed Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Overgrow", "item": "Life Orb", "moves": ["Leaf Storm", "Superpower", "Gunk Shot", "Rock Slide"]},
 	},
 	"Simisear": {
 		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Nasty Plot", "Fire Blast", "Focus Blast", "Grass Knot"]},
@@ -2765,28 +2894,45 @@ var SETDEX_SM = {
 	},
 	"Skuntank": {
 		"PU Physical Defog": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Aftermath", "item": "Black Sludge", "moves": ["Defog", "Pursuit", "Sucker Punch", "Poison Jab"]},
-		"PU Special Defog": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Aftermath", "item": "Black Sludge", "moves": ["Defog", "Dark Pulse", "Fire Blast", "Acid Spray"]},
+		"PU Special Defog": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Aftermath", "item": "Black Sludge", "moves": ["Defog", "Dark Pulse", "Acid Spray", "Taunt"]},
 		"PU All-out Attacker": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Aftermath", "item": "Choice Band", "moves": ["Pursuit", "Sucker Punch", "Crunch", "Poison Jab"]},
 	},
 	"Slaking": {
-		"PU Wallbreaker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Truant", "item": "Normalium Z", "moves": ["Giga Impact", "Earthquake", "Fire Punch", "Pursuit"]},
+		"PU All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Truant", "item": "Life Orb", "moves": ["Return", "Pursuit", "Earthquake", "Fire Blast"]},
 	},
 	"Slowbro": {
 		"NU Assault Vest": {"level": 100, "evs": {"hp": 212, "sp": 44, "sa": 252}, "nature": "Modest", "ability": "Regenerator", "item": "Assault Vest", "moves": ["Scald", "Future Sight", "Fire Blast", "Grass Knot"]},
 		"NU Defensive Pivot": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Colbur Berry", "moves": ["Scald", "Psyshock", "Toxic", "Slack Off"]},
+		"NU Block": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Waterium Z", "moves": ["Scald", "Block", "Calm Mind", "Rest"]},
 		"RU Defensive Calm Mind": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Calm Mind", "Scald", "Psyshock", "Slack Off"]},
-		"UU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Scald", "Psyshock", "Slack Off", "Thunder Wave"]},
+		"UU Mega Calm Mind": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Calm Mind", "Slack Off", "Ice Beam"]},
 		"UU Calm Mind": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Calm Mind", "Scald", "Psyshock", "Slack Off"]},
+		"UU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Scald", "Psyshock", "Slack Off", "Thunder Wave"]},
+		"UU Block": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Waterium Z", "moves": ["Block", "Rest", "Scald", "Toxic"]},
+		"UU Tank": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Psyshock", "Slack Off"]},
+		"UU Special Attacker": {"level": 100, "evs": {"hp": 212, "sp": 44, "sa": 252}, "nature": "Modest", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Slack Off", "Ice Beam", "Psyshock"]},
 		"OU Mega Tank": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Psyshock", "Slack Off"]},
+		"OU Defensive Pivot": {"level": 100, "evs": {"sd": 164, "df": 96, "hp": 248}, "nature": "Bold", "ability": "Regenerator", "item": "Leftovers", "moves": ["Scald", "Ice Beam", "Slack Off", "Toxic"]},
 		"Uber Physical Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Toxic", "Scald", "Slack Off", "Iron Defense"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Slack Off", "Iron Defense"]},
 		"Battle Spot Singles Trick Room Setter": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Trick Room", "Scald", "Ice Beam", "Flamethrower"]},
+		"Monotype Defensive Pivot (Psychic)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Colbur Berry", "moves": ["Scald", "Slack Off", "Thunder Wave", "Fire Blast"]},
+		"Monotype Calm Mind Mega (Psychic)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Slack Off", "Scald", "Psychic"]},
+		"Monotype Calm Mind (Water)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Slack Off", "Scald", "Psychic"]},
+		"Monotype Iron Defense (Water)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Iron Defense", "Scald", "Rest"]},
 	},
 	"Slowbro-Mega": {
+		"UU Mega Calm Mind": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Calm Mind", "Slack Off", "Ice Beam"]},
+		"UU Block": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Waterium Z", "moves": ["Block", "Rest", "Scald", "Toxic"]},
+		"UU Tank": {"level": 100, "evs": {"sd": 180, "df": 76, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Psyshock", "Slack Off"]},
+		"UU Special Attacker": {"level": 100, "evs": {"hp": 212, "sp": 44, "sa": 252}, "nature": "Modest", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Slack Off", "Ice Beam", "Psyshock"]},
 		"OU Mega Tank": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Psyshock", "Slack Off"]},
 		"Uber Physical Wall": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Toxic", "Scald", "Slack Off", "Iron Defense"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Scald", "Ice Beam", "Slack Off", "Iron Defense"]},
 		"Battle Spot Singles Trick Room Setter": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Trick Room", "Scald", "Ice Beam", "Flamethrower"]},
+		"Monotype Calm Mind Mega (Psychic)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Slack Off", "Scald", "Psychic"]},
+		"Monotype Calm Mind (Water)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Slack Off", "Scald", "Psychic"]},
+		"Monotype Iron Defense (Water)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Slowbronite", "moves": ["Calm Mind", "Iron Defense", "Scald", "Rest"]},
 	},
 	"Slowking": {
 		"NU Assault Vest": {"level": 100, "evs": {"hp": 248, "sp": 8, "sa": 252}, "nature": "Modest", "ability": "Regenerator", "item": "Assault Vest", "moves": ["Scald", "Future Sight", "Fire Blast", "Dragon Tail"]},
@@ -2802,7 +2948,8 @@ var SETDEX_SM = {
 	"Smeargle": {
 		"PU Sticky Web Lead": {"level": 100, "evs": {"sd": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Own Tempo", "item": "Focus Sash", "moves": ["Sticky Web", "Stealth Rock", "Spore", "Nuzzle"]},
 		"Uber Suicide Lead": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Own Tempo", "item": "Focus Sash", "moves": ["Sticky Web", "Nuzzle", "Taunt", "Whirlwind"]},
-		"Doubles Showdown Usage": {"level": 100, "evs": {"sd": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Own Tempo", "item": "Focus Sash", "moves": ["Spore", "Wide Guard", "Follow Me", "King\u0027s Shield"]},
+		"Doubles Showdown Usage": {"level": 100, "evs": {"sd": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Own Tempo", "item": "Focus Sash", "moves": ["Spore", "King\u0027s Shield", "Follow Me", "Wide Guard"]},
+		"Monotype Entry Hazard Setter": {"level": 100, "evs": {"sd": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Own Tempo", "item": "Focus Sash", "moves": ["Stealth Rock", "Sticky Web", "Spore", "Nuzzle"]},
 	},
 	"Sneasel": {
 		"NU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Inner Focus", "item": "Choice Band", "moves": ["Knock Off", "Icicle Crash", "Ice Shard", "Pursuit"]},
@@ -2822,6 +2969,9 @@ var SETDEX_SM = {
 		"UU RestTalk": {"level": 100, "evs": {"sd": 104, "df": 152, "hp": 252}, "nature": "Careful", "ability": "Thick Fat", "item": "Leftovers", "moves": ["Curse", "Return", "Rest", "Sleep Talk"]},
 		"VGC17 CurseLax": {"level": 50, "evs": {"df": 244, "at": 196, "hp": 68}, "nature": "Brave", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Return", "High Horsepower", "Curse", "Recycle"]},
 		"VGC17 DrumLax": {"level": 50, "evs": {"df": 188, "at": 252, "hp": 68}, "nature": "Brave", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Return", "High Horsepower", "Belly Drum", "Protect"]},
+		"Battle Spot Singles Phazer": {"level": 50, "evs": {"sd": 220, "df": 252, "at": 28, "hp": 4, "sp": 4}, "nature": "Impish", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Whirlwind", "Yawn", "Recycle", "Heavy Slam"]},
+		"Battle Spot Singles Curse": {"level": 50, "evs": {"sd": 92, "df": 252, "at": 12, "hp": 148, "sp": 4}, "nature": "Adamant", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Curse", "Recycle", "Return", "Earthquake"]},
+		"Monotype CurseLax (Normal)": {"level": 100, "evs": {"sd": 24, "df": 252, "hp": 228}, "nature": "Careful", "ability": "Gluttony", "item": "Iapapa Berry", "moves": ["Curse", "Recycle", "Facade", "Fire Punch"]},
 	},
 	"Snover": {
 		"LC Choice Scarf": {"level": 5, "evs": {"at": 104, "sp": 200, "sa": 184}, "nature": "Naive", "ability": "Snow Warning", "item": "Choice Scarf", "moves": ["Blizzard", "Giga Drain", "Ice Shard", "Hidden Power Ground"]},
@@ -2835,8 +2985,14 @@ var SETDEX_SM = {
 	"Solgaleo": {
 		"Uber Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Full Metal Body", "item": "Choice Scarf", "moves": ["Sunsteel Strike", "Flare Blitz", "Earthquake", "Stone Edge"]},
 	},
+	"Solosis": {
+		"LC Showdown Usage": {"level": 5, "evs": {"sd": 40, "df": 116, "hp": 76, "sa": 240}, "nature": "Quiet", "ability": "Regenerator", "item": "Eviolite", "moves": ["Psychic", "Trick Room", "Thunder", "Recover"]},
+	},
 	"Solrock": {
 		"PU Physical Wall": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Levitate", "item": "Leftovers", "moves": ["Stealth Rock", "Morning Sun", "Will-O-Wisp", "Rock Slide"]},
+	},
+	"Spearow": {
+		"LC Life Orb Attacker": {"level": 5, "evs": {"sd": 28, "df": 36, "at": 196, "sp": 196}, "ivs": {"hp": 0}, "nature": "Jolly", "ability": "Sniper", "item": "Life Orb", "moves": ["Double-Edge", "Drill Peck", "Drill Run", "U-turn"]},
 	},
 	"Spinarak": {
 		"LC Sticky Web": {"level": 5, "evs": {"sd": 116, "df": 196, "hp": 196}, "nature": "Impish", "ability": "Insomnia", "item": "Eviolite", "moves": ["Sticky Web", "Leech Life", "Poison Jab", "Toxic Spikes"]},
@@ -2846,14 +3002,18 @@ var SETDEX_SM = {
 	},
 	"Spiritomb": {
 		"PU Pursuit Trapper": {"level": 100, "evs": {"df": 8, "at": 252, "hp": 248}, "nature": "Adamant", "ability": "Infiltrator", "item": "Aguav Berry", "moves": ["Pursuit", "Sucker Punch", "Foul Play", "Will-O-Wisp"]},
-		"PU CroTomb": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Pressure", "item": "Leftovers", "moves": ["Calm Mind", "Dark Pulse", "Rest", "Sleep Talk"]},
+		"PU Calm Mind": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Pressure", "item": "Leftovers", "moves": ["Calm Mind", "Dark Pulse", "Rest", "Sleep Talk"]},
 	},
 	"Spritzee": {
 		"LC Defensive": {"level": 5, "evs": {"sd": 76, "df": 196, "hp": 212, "sp": 12, "sa": 12}, "nature": "Bold", "ability": "Aroma Veil", "item": "Eviolite", "moves": ["Wish", "Protect", "Moonblast", "Covet"]},
 		"LC Nasty Plot": {"level": 5, "evs": {"sd": 76, "df": 116, "hp": 52, "sp": 12, "sa": 252}, "nature": "Modest", "ability": "Aroma Veil", "item": "Eviolite", "moves": ["Nasty Plot", "Moonblast", "Psychic", "Trick Room"]},
 	},
+	"Squirtle": {
+		"LC Rapid Spin": {"level": 5, "evs": {"sd": 84, "df": 156, "at": 52, "hp": 84, "sp": 92}, "nature": "Impish", "ability": "Torrent", "item": "Eviolite", "moves": ["Rapid Spin", "Fake Out", "Waterfall", "Aqua Jet"]},
+	},
 	"Stakataka": {
 		"UU Offensive Trick Room": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"df": 15, "sp": 0}, "nature": "Lonely", "ability": "Beast Boost", "item": "Rockium Z", "moves": ["Trick Room", "Gyro Ball", "Stone Edge", "Earthquake"]},
+		"UU Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Sassy", "ability": "Beast Boost", "item": "Leftovers", "moves": ["Gyro Ball", "Rock Blast", "Stealth Rock", "Protect"]},
 		"OU Offensive Trick Room": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"df": 15, "sp": 0}, "nature": "Lonely", "ability": "Beast Boost", "item": "Rockium Z", "moves": ["Trick Room", "Gyro Ball", "Stone Edge", "Superpower"]},
 		"Doubles Offensive Trick Room": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"df": 15, "sp": 0}, "nature": "Lonely", "ability": "Beast Boost", "item": "Rockium Z", "moves": ["Gyro Ball", "Stone Edge", "Trick Room", "Protect"]},
 		"Battle Spot Singles Offensive Trick Room": {"level": 50, "evs": {"df": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Beast Boost", "item": "Rockium Z", "moves": ["Trick Room", "Gyro Ball", "Stone Edge", "Earthquake"]},
@@ -2864,9 +3024,11 @@ var SETDEX_SM = {
 		"PU All-Out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Lonely", "ability": "Intimidate", "item": "Life Orb", "moves": ["Double-Edge", "Sucker Punch", "Jump Kick", "Energy Ball"]},
 	},
 	"Staraptor": {
-		"Doubles Choice Scarf": {"level": 100, "evs": {"at": 124, "hp": 132, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Final Gambit", "Brave Bird", "U-turn", "Close Combat"]},
-		"Monotype Defensive Defogger (Normal)": {"level": 100, "evs": {"df": 252, "hp": 240, "sp": 16}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Brave Bird", "Roost", "Defog", "Close Combat"]},
-		"Monotype Choice Scarf (Normal)": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Scarf", "moves": ["Brave Bird", "Double-Edge", "Close Combat", "U-turn"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Reckless", "item": "Choice Scarf", "moves": ["Brave Bird", "Double-Edge", "U-turn", "Close Combat"]},
+		"Monotype Defensive Defog (Normal)": {"level": 100, "evs": {"df": 252, "hp": 240, "sp": 16}, "nature": "Impish", "ability": "Intimidate", "item": "Leftovers", "moves": ["Brave Bird", "Roost", "Defog", "Close Combat"]},
+	},
+	"Starly": {
+		"LC Choice Scarf": {"level": 5, "evs": {"at": 236, "hp": 36, "sp": 196, "sa": 36}, "nature": "Naive", "ability": "Reckless", "item": "Choice Scarf", "moves": ["Brave Bird", "Double-Edge", "U-turn", "Heat Wave"]},
 	},
 	"Starmie": {
 		"UU Offensive": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Analytic", "item": "Life Orb", "moves": ["Hydro Pump", "Ice Beam", "Psyshock", "Rapid Spin"]},
@@ -2878,32 +3040,32 @@ var SETDEX_SM = {
 		"LC Defensive Rapid Spin": {"level": 5, "evs": {"df": 156, "hp": 116, "sp": 236}, "nature": "Timid", "ability": "Natural Cure", "item": "Eviolite", "moves": ["Rapid Spin", "Scald", "Psychic", "Recover"]},
 	},
 	"Steelix": {
-		"NU Tank": {"level": 100, "evs": {"sd": 12, "at": 252, "hp": 244}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Sturdy", "item": "Leftovers", "moves": ["Stealth Rock", "Gyro Ball", "Earthquake", "Toxic"]},
+		"NU Tank": {"level": 100, "evs": {"sd": 180, "at": 76, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Leftovers", "moves": ["Stealth Rock", "Heavy Slam", "Earthquake", "Curse"]},
 		"RU Utility": {"level": 100, "evs": {"sd": 220, "at": 36, "hp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Steelixite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Curse"]},
-		"UU Tank": {"level": 100, "evs": {"sd": 200, "df": 56, "hp": 252}, "nature": "Impish", "ability": "Sturdy", "item": "Steelixite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
+		"UU Offensive Stealth Rock": {"level": 100, "evs": {"sd": 48, "at": 208, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Sturdy", "item": "Steelixite", "moves": ["Stealth Rock", "Gyro Ball", "Earthquake", "Curse"]},
 	},
 	"Steelix-Mega": {
 		"RU Utility": {"level": 100, "evs": {"sd": 220, "at": 36, "hp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Steelixite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Curse"]},
-		"UU Tank": {"level": 100, "evs": {"sd": 200, "df": 56, "hp": 252}, "nature": "Impish", "ability": "Sturdy", "item": "Steelixite", "moves": ["Heavy Slam", "Earthquake", "Stealth Rock", "Toxic"]},
+		"UU Offensive Stealth Rock": {"level": 100, "evs": {"sd": 48, "at": 208, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Sturdy", "item": "Steelixite", "moves": ["Stealth Rock", "Gyro Ball", "Earthquake", "Curse"]},
 	},
 	"Stoutland": {
 		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Scrappy", "item": "Choice Band", "moves": ["Return", "Superpower", "Pursuit", "Facade"]},
 		"PU Sand Rush": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Life Orb", "moves": ["Return", "Superpower", "Crunch", "Facade"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Choice Band", "moves": ["Superpower", "Crunch", "Return", "Facade"]},
 		"RU Sand Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Choice Band", "moves": ["Return", "Superpower", "Pursuit", "Crunch"]},
-		"UU Sand Rush": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sand Rush", "item": "Choice Band", "moves": ["Return", "Superpower", "Crunch", "Facade"]},
 	},
 	"Stufful": {
 		"LC Swords Dance": {"level": 5, "evs": {"sd": 196, "df": 36, "at": 236, "sp": 36}, "nature": "Adamant", "ability": "Fluffy", "item": "Eviolite", "moves": ["Swords Dance", "Return", "Brick Break", "Ice Punch"]},
 	},
 	"Stunfisk": {
+		"PU Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Static", "item": "Leftovers", "moves": ["Stealth Rock", "Earth Power", "Discharge", "Toxic"]},
 		"NU Support": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Static", "item": "Leftovers", "moves": ["Stealth Rock", "Discharge", "Earth Power", "Toxic"]},
 	},
 	"Stunky": {
+		"LC Life Orb": {"level": 5, "evs": {"at": 252, "hp": 12, "sp": 244}, "ivs": {"df": 30, "sa": 30}, "nature": "Hasty", "ability": "Aftermath", "item": "Life Orb", "moves": ["Sucker Punch", "Play Rough", "Fire Blast", "Hidden Power Grass"]},
 		"LC Offensive Utility": {"level": 5, "evs": {"sd": 188, "df": 60, "at": 252, "sp": 4}, "nature": "Careful", "ability": "Aftermath", "item": "Eviolite", "moves": ["Pursuit", "Sucker Punch", "Defog", "Sludge Bomb"]},
 	},
 	"Sudowoodo": {
-		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Earthquake", "Sucker Punch", "Wood Hammer"]},
+		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Rock Head", "item": "Choice Band", "moves": ["Head Smash", "Earthquake", "Sucker Punch", "Wood Hammer"]},
 	},
 	"Suicune": {
 		"UU Calm Mind + Protect": {"level": 100, "evs": {"sd": 40, "hp": 252, "sp": 216}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Calm Mind", "Protect", "Scald", "Substitute"]},
@@ -2918,7 +3080,7 @@ var SETDEX_SM = {
 		"Monotype Substitute + Calm Mind (Water)": {"level": 100, "evs": {"sd": 40, "hp": 252, "sp": 216}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Scald", "Substitute", "Calm Mind", "Protect"]},
 	},
 	"Sunflora": {
-		"PU Solar Sweeper": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Solar Power", "item": "Firium Z", "moves": ["Sunny Day", "Solar Beam", "Earth Power", "Hidden Power Fire"]},
+		"PU Sun Wallbreaker": {"level": 100, "evs": {"hp": 92, "sp": 164, "sa": 252}, "nature": "Modest", "ability": "Solar Power", "item": "Life Orb", "moves": ["Solar Beam", "Earth Power", "Sludge Bomb", "Giga Drain"]},
 	},
 	"Surskit": {
 		"LC Sticky Web Setter": {"level": 5, "evs": {"sd": 20, "df": 20, "hp": 36, "sp": 236, "sa": 196}, "nature": "Timid", "ability": "Swift Swim", "item": "Focus Sash", "moves": ["Sticky Web", "Hydro Pump", "Giga Drain", "Haze"]},
@@ -2951,6 +3113,9 @@ var SETDEX_SM = {
 	"Swoobat": {
 		"PU Calm Mind": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Simple", "item": "Salac Berry", "moves": ["Calm Mind", "Substitute", "Stored Power", "Air Slash"]},
 	},
+	"Syclant": {
+		"CAP Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Mountaineer", "item": "Choice Band", "moves": ["U-turn", "Icicle Crash", "Earthquake", "Ice Shard"]},
+	},
 	"Sylveon": {
 		"UU Cleric": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Pixilate", "item": "Leftovers", "moves": ["Hyper Voice", "Wish", "Protect", "Heal Bell"]},
 		"Monotype Choice Specs": {"level": 100, "evs": {"df": 4, "hp": 240, "sp": 12, "sa": 252}, "nature": "Modest", "ability": "Pixilate", "item": "Choice Specs", "moves": ["Hyper Voice", "Hidden Power Fire", "Psyshock", "Shadow Ball"]},
@@ -2966,16 +3131,13 @@ var SETDEX_SM = {
 	},
 	"Tangela": {
 		"PU Defensive Pivot": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Eviolite", "moves": ["Giga Drain", "Hidden Power Fire", "Knock Off", "Leech Seed"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "hp": 252, "sa": 252}, "nature": "Modest", "ability": "Regenerator", "item": "Eviolite", "moves": ["Giga Drain", "Hidden Power Fire", "Leaf Storm", "Sleep Powder"]},
 	},
 	"Tangrowth": {
-		"OU Assault Vest": {"level": 100, "evs": {"sd": 228, "df": 28, "hp": 252}, "nature": "Sassy", "ability": "Regenerator", "item": "Assault Vest", "moves": ["Giga Drain", "Knock Off", "Hidden Power Ice", "Earthquake"]},
+		"OU Assault Vest": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Sassy", "ability": "Regenerator", "item": "Assault Vest", "moves": ["Giga Drain", "Knock Off", "Hidden Power Ice", "Earthquake"]},
 		"OU Physically Defensive": {"level": 100, "evs": {"sd": 48, "df": 212, "hp": 248}, "nature": "Relaxed", "ability": "Regenerator", "item": "Leftovers", "moves": ["Giga Drain", "Knock Off", "Sleep Powder", "Hidden Power Ice"]},
 	},
 	"Tapu Bulu": {
-		"OU Swords Dance": {"level": 100, "evs": {"sd": 216, "hp": 224, "sp": 68}, "nature": "Careful", "ability": "Grassy Surge", "item": "Leftovers", "moves": ["Swords Dance", "Horn Leech", "Superpower", "Synthesis"]},
-		"OU Assault Vest": {"level": 100, "evs": {"sd": 52, "df": 36, "at": 28, "hp": 248, "sp": 144}, "nature": "Impish", "ability": "Grassy Surge", "item": "Assault Vest", "moves": ["Horn Leech", "Wood Hammer", "Superpower", "Nature\u0027s Madness"]},
-		"OU SubSD": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Grassy Surge", "item": "Life Orb", "moves": ["Swords Dance", "Substitute", "Horn Leech", "Superpower"]},
+		"OU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Grassy Surge", "item": "Leftovers", "moves": ["Swords Dance", "Horn Leech", "Superpower", "Synthesis"]},
 		"OU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Grassy Surge", "item": "Choice Band", "moves": ["Wood Hammer", "Horn Leech", "Superpower", "Zen Headbutt"]},
 		"Doubles Assault Vest Pivot": {"level": 100, "evs": {"sd": 136, "at": 120, "hp": 252}, "nature": "Adamant", "ability": "Grassy Surge", "item": "Assault Vest", "moves": ["Wood Hammer", "Horn Leech", "Nature\u0027s Madness", "Stone Edge"]},
 		"VGC17 Scarf Bulu": {"level": 50, "evs": {"at": 252, "hp": 108, "sp": 148}, "nature": "Adamant", "ability": "Grassy Surge", "item": "Choice Scarf", "moves": ["Wood Hammer", "Horn Leech", "Superpower", "Stone Edge"]},
@@ -2989,8 +3151,8 @@ var SETDEX_SM = {
 	},
 	"Tapu Fini": {
 		"OU Defensive": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Misty Surge", "item": "Leftovers", "moves": ["Taunt", "Nature\u0027s Madness", "Moonblast", "Scald"]},
-		"Doubles Calm Mind": {"level": 100, "evs": {"sd": 28, "df": 72, "hp": 252, "sa": 156}, "nature": "Modest", "ability": "Misty Surge", "item": "Leftovers", "moves": ["Muddy Water", "Moonblast", "Calm Mind", "Protect"]},
-		"Doubles Support": {"level": 100, "evs": {"sd": 28, "df": 128, "hp": 252, "sa": 100}, "nature": "Bold", "ability": "Misty Surge", "item": "Mago Berry", "moves": ["Muddy Water", "Moonblast", "Heal Pulse", "Protect"]},
+		"Doubles Support": {"level": 100, "evs": {"df": 140, "hp": 252, "sa": 116}, "nature": "Calm", "ability": "Misty Surge", "item": "Wiki Berry", "moves": ["Muddy Water", "Moonblast", "Heal Pulse", "Protect"]},
+		"Doubles Calm Mind": {"level": 100, "evs": {"df": 32, "hp": 252, "sa": 224}, "nature": "Bold", "ability": "Misty Surge", "item": "Wiki Berry", "moves": ["Muddy Water", "Moonblast", "Calm Mind", "Protect"]},
 		"VGC17 Calm Mind": {"level": 50, "evs": {"sd": 140, "df": 116, "hp": 252}, "nature": "Bold", "ability": "Misty Surge", "item": "Leftovers", "moves": ["Calm Mind", "Muddy Water", "Moonblast", "Protect"]},
 		"VGC17 Choice Specs": {"level": 50, "evs": {"sd": 4, "hp": 252, "sa": 252}, "nature": "Modest", "ability": "Misty Surge", "item": "Choice Specs", "moves": ["Hydro Pump", "Muddy Water", "Dazzling Gleam", "Moonblast"]},
 		"Battle Spot Singles Calm Mind": {"level": 50, "evs": {"df": 252, "hp": 244, "sp": 12}, "nature": "Bold", "ability": "Misty Surge", "item": "Icium Z", "moves": ["Calm Mind", "Surf", "Moonblast", "Mist"]},
@@ -2998,12 +3160,10 @@ var SETDEX_SM = {
 		"Monotype Support (Fairy)": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Misty Surge", "item": "Leftovers", "moves": ["Taunt", "Nature\u0027s Madness", "Scald", "Defog"]},
 	},
 	"Tapu Koko": {
-		"OU Shuca Berry": {"level": 100, "evs": {"df": 12, "hp": 104, "sp": 216, "sa": 176}, "nature": "Timid", "ability": "Electric Surge", "item": "Shuca Berry", "moves": ["Thunderbolt", "Volt Switch", "Hidden Power Ice", "Roost"]},
-		"OU Special Z-Move": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Thunderbolt", "Roost", "Hidden Power Ice", "U-turn"]},
 		"OU Defog Pivot": {"level": 100, "evs": {"sd": 20, "hp": 20, "sp": 216, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Thunderbolt", "Defog", "Roost", "U-turn"]},
-		"OU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Choice Specs", "moves": ["Thunderbolt", "Dazzling Gleam", "Volt Switch", "Hidden Power Ice"]},
-		"OU Lightshot (Dual Screens)": {"level": 100, "evs": {"at": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Electric Surge", "item": "Light Clay", "moves": ["Taunt", "Reflect", "Light Screen", "U-turn"]},
-		"OU Z-Wild Charge": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Wild Charge", "Hidden Power Ice", "Taunt", "U-turn"]},
+		"OU Shuca Berry": {"level": 100, "evs": {"df": 12, "hp": 104, "sp": 216, "sa": 176}, "nature": "Timid", "ability": "Electric Surge", "item": "Shuca Berry", "moves": ["Thunderbolt", "Volt Switch", "Hidden Power Ice", "Roost"]},
+		"OU Dual Screens": {"level": 100, "evs": {"at": 8, "hp": 248, "sp": 252}, "nature": "Jolly", "ability": "Electric Surge", "item": "Light Clay", "moves": ["Taunt", "Reflect", "Light Screen", "U-turn"]},
+		"OU Z-Wild Charge": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Naive", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Wild Charge", "Hidden Power Ice", "Taunt", "U-turn"]},
 		"Uber Utility Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Thunder", "Nature\u0027s Madness", "Taunt", "U-turn"]},
 		"Doubles Special Attacker": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Life Orb", "moves": ["Thunderbolt", "Dazzling Gleam", "Volt Switch", "Protect"]},
 		"VGC17 ZAP!!": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Life Orb", "moves": ["Thunderbolt", "Dazzling Gleam", "Volt Switch", "Protect"]},
@@ -3012,7 +3172,8 @@ var SETDEX_SM = {
 		"Battle Spot Singles Mixed Attacker": {"level": 50, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "item": "Life Orb", "moves": ["Thunderbolt", "Brave Bird", "Dazzling Gleam", "U-turn"]},
 		"Battle Spot Singles Calm Mind": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Calm Mind", "Thunderbolt", "Dazzling Gleam", "Roost"]},
 		"Battle Spot Singles Physical Based Attacker": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Naive", "ability": "Electric Surge", "item": "Electrium Z", "moves": ["Wild Charge", "Brave Bird", "U-turn", "Dazzling Gleam"]},
-		"Monotype Terrain Setter (Electric)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Magnet", "moves": ["Volt Switch", "Thunderbolt", "Dazzling Gleam", "Hidden Power Ice"]},
+		"Monotype Choice Specs (Electric)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Choice Specs", "moves": ["Thunderbolt", "Volt Switch", "Hidden Power Ice", "Dazzling Gleam"]},
+		"Monotype Utility (Electric)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Magnet", "moves": ["Thunderbolt", "Hidden Power Ice", "Taunt", "U-turn"]},
 		"Monotype Pivot (Fairy)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Electric Surge", "item": "Magnet", "moves": ["Thunderbolt", "Hidden Power Ice", "Taunt", "U-turn"]},
 	},
 	"Tapu Lele": {
@@ -3023,8 +3184,8 @@ var SETDEX_SM = {
 		"Uber Psychic Terrain Support": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Psychic Surge", "item": "Terrain Extender", "moves": ["Psychic", "Moonblast", "Nature\u0027s Madness", "Taunt"]},
 		"Uber Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Psychic Surge", "item": "Choice Scarf", "moves": ["Psychic", "Moonblast", "Aromatherapy", "Hidden Power Fire"]},
 		"Doubles Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Psychic Surge", "item": "Choice Scarf", "moves": ["Psychic", "Moonblast", "Dazzling Gleam", "Focus Blast"]},
-		"Doubles Life Orb": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Psychic Surge", "item": "Life Orb", "moves": ["Psyshock", "Moonblast", "Taunt", "Protect"]},
-		"Doubles Bulky Pivot": {"level": 100, "evs": {"sd": 8, "hp": 212, "sp": 176, "sa": 112}, "nature": "Modest", "ability": "Psychic Surge", "item": "Sitrus Berry", "moves": ["Psyshock", "Moonblast", "Taunt", "Protect"]},
+		"Doubles All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Psychic Surge", "item": "Life Orb", "moves": ["Psyshock", "Moonblast", "Taunt", "Protect"]},
+		"Doubles Bulky Pivot": {"level": 100, "evs": {"df": 60, "hp": 252, "sp": 84, "sa": 112}, "nature": "Modest", "ability": "Psychic Surge", "item": "Wiki Berry", "moves": ["Psyshock", "Moonblast", "Taunt", "Protect"]},
 		"VGC17 Choice Scarf": {"level": 50, "evs": {"sd": 4, "df": 60, "hp": 28, "sp": 164, "sa": 252}, "nature": "Modest", "ability": "Psychic Surge", "item": "Choice Scarf", "moves": ["Psychic", "Moonblast", "Dazzling Gleam", "Hidden Power Fire"]},
 		"VGC17 Psychium Z": {"level": 50, "evs": {"df": 92, "hp": 164, "sa": 252}, "nature": "Modest", "ability": "Psychic Surge", "item": "Psychium Z", "moves": ["Psychic", "Moonblast", "Taunt", "Protect"]},
 		"VGC17 Life Orb": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Psychic Surge", "item": "Life Orb", "moves": ["Psychic", "Moonblast", "Thunderbolt", "Protect"]},
@@ -3033,7 +3194,7 @@ var SETDEX_SM = {
 		"Battle Spot Singles Versatile Attacker": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Psychic Surge", "item": "Psychium Z", "moves": ["Psychic", "Moonblast", "Shadow Ball", "Taunt"]},
 	},
 	"Tauros": {
-		"NU All-Out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Body Slam", "Earthquake", "Fire Blast", "Zen Headbutt"]},
+		"NU Tauros": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Sheer Force", "item": "Life Orb", "moves": ["Body Slam", "Fire Blast", "Work Up", "Earthquake"]},
 	},
 	"Teddiursa": {
 		"LC Quick Feet": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 196, "hp": 36, "sp": 196}, "nature": "Jolly", "ability": "Quick Feet", "item": "Toxic Orb", "moves": ["Facade", "Crunch", "Close Combat", "Protect"]},
@@ -3043,19 +3204,20 @@ var SETDEX_SM = {
 		"LC Offensive": {"level": 5, "evs": {"sd": 36, "df": 76, "sp": 196, "sa": 196}, "ivs": {"hp": 19}, "nature": "Timid", "ability": "Clear Body", "item": "Life Orb", "moves": ["Hydro Pump", "Sludge Bomb", "Knock Off", "Hidden Power Fire"]},
 	},
 	"Tentacruel": {
-		"UU Defensive Rapid Spin": {"level": 100, "evs": {"df": 156, "hp": 248, "sp": 96, "sa": 8}, "nature": "Timid", "ability": "Liquid Ooze", "item": "Black Sludge", "moves": ["Rapid Spin", "Scald", "Haze", "Toxic Spikes"]},
+		"UU Defensive": {"level": 100, "evs": {"df": 112, "hp": 252, "sp": 144}, "nature": "Timid", "ability": "Clear Body", "item": "Black Sludge", "moves": ["Scald", "Rapid Spin", "Haze", "Sludge Bomb"]},
 		"Uber Support": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Liquid Ooze", "item": "Leftovers", "moves": ["Toxic Spikes", "Scald", "Rapid Spin", "Protect"]},
 	},
+	"Tepig": {
+		"LC Life Orb": {"level": 5, "evs": {"at": 252, "sp": 236}, "nature": "Jolly", "ability": "Thick Fat", "item": "Life Orb", "moves": ["Flare Blitz", "Head Smash", "Sucker Punch", "Superpower"]},
+	},
 	"Terrakion": {
-		"UU Setup Sweeper": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Rockium Z", "moves": ["Stone Edge", "Close Combat", "Swords Dance", "Rock Polish"]},
-		"UU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Band", "moves": ["Close Combat", "Stone Edge", "Rock Slide", "Earthquake"]},
-		"UU Lead": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Focus Sash", "moves": ["Stealth Rock", "Stone Edge", "Close Combat", "Swords Dance"]},
-		"UU Choice Scarf": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Close Combat", "Stone Edge", "Rock Slide", "Earthquake"]},
+		"UU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Band", "moves": ["Close Combat", "Stone Edge", "Earthquake", "Rock Slide"]},
+		"UU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Swords Dance", "Stone Edge", "Close Combat", "Earthquake"]},
+		"UU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Close Combat", "Stone Edge", "Earthquake", "Rock Slide"]},
 		"OU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Rockium Z", "moves": ["Swords Dance", "Stone Edge", "Close Combat", "Stealth Rock"]},
 		"OU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Stone Edge", "Close Combat", "Rock Slide", "Toxic"]},
 		"Doubles Physical Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Life Orb", "moves": ["Close Combat", "Rock Slide", "Poison Jab", "Protect"]},
-		"Monotype Choice Scarf (Fighting)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Stone Edge", "Close Combat", "Iron Head", "Earthquake"]},
-		"Monotype Double Dance (Fighting)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Rockium Z", "moves": ["Swords Dance", "Rock Polish", "Close Combat", "Stone Edge"]},
+		"Monotype Choice Scarf (Fighting)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Stone Edge", "Close Combat", "Earthquake", "Iron Head"]},
 		"Monotype Choice Scarf (Rock)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Scarf", "moves": ["Stone Edge", "Close Combat", "Earthquake", "Poison Jab"]},
 		"Monotype Choice Band (Rock)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Choice Band", "moves": ["Stone Edge", "Close Combat", "Earthquake", "Quick Attack"]},
 	},
@@ -3063,16 +3225,15 @@ var SETDEX_SM = {
 		"PU RestTalk": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Careful", "ability": "Guts", "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Circle Throw", "Bulk Up"]},
 	},
 	"Thundurus": {
-		"OU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Nasty Plot", "Thunderbolt", "Hidden Power Ice", "Focus Blast"]},
+		"OU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Nasty Plot", "Thunderbolt", "Hidden Power Ice", "Focus Blast"]},
 		"OU Mixed Attacker": {"level": 100, "evs": {"at": 68, "sp": 252, "sa": 188}, "nature": "Naive", "ability": "Defiant", "item": "Life Orb", "moves": ["Thunderbolt", "Knock Off", "Superpower", "Hidden Power Ice"]},
-		"Doubles Defiant Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Electrium Z", "moves": ["Wild Charge", "Superpower", "Knock Off", "Protect"]},
 		"Battle Spot Singles SubToxic": {"level": 50, "evs": {"sd": 36, "df": 100, "hp": 244, "sp": 124, "sa": 4}, "ivs": {"at": 0}, "nature": "Bold", "ability": "Prankster", "item": "Leftovers", "moves": ["Substitute", "Toxic", "Protect", "Thunderbolt"]},
 		"Battle Spot Singles Offensive": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "ivs": {"at": 0}, "nature": "Timid", "ability": "Prankster", "item": "Electrium Z", "moves": ["Nasty Plot", "Thunderbolt", "Focus Blast", "Hidden Power Ice"]},
+		"Monotype Mixed Attacker (Electric)": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Defiant", "item": "Flyinium Z", "moves": ["Thunderbolt", "Knock Off", "Superpower", "Fly"]},
 		"Monotype Thunder Wave + 3 Attacks (Flying)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Thunder Wave", "Thunderbolt", "Hidden Power Ice", "Grass Knot"]},
 	},
 	"Thundurus-Therian": {
 		"OU Double Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Volt Absorb", "item": "Electrium Z", "moves": ["Agility", "Thunderbolt", "Hidden Power Ice", "Nasty Plot"]},
-		"Doubles Assault Vest": {"level": 100, "evs": {"sd": 16, "sp": 252, "sa": 240}, "nature": "Timid", "ability": "Volt Absorb", "item": "Assault Vest", "moves": ["Thunderbolt", "Volt Switch", "Hidden Power Ice", "Sludge Bomb"]},
 		"Battle Spot Singles Special Attacker": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Volt Absorb", "item": "Electrium Z", "moves": ["Thunderbolt", "Hidden Power Ice", "Sludge Wave", "Focus Blast"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Volt Absorb", "item": "Choice Scarf", "moves": ["Thunderbolt", "Hidden Power Ice", "Focus Blast", "Volt Switch"]},
 	},
@@ -3081,18 +3242,20 @@ var SETDEX_SM = {
 		"LC Bulk Up": {"level": 5, "evs": {"sd": 236, "df": 156, "at": 116}, "nature": "Careful", "ability": "Guts", "item": "Eviolite", "moves": ["Drain Punch", "Mach Punch", "Knock Off", "Bulk Up"]},
 	},
 	"Tirtouga": {
+		"LC Defensive": {"level": 5, "evs": {"sd": 156, "df": 92, "at": 52, "hp": 164, "sp": 20}, "nature": "Careful", "ability": "Solid Rock", "item": "Eviolite", "moves": ["Stealth Rock", "Stone Edge", "Knock Off", "Aqua Jet"]},
 		"LC Solid Rock Smash": {"level": 5, "evs": {"sd": 76, "df": 92, "at": 132, "hp": 4, "sp": 180}, "nature": "Jolly", "ability": "Solid Rock", "item": "Eviolite", "moves": ["Shell Smash", "Waterfall", "Stone Edge", "Zen Headbutt"]},
-		"LC Defensive": {"level": 5, "evs": {"sd": 156, "df": 252, "hp": 84, "sa": 12}, "nature": "Sassy", "ability": "Solid Rock", "item": "Eviolite", "moves": ["Stealth Rock", "Scald", "Stone Edge", "Knock Off"]},
 		"LC Sturdy Smash": {"level": 5, "evs": {"df": 92, "at": 212, "sp": 180}, "nature": "Jolly", "ability": "Sturdy", "item": "Berry Juice", "moves": ["Shell Smash", "Waterfall", "Stone Edge", "Zen Headbutt"]},
 	},
 	"Togedemaru": {
-		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Lightning Rod", "item": "Choice Scarf", "moves": ["Zing Zap", "Iron Head", "U-turn", "Toxic"]},
-		"PU Support Pivot": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Lightning Rod", "item": "Leftovers", "moves": ["Zing Zap", "Encore", "Toxic", "U-turn"]},
-		"PU Specially Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Lightning Rod", "item": "Leftovers", "moves": ["Wish", "Spiky Shield", "Zing Zap", "U-turn"]},
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Lightning Rod", "item": "Leftovers", "moves": ["U-turn", "Zing Zap", "Iron Head", "Wish"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Barbs", "item": "Choice Scarf", "moves": ["Zing Zap", "Iron Head", "U-turn", "Toxic"]},
+		"PU Support Pivot": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Barbs", "item": "Leftovers", "moves": ["Zing Zap", "Encore", "Toxic", "U-turn"]},
+		"PU Specially Defensive Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Iron Barbs", "item": "Rocky Helmet", "moves": ["Wish", "Spiky Shield", "Zing Zap", "U-turn"]},
+		"NU Showdown Usage": {"level": 100, "evs": {"sd": 252, "at": 4, "hp": 252}, "nature": "Careful", "ability": "Lightning Rod", "item": "Leftovers", "moves": ["U-turn", "Zing Zap", "Wish", "Spiky Shield"]},
+		"Doubles Showdown Usage": {"level": 100, "evs": {}, "nature": "Brave", "ability": "Sturdy", "item": "Shell Bell", "moves": ["Fake Out", "Spiky Shield", "Endeavor", "Nuzzle"]},
 	},
 	"Togekiss": {
 		"UU Nasty Plot": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Nasty Plot", "Heal Bell", "Air Slash", "Roost"]},
+		"UU Offensive Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Serene Grace", "item": "Babiri Berry", "moves": ["Nasty Plot", "Air Slash", "Flamethrower", "Roost"]},
 		"UU Support": {"level": 100, "evs": {"df": 160, "hp": 252, "sp": 96}, "nature": "Bold", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Air Slash", "Heal Bell", "Roost", "Defog"]},
 		"UU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Serene Grace", "item": "Choice Specs", "moves": ["Air Slash", "Dazzling Gleam", "Flamethrower", "Trick"]},
 		"Doubles Follow Me Support": {"level": 100, "evs": {"sd": 24, "df": 204, "hp": 252, "sp": 28}, "nature": "Calm", "ability": "Serene Grace", "item": "Wiki Berry", "moves": ["Air Slash", "Follow Me", "Tailwind", "Encore"]},
@@ -3113,17 +3276,18 @@ var SETDEX_SM = {
 		"Monotype Entry Hazard Remover": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Drought", "item": "Heat Rock", "moves": ["Rapid Spin", "Stealth Rock", "Lava Plume", "Yawn"]},
 	},
 	"Tornadus": {
-		"UU Offensive Support": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Prankster", "item": "Life Orb", "moves": ["Hurricane", "Heat Wave", "Superpower", "Tailwind"]},
-		"Doubles Defiant Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Misty Seed", "moves": ["Acrobatics", "Knock Off", "Tailwind", "Protect"]},
+		"UU Life Orb": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Defiant", "item": "Life Orb", "moves": ["Hurricane", "Heat Wave", "Superpower", "Grass Knot"]},
+		"UU Offensive Support": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Prankster", "item": "Flyinium Z", "moves": ["Hurricane", "U-turn", "Superpower", "Defog"]},
+		"Doubles Defiant Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Defiant", "item": "Misty Seed", "moves": ["Acrobatics", "Superpower", "Tailwind", "Protect"]},
 	},
 	"Tornadus-Therian": {
-		"OU Flyinium Z": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Regenerator", "item": "Flyinium Z", "moves": ["Hurricane", "Knock Off", "U-turn", "Defog"]},
+		"OU Flyinium Z": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Regenerator", "item": "Flyinium Z", "moves": ["Hurricane", "Knock Off", "U-turn", "Defog"]},
 		"OU Pivot": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Regenerator", "item": "Rocky Helmet", "moves": ["Hurricane", "Knock Off", "U-turn", "Defog"]},
+		"Monotype Offensive Utility": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Regenerator", "item": "Flyinium Z", "moves": ["Hurricane", "U-turn", "Knock Off", "Defog"]},
 	},
 	"Torterra": {
-		"PU Stealth Rock": {"level": 100, "evs": {"df": 196, "at": 60, "hp": 252}, "nature": "Adamant", "ability": "Overgrow", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Wood Hammer", "Synthesis"]},
-		"PU Dancing Turtle (Double Dance)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Shell Armor", "item": "Rockium Z", "moves": ["Rock Polish", "Swords Dance", "Earthquake", "Stone Edge"]},
-		"NU Stealth Rock Wall": {"level": 100, "evs": {"sd": 176, "at": 80, "hp": 252}, "nature": "Careful", "ability": "Overgrow", "item": "Leftovers", "moves": ["Stealth Rock", "Wood Hammer", "Earthquake", "Synthesis"]},
+		"NU Defensive": {"level": 100, "evs": {"sd": 136, "df": 68, "at": 56, "hp": 248}, "nature": "Adamant", "ability": "Overgrow", "item": "Leftovers", "moves": ["Stealth Rock", "Wood Hammer", "Earthquake", "Synthesis"]},
+		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Overgrow", "item": "Grassium Z", "moves": ["Swords Dance", "Wood Hammer", "Earthquake", "Stone Edge"]},
 	},
 	"Totodile": {
 		"LC Dragon Dance": {"level": 5, "evs": {"df": 4, "at": 236, "sp": 252}, "nature": "Adamant", "ability": "Sheer Force", "item": "Eviolite", "moves": ["Dragon Dance", "Waterfall", "Ice Punch", "Superpower"]},
@@ -3132,18 +3296,15 @@ var SETDEX_SM = {
 		"PU Mixed Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Rash", "ability": "Skill Link", "item": "Life Orb", "moves": ["Boomburst", "Brave Bird", "Bullet Seed", "Overheat"]},
 	},
 	"Toxapex": {
-		"OU The Pex": {"level": 100, "evs": {"sd": 252, "df": 8, "hp": 248}, "nature": "Calm", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Scald", "Haze", "Recover", "Toxic"]},
+		"OU The Pex": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Scald", "Haze", "Recover", "Toxic"]},
 		"Uber Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Rocky Helmet", "moves": ["Toxic Spikes", "Scald", "Haze", "Recover"]},
 		"Battle Spot Singles Physically Defensive": {"level": 50, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Recover", "Scald", "Haze", "Toxic"]},
 		"Monotype Physically Defensive (Water)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Scald", "Recover", "Toxic Spikes", "Haze"]},
 		"Monotype Defensive Pivot (Poison)": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Regenerator", "item": "Black Sludge", "moves": ["Scald", "Recover", "Toxic Spikes", "Haze"]},
 	},
 	"Toxicroak": {
-		"NU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Swords Dance", "Gunk Shot", "Drain Punch", "Sucker Punch"]},
-		"NU Nasty Plot": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Nasty Plot", "Sludge Wave", "Vacuum Wave", "Shadow Ball"]},
 		"RU Swords Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Swords Dance", "Gunk Shot", "Drain Punch", "Ice Punch"]},
-		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Swords Dance", "Gunk Shot", "Drain Punch", "Sucker Punch"]},
-		"UU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Nasty Plot", "Sludge Bomb", "Vacuum Wave", "Dark Pulse"]},
+		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Dry Skin", "item": "Life Orb", "moves": ["Swords Dance", "Drain Punch", "Gunk Shot", "Sucker Punch"]},
 	},
 	"Trapinch": {
 		"LC Trapper": {"level": 5, "evs": {"sd": 76, "df": 236, "at": 36, "hp": 156}, "nature": "Brave", "ability": "Arena Trap", "item": "Berry Juice", "moves": ["Earthquake", "Rock Slide", "Feint", "Giga Drain"]},
@@ -3152,7 +3313,7 @@ var SETDEX_SM = {
 		"LC Swords Dance": {"level": 5, "evs": {"df": 156, "at": 156, "hp": 116, "sp": 36}, "nature": "Adamant", "ability": "Unburden", "item": "Berry Juice", "moves": ["Swords Dance", "Bullet Seed", "Drain Punch", "Acrobatics"]},
 	},
 	"Trevenant": {
-		"PU SkillTree (Harvest)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Harvest", "item": "Sitrus Berry", "moves": ["Leech Seed", "Will-O-Wisp", "Substitute", "Phantom Force"]},
+		"PU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Natural Cure", "item": "Choice Band", "moves": ["Wood Hammer", "Earthquake", "Rock Slide", "Shadow Claw"]},
 	},
 	"Tropius": {
 		"PU Harvest": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Harvest", "item": "Sitrus Berry", "moves": ["Leech Seed", "Substitute", "Air Slash", "Protect"]},
@@ -3163,28 +3324,35 @@ var SETDEX_SM = {
 	"Tsareena": {
 		"RU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Queenly Majesty", "item": "Meadow Plate", "moves": ["Rapid Spin", "Power Whip", "Knock Off", "Synthesis"]},
 		"UU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Queenly Majesty", "item": "Choice Band", "moves": ["Power Whip", "Knock Off", "High Jump Kick", "U-turn"]},
+		"UU Offensive Utility": {"level": 100, "evs": {"at": 252, "hp": 56, "sp": 200}, "nature": "Adamant", "ability": "Queenly Majesty", "item": "Meadow Plate", "moves": ["Power Whip", "Rapid Spin", "Knock Off", "Synthesis"]},
 	},
 	"Turtonator": {
 		"PU Shell Smash": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Shell Armor", "item": "Dragonium Z", "moves": ["Fire Blast", "Shell Smash", "Draco Meteor", "Dragon Pulse"]},
 	},
+	"Tympole": {
+		"LC Rain Dance Sweeper": {"level": 5, "evs": {"sd": 36, "df": 116, "sp": 84, "sa": 196}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Rain Dance", "Hydro Pump", "Earth Power", "Sludge Bomb"]},
+	},
 	"Type: Null": {
-		"PU Showdown Usage": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Eviolite", "moves": ["Rest", "Swords Dance", "Sleep Talk", "Return"]},
+		"PU Bulky Pivot": {"level": 100, "evs": {"sd": 248, "df": 8, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Eviolite", "moves": ["U-turn", "Return", "Rest", "Sleep Talk"]},
+		"PU Swords Dance": {"level": 100, "evs": {"sd": 248, "df": 8, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Eviolite", "moves": ["Swords Dance", "Return", "Rest", "Sleep Talk"]},
 		"NU Swords Dance": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Eviolite", "moves": ["Swords Dance", "Return", "Rest", "Iron Defense"]},
 		"NU Pivot": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Battle Armor", "item": "Eviolite", "moves": ["U-turn", "Return", "Rest", "Sleep Talk"]},
 	},
 	"Typhlosion": {
 		"NU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Specs", "moves": ["Eruption", "Fire Blast", "Hidden Power Grass", "Focus Blast"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flash Fire", "item": "Choice Specs", "moves": ["Eruption", "Flamethrower", "Solar Beam", "Overheat"]},
 	},
 	"Tyranitar": {
-		"OU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 80, "sp": 176}, "nature": "Adamant", "ability": "Sand Stream", "item": "Choice Band", "moves": ["Stone Edge", "Crunch", "Pursuit", "Earthquake"]},
 		"OU Stealth Rock": {"level": 100, "evs": {"at": 252, "hp": 168, "sp": 88}, "nature": "Adamant", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Stealth Rock", "Pursuit", "Stone Edge", "Fire Punch"]},
+		"OU Choice Band": {"level": 100, "evs": {"sd": 44, "at": 252, "hp": 8, "sp": 204}, "nature": "Adamant", "ability": "Sand Stream", "item": "Choice Band", "moves": ["Stone Edge", "Crunch", "Pursuit", "Earthquake"]},
+		"OU Assault Vest": {"level": 100, "evs": {"sd": 232, "hp": 184, "sp": 92}, "nature": "Careful", "ability": "Sand Stream", "item": "Assault Vest", "moves": ["Rock Slide", "Crunch", "Pursuit", "Earthquake"]},
 		"OU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Ice Punch", "Fire Punch"]},
 		"Uber Utility": {"level": 100, "evs": {"df": 148, "at": 76, "hp": 248, "sp": 36}, "nature": "Adamant", "ability": "Sand Stream", "item": "Lum Berry", "moves": ["Stealth Rock", "Pursuit", "Rock Slide", "Toxic"]},
 		"Uber Mega Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Crunch", "Ice Punch"]},
 		"Uber Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Choice Band", "moves": ["Stone Edge", "Crunch", "Pursuit", "Superpower"]},
+		"Doubles Offensive": {"level": 100, "evs": {"at": 252, "hp": 88, "sp": 168}, "nature": "Adamant", "ability": "Sand Stream", "item": "Rockium Z", "moves": ["Crunch", "Rock Slide", "Ice Punch", "Protect"]},
 		"Doubles Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sand Stream", "item": "Choice Band", "moves": ["Crunch", "Rock Slide", "Stone Edge", "Superpower"]},
 		"Doubles Mega Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Rock Slide", "Crunch", "Dragon Dance", "Protect"]},
-		"Doubles Offensive": {"level": 100, "evs": {"at": 252, "hp": 88, "sp": 168}, "nature": "Adamant", "ability": "Sand Stream", "item": "Rockium Z", "moves": ["Crunch", "Rock Slide", "Ice Punch", "Protect"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Ice Punch", "Fire Punch"]},
 		"Battle Spot Singles Mega + 4 Attacks": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Stone Edge", "Ice Punch", "Crunch", "Superpower"]},
 		"Battle Spot Singles Specially-Defensive Support": {"level": 50, "evs": {"sd": 148, "at": 108, "hp": 252}, "nature": "Adamant", "ability": "Sand Stream", "item": "Lum Berry", "moves": ["Pursuit", "Rock Tomb", "Stealth Rock", "Roar"]},
@@ -3198,6 +3366,7 @@ var SETDEX_SM = {
 		"OU Stealth Rock": {"level": 100, "evs": {"at": 252, "hp": 168, "sp": 88}, "nature": "Adamant", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Stealth Rock", "Pursuit", "Stone Edge", "Fire Punch"]},
 		"OU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Ice Punch", "Fire Punch"]},
 		"Uber Mega Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Crunch", "Ice Punch"]},
+		"Doubles Offensive": {"level": 100, "evs": {"at": 252, "hp": 88, "sp": 168}, "nature": "Adamant", "ability": "Sand Stream", "item": "Rockium Z", "moves": ["Crunch", "Rock Slide", "Ice Punch", "Protect"]},
 		"Doubles Mega Dragon Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Rock Slide", "Crunch", "Dragon Dance", "Protect"]},
 		"Battle Spot Singles Dragon Dance": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Jolly", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Dragon Dance", "Stone Edge", "Ice Punch", "Fire Punch"]},
 		"Battle Spot Singles Mega + 4 Attacks": {"level": 50, "evs": {"sd": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sand Stream", "item": "Tyranitarite", "moves": ["Stone Edge", "Ice Punch", "Crunch", "Superpower"]},
@@ -3213,19 +3382,20 @@ var SETDEX_SM = {
 	},
 	"Umbreon": {
 		"RU Cleric": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Synchronize", "item": "Leftovers", "moves": ["Wish", "Protect", "Heal Bell", "Foul Play"]},
+		"UU Specially Defensive": {"level": 100, "evs": {"sd": 252, "hp": 252, "sp": 4}, "nature": "Calm", "ability": "Synchronize", "item": "Leftovers", "moves": ["Foul Play", "Heal Bell", "Wish", "Protect"]},
 	},
 	"Unfezant": {
-		"PU Critical Hit": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Super Luck", "item": "Flyinium Z", "moves": ["Tailwind", "Hypnosis", "U-turn", "Return"]},
+		"PU Tailwind Support": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Super Luck", "item": "Scope Lens", "moves": ["Tailwind", "Hypnosis", "U-turn", "Return"]},
 	},
 	"Unown": {
-		"PU Reading Glasses": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Specs", "moves": ["Hidden Power Psychic"]},
+		"PU Mesprit Unknown": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Levitate", "item": "Choice Specs", "moves": ["Hidden Power Psychic"]},
 	},
 	"Ursaring": {
-		"PU All-Out Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Quick Feet", "item": "Toxic Orb", "moves": ["Facade", "Close Combat", "Crunch", "Swords Dance"]},
+		"PU Trick Room Wallbreaker": {"level": 100, "evs": {"sd": 4, "at": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Brave", "ability": "Guts", "item": "Flame Orb", "moves": ["Swords Dance", "Facade", "Crunch", "Close Combat"]},
 	},
 	"Uxie": {
 		"NU Stealth Rock Utility": {"level": 100, "evs": {"df": 80, "hp": 252, "sp": 176}, "nature": "Timid", "ability": "Levitate", "item": "Leftovers", "moves": ["Stealth Rock", "Psychic", "U-turn", "Protect"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"df": 196, "hp": 252, "sp": 60}, "nature": "Bold", "ability": "Levitate", "item": "Leftovers", "moves": ["Stealth Rock", "Psychic", "Knock Off", "Toxic"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Light Clay", "moves": ["Stealth Rock", "U-turn", "Reflect", "Memento"]},
 		"UU Trick Room Setter": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Levitate", "item": "Mental Herb", "moves": ["Trick Room", "Stealth Rock", "Memento", "Magic Coat"]},
 		"OU Trick Room Setter": {"level": 100, "evs": {"sd": 140, "df": 116, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Levitate", "item": "Mental Herb", "moves": ["Trick Room", "Stealth Rock", "Memento", "Magic Coat"]},
 	},
@@ -3236,8 +3406,7 @@ var SETDEX_SM = {
 		"VGC17 Choice Scarf": {"level": 50, "evs": {"hp": 56, "sp": 200, "sa": 252}, "nature": "Timid", "ability": "Snow Warning", "item": "Choice Scarf", "moves": ["Blizzard", "Freeze-Dry", "Hidden Power Fire", "Sheer Cold"]},
 	},
 	"Vaporeon": {
-		"NU Wish Support": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Wish", "Protect", "Toxic"]},
-		"NU Z-Celebrate": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Water Absorb", "item": "Normalium Z", "moves": ["Celebrate", "Hydro Pump", "Ice Beam", "Shadow Ball"]},
+		"NU Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Toxic", "Wish", "Protect"]},
 	},
 	"Venipede": {
 		"LC Entry Hazard Stacker": {"level": 5, "evs": {"sd": 44, "df": 204, "at": 76, "sp": 148, "sa": 36}, "nature": "Serious", "ability": "Speed Boost", "item": "Grassium Z", "moves": ["Spikes", "Solar Beam", "Protect", "Pin Missile"]},
@@ -3246,14 +3415,9 @@ var SETDEX_SM = {
 		"UU Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Tinted Lens", "item": "Buginium Z", "moves": ["Quiver Dance", "Sleep Powder", "Bug Buzz", "Sludge Bomb"]},
 	},
 	"Venusaur": {
-		"NU Life Orb": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Life Orb", "moves": ["Leaf Storm", "Sludge Bomb", "Synthesis", "Sleep Powder"]},
-		"NU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Overgrow", "item": "Choice Specs", "moves": ["Leaf Storm", "Giga Drain", "Sludge Bomb", "Hidden Power Fire"]},
-		"NU Z-Celebrate": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Chlorophyll", "item": "Normalium Z", "moves": ["Celebrate", "Sludge Bomb", "Giga Drain", "Growth"]},
-		"NU SpDef": {"level": 100, "evs": {"sd": 252, "hp": 252, "sa": 4}, "nature": "Timid", "ability": "Overgrow", "item": "Black Sludge", "moves": ["Synthesis", "Sludge Bomb", "Giga Drain", "Sleep Powder"]},
 		"RU Sun Sweeper": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Growth", "Sludge Bomb", "Giga Drain", "Hidden Power Fire"]},
 		"OU Defensive": {"level": 100, "evs": {"sd": 156, "df": 88, "hp": 248, "sp": 16}, "nature": "Calm", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Leech Seed", "Sludge Bomb", "Synthesis", "Hidden Power Fire"]},
 		"Uber Defensive": {"level": 100, "evs": {"sd": 76, "df": 180, "hp": 252}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Leech Seed", "Toxic", "Synthesis", "Grass Knot"]},
-		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 84, "df": 108, "hp": 252, "sp": 12, "sa": 52}, "nature": "Modest", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Giga Drain", "Synthesis", "Protect"]},
 		"Battle Spot Singles Bulky Offense": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Synthesis", "Giga Drain", "Hidden Power Fire"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Synthesis", "Leech Seed", "Giga Drain"]},
 		"Monotype Physical Tank (Poison)": {"level": 100, "evs": {"sd": 28, "df": 212, "hp": 252, "sp": 16}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Giga Drain", "Sludge Bomb", "Synthesis", "Hidden Power Fire"]},
@@ -3262,7 +3426,6 @@ var SETDEX_SM = {
 	"Venusaur-Mega": {
 		"OU Defensive": {"level": 100, "evs": {"sd": 156, "df": 88, "hp": 248, "sp": 16}, "nature": "Calm", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Leech Seed", "Sludge Bomb", "Synthesis", "Hidden Power Fire"]},
 		"Uber Defensive": {"level": 100, "evs": {"sd": 76, "df": 180, "hp": 252}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Leech Seed", "Toxic", "Synthesis", "Grass Knot"]},
-		"Doubles Bulky Attacker": {"level": 100, "evs": {"sd": 84, "df": 108, "hp": 252, "sp": 12, "sa": 52}, "nature": "Modest", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Giga Drain", "Synthesis", "Protect"]},
 		"Battle Spot Singles Bulky Offense": {"level": 50, "evs": {"hp": 252, "sp": 4, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Synthesis", "Giga Drain", "Hidden Power Fire"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Sludge Bomb", "Synthesis", "Leech Seed", "Giga Drain"]},
 		"Monotype Physical Tank (Poison)": {"level": 100, "evs": {"sd": 28, "df": 212, "hp": 252, "sp": 16}, "nature": "Bold", "ability": "Chlorophyll", "item": "Venusaurite", "moves": ["Giga Drain", "Sludge Bomb", "Synthesis", "Hidden Power Fire"]},
@@ -3272,18 +3435,20 @@ var SETDEX_SM = {
 		"PU Utility": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Pressure", "item": "Leftovers", "moves": ["Defog", "Bug Buzz", "U-turn", "Destiny Bond"]},
 	},
 	"Victini": {
-		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Scarf", "moves": ["V-create", "Bolt Strike", "U-turn", "Trick"]},
 		"OU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Band", "moves": ["V-create", "Bolt Strike", "U-turn", "Zen Headbutt"]},
+		"OU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Scarf", "moves": ["V-create", "Bolt Strike", "U-turn", "Trick"]},
 		"OU Z-Celebrate": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Victory Star", "item": "Normalium Z", "moves": ["Celebrate", "Searing Shot", "Stored Power", "Focus Blast"]},
 		"Doubles Choice Scarf": {"level": 100, "evs": {"at": 84, "hp": 172, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Scarf", "moves": ["Final Gambit", "V-create", "Bolt Strike", "U-turn"]},
 		"Monotype Choice Scarf (Psychic)": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Hasty", "ability": "Victory Star", "item": "Choice Scarf", "moves": ["V-create", "Bolt Strike", "U-turn", "Blue Flare"]},
 		"Monotype Choice Band (Psychic)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Band", "moves": ["V-create", "Bolt Strike", "U-turn", "Trick"]},
+		"Monotype Choice Band (Fire)": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Victory Star", "item": "Choice Band", "moves": ["V-create", "Bolt Strike", "U-turn", "Trick"]},
 	},
 	"Victreebel": {
 		"PU Chlorophyll Sweeper": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Life Orb", "moves": ["Solar Beam", "Sludge Bomb", "Weather Ball", "Sleep Powder"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Chlorophyll", "item": "Poisonium Z", "moves": ["Weather Ball", "Sludge Bomb", "Solar Beam", "Growth"]},
 	},
 	"Vigoroth": {
-		"PU Bulk Up": {"level": 100, "evs": {"sd": 240, "hp": 252, "sp": 16}, "nature": "Jolly", "ability": "Vital Spirit", "item": "Eviolite", "moves": ["Bulk Up", "Slack Off", "Taunt", "Return"]},
+		"PU Bulk Up": {"level": 100, "evs": {"sd": 240, "hp": 252, "sp": 16}, "nature": "Jolly", "ability": "Vital Spirit", "item": "Eviolite", "moves": ["Bulk Up", "Taunt", "Return", "Slack Off"]},
 	},
 	"Vikavolt": {
 		"NU Tank": {"level": 100, "evs": {"sd": 44, "hp": 252, "sp": 76, "sa": 136}, "nature": "Modest", "ability": "Levitate", "item": "Leftovers", "moves": ["Bug Buzz", "Volt Switch", "Energy Ball", "Roost"]},
@@ -3291,39 +3456,41 @@ var SETDEX_SM = {
 		"VGC17 Assault Vest": {"level": 50, "evs": {"sd": 180, "df": 52, "hp": 244, "sp": 4, "sa": 28}, "nature": "Modest", "ability": "Levitate", "item": "Assault Vest", "moves": ["Thunderbolt", "Bug Buzz", "Discharge", "Electroweb"]},
 		"VGC17 String Shot Support": {"level": 50, "evs": {"sd": 156, "df": 68, "hp": 252, "sp": 4, "sa": 28}, "nature": "Modest", "ability": "Levitate", "item": "Iapapa Berry", "moves": ["Thunderbolt", "Bug Buzz", "String Shot", "Protect"]},
 	},
-	"Vikavolt-Totem": {
-		"NU Showdown Usage": {"level": 100, "evs": {"sd": 44, "hp": 188, "sp": 140, "sa": 136}, "nature": "Modest", "ability": "Levitate", "item": "Leftovers", "moves": ["Bug Buzz", "Energy Ball", "Volt Switch", "Roost"]},
-	},
 	"Vileplume": {
 		"NU Defensive": {"level": 100, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "ability": "Effect Spore", "item": "Black Sludge", "moves": ["Giga Drain", "Sludge Bomb", "Strength Sap", "Sleep Powder"]},
 		"UU Defensive Utility": {"level": 100, "evs": {"df": 252, "hp": 252, "sa": 4}, "nature": "Bold", "ability": "Effect Spore", "item": "Black Sludge", "moves": ["Sludge Bomb", "Strength Sap", "Sleep Powder", "Hidden Power Fire"]},
 	},
 	"Virizion": {
-		"NU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Rockium Z", "moves": ["Swords Dance", "Leaf Blade", "Close Combat", "Stone Edge"]},
 		"RU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Grassium Z", "moves": ["Swords Dance", "Leaf Blade", "Close Combat", "Stone Edge"]},
 	},
 	"Vivillon": {
 		"NU Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Compound Eyes", "item": "Flyinium Z", "moves": ["Quiver Dance", "Hurricane", "Energy Ball", "Sleep Powder"]},
+		"AG The Butterfly Effect (Quiver Dance)": {"level": 100, "evs": {"df": 136, "sp": 252, "sa": 120}, "nature": "Timid", "ability": "Compound Eyes", "item": "Leftovers", "moves": ["Sleep Powder", "Substitute", "Quiver Dance", "Hurricane"]},
 	},
 	"Volbeat": {
 		"PU Weather Setter": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Prankster", "item": "Heat Rock", "moves": ["Sunny Day", "U-turn", "Thunder Wave", "Encore"]},
 	},
 	"Volcanion": {
-		"UU Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Water Absorb", "item": "Choice Scarf", "moves": ["Steam Eruption", "Fire Blast", "Sludge Bomb", "Toxic"]},
-		"UU Wallbreaker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Steam Eruption", "Fire Blast", "Hidden Power Electric", "Sludge Wave"]},
-		"UU All-out Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Grassium Z", "moves": ["Steam Eruption", "Fire Blast", "Sludge Wave", "Solar Beam"]},
+		"UU Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Choice Specs", "moves": ["Steam Eruption", "Fire Blast", "Earth Power", "Sludge Bomb"]},
+		"UU Toxic": {"level": 100, "evs": {"hp": 248, "sp": 216, "sa": 44}, "nature": "Modest", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Steam Eruption", "Flamethrower", "Toxic", "Protect"]},
 		"OU Substitute": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Substitute", "Steam Eruption", "Flamethrower", "Earth Power"]},
 		"Doubles All-out Attacker": {"level": 100, "evs": {"sd": 44, "hp": 208, "sp": 44, "sa": 212}, "nature": "Modest", "ability": "Water Absorb", "item": "Shuca Berry", "moves": ["Steam Eruption", "Heat Wave", "Hidden Power Ice", "Protect"]},
 		"Doubles Substitute": {"level": 100, "evs": {"sd": 212, "hp": 220, "sa": 76}, "nature": "Modest", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Steam Eruption", "Heat Wave", "Substitute", "Protect"]},
 	},
 	"Volcarona": {
+		"OU Bulky Quiver Dance": {"level": 100, "evs": {"df": 124, "hp": 248, "sp": 136}, "nature": "Timid", "ability": "Flame Body", "item": "Buginium Z", "moves": ["Quiver Dance", "Flamethrower", "Bug Buzz", "Roost"]},
 		"OU Quiver Dance": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Buginium Z", "moves": ["Quiver Dance", "Fire Blast", "Bug Buzz", "Hidden Power Ground"]},
-		"OU SubSwarm": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Swarm", "item": "Buginium Z", "moves": ["Bug Buzz", "Fire Blast", "Quiver Dance", "Substitute"]},
-		"Doubles Quiver Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Firium Z", "moves": ["Heat Wave", "Giga Drain", "Quiver Dance", "Protect"]},
+		"Doubles Showdown Usage": {"level": 100, "evs": {"df": 252, "hp": 252, "sp": 4}, "nature": "Bold", "ability": "Flame Body", "item": "Charti Berry", "moves": ["Quiver Dance", "Heat Wave", "Protect", "Giga Drain"]},
 		"Battle Spot Singles Special Sweeper": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Focus Sash", "moves": ["Quiver Dance", "Fire Blast", "Bug Buzz", "Giga Drain"]},
 		"Battle Spot Singles Choiced Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Choice Scarf", "moves": ["Fire Blast", "Bug Buzz", "Fiery Dance", "Hidden Power Ice"]},
 		"Monotype Setup Sweeper (Bug)": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Firium Z", "moves": ["Quiver Dance", "Fire Blast", "Hidden Power Ground", "Giga Drain"]},
 		"Monotype Quiver Dance Sweeper (Fire)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Flame Body", "item": "Firium Z", "moves": ["Quiver Dance", "Fire Blast", "Giga Drain", "Bug Buzz"]},
+	},
+	"Volkraken": {
+		"CAP Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Analytic", "item": "Choice Scarf", "moves": ["Fire Blast", "Hydro Pump", "U-turn", "Flamethrower"]},
+	},
+	"Voodoom": {
+		"CAP Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Nasty Plot", "Dark Pulse", "Focus Blast", "Flash Cannon"]},
 	},
 	"Vullaby": {
 		"LC Weak Armor Pivot": {"level": 5, "evs": {"df": 76, "at": 236, "sp": 196}, "nature": "Adamant", "ability": "Weak Armor", "item": "Berry Juice", "moves": ["Brave Bird", "Knock Off", "U-turn", "Defog"]},
@@ -3334,6 +3501,9 @@ var SETDEX_SM = {
 	},
 	"Vulpix-Alola": {
 		"LC Hail Support": {"level": 5, "evs": {"hp": 52, "sp": 240, "sa": 200}, "nature": "Timid", "ability": "Snow Warning", "item": "Light Clay", "moves": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Hidden Power Ground"]},
+	},
+	"Wailmer": {
+		"LC Choice Scarf": {"level": 5, "evs": {"hp": 36, "sp": 200, "sa": 200}, "nature": "Timid", "ability": "Pressure", "item": "Choice Scarf", "moves": ["Water Spout", "Hydro Pump", "Ice Beam", "Hidden Power Fire"]},
 	},
 	"Wailord": {
 		"PU Pressure Stall": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Pressure", "item": "Leftovers", "moves": ["Aqua Ring", "Scald", "Substitute", "Protect"]},
@@ -3352,17 +3522,19 @@ var SETDEX_SM = {
 	},
 	"Weezing": {
 		"PU Physically Defensive": {"level": 100, "evs": {"df": 224, "hp": 252, "sp": 32}, "nature": "Bold", "ability": "Levitate", "item": "Black Sludge", "moves": ["Sludge Bomb", "Toxic Spikes", "Will-O-Wisp", "Taunt"]},
+		"NU Physically Defensive": {"level": 100, "evs": {"df": 212, "hp": 252, "sp": 44}, "nature": "Bold", "ability": "Levitate", "item": "Rocky Helmet", "moves": ["Sludge Bomb", "Will-O-Wisp", "Taunt", "Pain Split"]},
 	},
 	"Whimsicott": {
-		"NU Life Orb": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Moonblast", "Energy Ball", "Psychic", "Defog"]},
 		"NU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Infiltrator", "item": "Choice Specs", "moves": ["Moonblast", "Energy Ball", "Psychic", "U-turn"]},
-		"RU Bulky Pivot": {"level": 100, "evs": {"df": 252, "hp": 248, "sp": 8}, "nature": "Bold", "ability": "Prankster", "item": "Leftovers", "moves": ["Moonblast", "Encore", "U-turn", "Tailwind"]},
-		"UU Offensive Support": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Moonblast", "Psychic", "Hidden Power Fire", "Memento"]},
-		"Doubles Prankster Support": {"level": 100, "evs": {"hp": 192, "sp": 216, "sa": 100}, "nature": "Timid", "ability": "Prankster", "item": "Focus Sash", "moves": ["Moonblast", "Tailwind", "Encore", "Fake Tears"]},
+		"NU Life Orb": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Life Orb", "moves": ["Moonblast", "Energy Ball", "Psychic", "Defog"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Prankster", "item": "Leftovers", "moves": ["Moonblast", "Encore", "Energy Ball", "U-turn"]},
 		"VGC17 Tailwind Support": {"level": 50, "evs": {"df": 4, "hp": 252, "sp": 252}, "nature": "Timid", "ability": "Prankster", "item": "Focus Sash", "moves": ["Moonblast", "Tailwind", "Encore", "Taunt"]},
 	},
 	"Whiscash": {
 		"PU Dragon Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Oblivious", "item": "Flyinium Z", "moves": ["Dragon Dance", "Earthquake", "Waterfall", "Bounce"]},
+	},
+	"Whismur": {
+		"LC Trick Room Breaker": {"level": 5, "evs": {"sd": 36, "df": 36, "hp": 244, "sa": 188}, "nature": "Quiet", "ability": "Soundproof", "item": "Life Orb", "moves": ["Hyper Voice", "Shadow Ball", "Ice Beam", "Fire Blast"]},
 	},
 	"Wigglytuff": {
 		"PU Competitive": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Competitive", "item": "Life Orb", "moves": ["Hyper Voice", "Dazzling Gleam", "Fire Blast", "Stealth Rock"]},
@@ -3379,6 +3551,12 @@ var SETDEX_SM = {
 	"Wishiwashi-School": {
 		"PU Trick Room Sweeper": {"level": 100, "evs": {"df": 4, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Quiet", "ability": "Schooling", "item": "Choice Specs", "moves": ["Hydro Pump", "Ice Beam", "Hidden Power Grass", "U-turn"]},
 	},
+	"Wobbuffet": {
+		"Uber Please Free Custap (Trapper)": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Calm", "ability": "Shadow Tag", "item": "Sitrus Berry", "moves": ["Encore", "Counter", "Mirror Coat", "Safeguard"]},
+	},
+	"Woobat": {
+		"LC Simple Sweeper": {"level": 5, "evs": {"df": 12, "hp": 76, "sp": 180, "sa": 236}, "nature": "Timid", "ability": "Simple", "item": "Eviolite", "moves": ["Calm Mind", "Stored Power", "Heat Wave", "Roost"]},
+	},
 	"Wooper": {
 		"LC Defensive": {"level": 5, "evs": {"sd": 156, "df": 236, "hp": 76}, "nature": "Sassy", "ability": "Water Absorb", "item": "Eviolite", "moves": ["Scald", "Recover", "Earthquake", "Yawn"]},
 	},
@@ -3389,15 +3567,14 @@ var SETDEX_SM = {
 		"PU Stealth Rock": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Overcoat", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Sucker Punch"]},
 	},
 	"Wormadam-Trash": {
-		"PU Utility": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Overcoat", "item": "Leftovers", "moves": ["Stealth Rock", "Protect", "Toxic", "Gyro Ball"]},
+		"PU Defensive Utility": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Overcoat", "item": "Leftovers", "moves": ["Stealth Rock", "Toxic", "Protect", "Iron Head"]},
 	},
 	"Wynaut": {
 		"LC Trapper": {"level": 5, "evs": {"sd": 132, "df": 132, "hp": 156, "sp": 12}, "nature": "Bold", "ability": "Shadow Tag", "item": "Berry Juice", "moves": ["Counter", "Mirror Coat", "Encore", "Tickle"]},
 	},
 	"Xatu": {
-		"NU Pivot": {"level": 100, "evs": {"df": 240, "hp": 252, "sp": 16}, "ivs": {"at": 0}, "nature": "Bold", "ability": "Magic Bounce", "item": "Rocky Helmet", "moves": ["Roost", "U-turn", "Psychic", "Grass Knot"]},
-		"RU Showdown Usage": {"level": 100, "evs": {"df": 192, "hp": 252, "sp": 64}, "nature": "Bold", "ability": "Magic Bounce", "item": "Rocky Helmet", "moves": ["Roost", "U-turn", "Night Shade", "Haze"]},
-		"UU Showdown Usage": {"level": 100, "evs": {"df": 68, "hp": 252, "sp": 188}, "nature": "Timid", "ability": "Magic Bounce", "item": "Rocky Helmet", "moves": ["Roost", "U-turn", "Psychic", "Feather Dance"]},
+		"NU Defensive Pivot": {"level": 100, "evs": {"df": 196, "hp": 252, "sp": 60}, "nature": "Impish", "ability": "Magic Bounce", "item": "Rocky Helmet", "moves": ["Night Shade", "Roost", "U-turn", "Toxic"]},
+		"RU Showdown Usage": {"level": 100, "evs": {"df": 196, "hp": 252, "sp": 60}, "nature": "Impish", "ability": "Magic Bounce", "item": "Rocky Helmet", "moves": ["Roost", "Night Shade", "U-turn", "Toxic"]},
 	},
 	"Xerneas": {
 		"Uber Choice Scarf": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Fairy Aura", "item": "Choice Scarf", "moves": ["Moonblast", "Focus Blast", "Aromatherapy", "Defog"]},
@@ -3407,6 +3584,7 @@ var SETDEX_SM = {
 		"Uber Z-Geomancy": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Fairy Aura", "item": "Fairium Z", "moves": ["Geomancy", "Ingrain", "Rest", "Moonblast"]},
 	},
 	"Xurkitree": {
+		"OU Tail Glow": {"level": 100, "evs": {"df": 24, "sp": 252, "sa": 232}, "nature": "Timid", "ability": "Beast Boost", "item": "Shuca Berry", "moves": ["Thunderbolt", "Hidden Power Ice", "Tail Glow", "Energy Ball"]},
 		"Uber Z-Hypnosis Sweeper": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Beast Boost", "item": "Psychium Z", "moves": ["Hypnosis", "Tail Glow", "Thunderbolt", "Grass Knot"]},
 		"VGC17 Choice Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Choice Scarf", "moves": ["Thunderbolt", "Hidden Power Ice", "Energy Ball", "Volt Switch"]},
 		"VGC17 Special Attacker": {"level": 50, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Beast Boost", "item": "Electrium Z", "moves": ["Thunderbolt", "Hidden Power Ice", "Energy Ball", "Protect"]},
@@ -3419,11 +3597,18 @@ var SETDEX_SM = {
 		"UU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Tinted Lens", "item": "Choice Specs", "moves": ["Bug Buzz", "Air Slash", "U-turn", "Giga Drain"]},
 		"Monotype Speed Boost Cleaner (Bug)": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Speed Boost", "item": "Life Orb", "moves": ["Protect", "Air Slash", "Giga Drain", "Ancient Power"]},
 	},
+	"Yungoos": {
+		"LC Choice Scarf": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 196, "sp": 236}, "nature": "Adamant", "ability": "Adaptability", "item": "Choice Scarf", "moves": ["Return", "Earthquake", "U-turn", "Pursuit"]},
+	},
 	"Yveltal": {
-		"Uber Life Orb Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Dark Aura", "item": "Life Orb", "moves": ["Dark Pulse", "Oblivion Wing", "Taunt", "Knock Off"]},
-		"Uber Choice Scarf": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Dark Aura", "item": "Choice Scarf", "moves": ["Dark Pulse", "Foul Play", "Oblivion Wing", "U-turn"]},
+		"Uber Life Orb": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Mild", "ability": "Dark Aura", "item": "Life Orb", "moves": ["Dark Pulse", "Oblivion Wing", "Taunt", "Sucker Punch"]},
+		"Uber Choice Scarf": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Dark Aura", "item": "Choice Scarf", "moves": ["Foul Play", "Dark Pulse", "Oblivion Wing", "U-turn"]},
+		"Uber Stallbreaker": {"level": 100, "evs": {"sd": 72, "hp": 252, "sp": 184}, "nature": "Timid", "ability": "Dark Aura", "item": "Dread Plate", "moves": ["Dark Pulse", "Toxic", "Taunt", "Roost"]},
 		"Uber Choice Specs": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Dark Aura", "item": "Choice Specs", "moves": ["Dark Pulse", "Oblivion Wing", "U-turn", "Heat Wave"]},
-		"Uber Physically Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Dark Aura", "item": "Leftovers", "moves": ["Foul Play", "Roost", "Taunt", "Toxic"]},
+		"Uber Physically Defensive": {"level": 100, "evs": {"df": 176, "hp": 252, "sp": 80}, "nature": "Impish", "ability": "Dark Aura", "item": "Charti Berry", "moves": ["Foul Play", "Roost", "Toxic", "Sucker Punch"]},
+		"AG Life Orb": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Rash", "ability": "Dark Aura", "item": "Life Orb", "moves": ["Dark Pulse", "Oblivion Wing", "Taunt", "Sucker Punch"]},
+		"AG Choice Scarf": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Dark Aura", "item": "Choice Scarf", "moves": ["Dark Pulse", "Oblivion Wing", "Foul Play", "U-turn"]},
+		"AG Physically Defensive": {"level": 100, "evs": {"df": 180, "hp": 248, "sp": 80}, "nature": "Bold", "ability": "Dark Aura", "item": "Leftovers", "moves": ["Foul Play", "Roost", "Taunt", "Toxic"]},
 	},
 	"Zangoose": {
 		"PU Toxic Orb Wallbreaker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Toxic Boost", "item": "Toxic Orb", "moves": ["Facade", "Knock Off", "Close Combat", "Quick Attack"]},
@@ -3434,9 +3619,10 @@ var SETDEX_SM = {
 		"OU Defensive": {"level": 100, "evs": {"df": 240, "hp": 248, "sp": 20}, "nature": "Bold", "ability": "Pressure", "item": "Leftovers", "moves": ["Discharge", "Roost", "Heat Wave", "Defog"]},
 		"OU Roost + 3 Attacks": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Discharge", "Hidden Power Ice", "Heat Wave", "Roost"]},
 		"Doubles Tailwind Roost": {"level": 100, "evs": {"sd": 80, "df": 136, "hp": 244, "sp": 48}, "nature": "Bold", "ability": "Static", "item": "Misty Seed", "moves": ["Tailwind", "Roost", "Thunderbolt", "Heat Wave"]},
+		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 244, "hp": 244, "sp": 20}, "nature": "Bold", "ability": "Static", "item": "Rocky Helmet", "moves": ["Volt Switch", "Heat Wave", "Hidden Power Ice", "Roost"]},
+		"Monotype Defensive (Electric)": {"level": 100, "evs": {"df": 176, "hp": 252, "sp": 80}, "nature": "Timid", "ability": "Static", "item": "Leftovers", "moves": ["Volt Switch", "Defog", "Roost", "Heat Wave"]},
 		"Monotype SubToxic (Flying)": {"level": 100, "evs": {"sd": 136, "hp": 252, "sp": 120}, "nature": "Timid", "ability": "Pressure", "item": "Leftovers", "moves": ["Discharge", "Roost", "Toxic", "Substitute"]},
 		"Monotype Defog (Flying)": {"level": 100, "evs": {"sd": 176, "hp": 252, "sp": 80}, "nature": "Calm", "ability": "Pressure", "item": "Leftovers", "moves": ["Volt Switch", "Roost", "Defog", "Heat Wave"]},
-		"Monotype Specially Defensive Pivot (Electric)": {"level": 100, "evs": {"sd": 132, "df": 16, "hp": 252, "sp": 108}, "nature": "Calm", "ability": "Pressure", "item": "Leftovers", "moves": ["Volt Switch", "Roost", "Defog", "Heat Wave"]},
 	},
 	"Zebstrika": {
 		"PU All-out Attacker": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sap Sipper", "item": "Life Orb", "moves": ["Thunderbolt", "Volt Switch", "Overheat", "Hidden Power Grass"]},
@@ -3444,20 +3630,32 @@ var SETDEX_SM = {
 	"Zekrom": {
 		"Uber Hone Claws": {"level": 100, "evs": {"at": 252, "hp": 104, "sp": 152}, "nature": "Adamant", "ability": "Teravolt", "item": "Dragonium Z", "moves": ["Hone Claws", "Bolt Strike", "Outrage", "Substitute"]},
 		"Uber Physically Defensive": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Teravolt", "item": "Leftovers", "moves": ["Bolt Strike", "Dragon Tail", "Toxic", "Roost"]},
+		"BH Adaptability Setup Sweeper": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Rash", "ability": "Adaptability", "item": "Dragonium Z", "moves": ["Shell Smash", "Bolt Strike", "Draco Meteor", "Taunt"]},
+		"BH Mixed Galvanize Setup Sweeper": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sp": 252, "sa": 252}, "nature": "Rash", "ability": "Galvanize", "item": "Draco Plate", "moves": ["Shell Smash", "Extreme Speed", "Boomburst", "Judgment"]},
+	},
+	"Zeraora": {
+		"UU All-out Attacker": {"level": 100, "evs": {"at": 252, "sp": 252, "sa": 4}, "nature": "Naive", "ability": "Volt Absorb", "item": "Life Orb", "moves": ["Plasma Fists", "Close Combat", "Grass Knot", "Knock Off"]},
+		"OU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Volt Absorb", "item": "Choice Band", "moves": ["Plasma Fists", "Knock Off", "Close Combat", "Fire Punch"]},
+		"Doubles Fast Utility Pivot": {"level": 100, "evs": {"sd": 72, "at": 116, "hp": 128, "sp": 192}, "nature": "Jolly", "ability": "Volt Absorb", "item": "Assault Vest", "moves": ["Fake Out", "Plasma Fists", "Snarl", "Volt Switch"]},
 	},
 	"Zigzagoon": {
 		"LC Belly Drum Sweeper": {"level": 5, "evs": {"sd": 28, "df": 108, "at": 196, "hp": 132, "sp": 36}, "nature": "Adamant", "ability": "Pickup", "item": "Berry Juice", "moves": ["Belly Drum", "Extreme Speed", "Thief", "Seed Bomb"]},
+	},
+	"Zoroark": {
+		"UU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Illusion", "item": "Fightinium Z", "moves": ["Nasty Plot", "Dark Pulse", "Focus Blast", "Sludge Bomb"]},
 	},
 	"Zorua": {
 		"LC Life Orb": {"level": 5, "evs": {"sd": 36, "df": 36, "sp": 236, "sa": 196}, "nature": "Timid", "ability": "Illusion", "item": "Life Orb", "moves": ["Night Daze", "Extrasensory", "Nasty Plot", "U-turn"]},
 	},
 	"Zygarde": {
-		"OU Offensive Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Aura Break", "item": "Dragonium Z", "moves": ["Thousand Arrows", "Outrage", "Extreme Speed", "Dragon Dance"]},
-		"OU Substitute + Dragon Dance": {"level": 100, "evs": {"at": 140, "hp": 188, "sp": 180}, "nature": "Adamant", "ability": "Aura Break", "item": "Leftovers", "moves": ["Substitute", "Dragon Dance", "Thousand Arrows", "Protect"]},
-		"OU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Aura Break", "item": "Choice Band", "moves": ["Thousand Arrows", "Extreme Speed", "Outrage", "Toxic"]},
-		"OU Double Dance": {"level": 100, "evs": {"sd": 28, "at": 216, "hp": 160, "sp": 104}, "nature": "Adamant", "ability": "Aura Break", "item": "Iapapa Berry", "moves": ["Thousand Arrows", "Extreme Speed", "Dragon Dance", "Coil"]},
-		"Uber Showdown Usage": {"level": 100, "evs": {"df": 252, "at": 4, "hp": 252}, "nature": "Impish", "ability": "Power Construct", "item": "Leftovers", "moves": ["Thousand Arrows", "Rest", "Glare", "Dragon Dance"]},
-		"Doubles Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 92, "sp": 164}, "nature": "Adamant", "ability": "Aura Break", "item": "Groundium Z", "moves": ["Thousand Arrows", "Extreme Speed", "Dragon Dance", "Protect"]},
+		"OU Choice Band": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Aura Break", "item": "Choice Band", "moves": ["Thousand Arrows", "Extreme Speed", "Iron Tail", "Outrage"]},
+		"OU Substitute Utility": {"level": 100, "evs": {"sd": 160, "hp": 236, "sp": 112}, "nature": "Jolly", "ability": "Aura Break", "item": "Leftovers", "moves": ["Thousand Arrows", "Substitute", "Coil", "Glare"]},
+		"OU Double Dance": {"level": 100, "evs": {"sd": 68, "at": 228, "sp": 212}, "nature": "Adamant", "ability": "Aura Break", "item": "Figy Berry", "moves": ["Dragon Dance", "Coil", "Thousand Arrows", "Substitute"]},
+		"OU Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Aura Break", "item": "Groundium Z", "moves": ["Dragon Dance", "Thousand Arrows", "Extreme Speed", "Substitute"]},
+		"OU RestTalk": {"level": 100, "evs": {"sd": 168, "df": 4, "at": 68, "hp": 236, "sp": 32}, "nature": "Careful", "ability": "Aura Break", "item": "Leftovers", "moves": ["Thousand Arrows", "Dragon Dance", "Rest", "Sleep Talk"]},
+		"Uber Showdown Usage": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Power Construct", "item": "Leftovers", "moves": ["Thousand Arrows", "Dragon Dance", "Substitute", "Glare"]},
+		"Doubles Dragon Dance": {"level": 100, "evs": {"at": 252, "hp": 76, "sp": 180}, "nature": "Adamant", "ability": "Aura Break", "item": "Groundium Z", "moves": ["Thousand Arrows", "Substitute", "Dragon Dance", "Protect"]},
+		"Doubles Choice Band": {"level": 100, "evs": {"sd": 56, "at": 252, "hp": 24, "sp": 176}, "nature": "Adamant", "ability": "Aura Break", "item": "Choice Band", "moves": ["Thousand Arrows", "Extreme Speed", "Superpower", "Dragon Tail"]},
 	},
 	"Zygarde-10%": {
 		"RU Choice Band": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Aura Break", "item": "Choice Band", "moves": ["Thousand Arrows", "Outrage", "Extreme Speed", "Toxic"]},
@@ -3467,13 +3665,8 @@ var SETDEX_SM = {
 		"Uber Big Boss (Dragon Dance)": {"level": 100, "evs": {"sd": 48, "at": 228, "sp": 232}, "nature": "Adamant", "ability": "Power Construct", "item": "Leftovers", "moves": ["Dragon Dance", "Thousand Arrows", "Substitute", "Dragon Tail"]},
 		"Uber Defensive": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Impish", "ability": "Power Construct", "item": "Leftovers", "moves": ["Rest", "Sleep Talk", "Thousand Arrows", "Dragon Tail"]},
 		"Uber Trapping Boss": {"level": 100, "evs": {"df": 208, "at": 220, "hp": 80}, "nature": "Adamant", "ability": "Power Construct", "item": "Leftovers", "moves": ["Dragon Dance", "Thousand Arrows", "Thousand Waves", "Rest"]},
-	},
-	"Arghonaut": {
-		"CAP Mixed Wall": {"level": 100, "evs": {"hp": 252, "df": 124, "sd": 132}, "nature": "Careful", "ability": "Unaware", "item": "Leftovers", "moves": ["Recover", "Drain Punch", "Knock Off", "Spikes"]},
-	},
-	"Aurumoth": {
-		"CAP No Guard Quiver Dance": {"level": 100, "evs": {"df": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "No Guard", "item": "Fightinium Z", "moves": ["Quiver Dance", "Bug Buzz", "Psychic", "Focus Blast"]},
-		"CAP Weak Armor Tail Glow": {"level": 100, "evs": {"hp": 104, "sa": 252, "sp": 152}, "nature": "Modest", "ability": "Weak Armor", "item": "Iapapa Berry", "moves": ["Tail Glow", "Bug Buzz", "Psyshock", "Focus Blast"]},
+		"BH Poison Heal": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Poison Heal", "item": "Toxic Orb", "moves": ["Core Enforcer", "Spectral Thief", "U-turn", "Shore Up"]},
+		"BH Physical Setup Check": {"level": 100, "evs": {"sd": 252, "df": 252, "at": 252, "hp": 252, "sa": 252}, "ivs": {"sp": 0}, "nature": "Relaxed", "ability": "Fur Coat", "item": "Safety Goggles", "moves": ["Shore Up", "Core Enforcer", "Topsy-Turvy", "U-turn"]},
 	},
 	"Cawmodore": {
 		"CAP Belly Drum": {"level": 100, "evs": {"at": 252, "sp": 252, "hp": 4}, "nature": "Jolly", "ability": "Volt Absorb", "item": "Sitrus Berry", "moves": ["Belly Drum", "Acrobatics", "Drain Punch", "Bullet Punch"]},
@@ -3489,13 +3682,6 @@ var SETDEX_SM = {
 	"Crucibelle-Mega": {
 		"CAP All-Out Attacker": {"level": 100, "evs": {"hp": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Magic Guard", "moves": ["Head Smash", "Gunk Shot", "Low Kick", "U-turn"]},
 	},
-	"Cyclohm": {
-		"CAP Physically Defensive": {"level": 100, "evs": {"sa": 4, "hp": 252, "df": 252}, "nature": "Bold", "ability": "Shield Dust", "item": "Leftovers", "moves": ["Slack Off", "Discharge", "Fire Blast", "Ice Beam"]},
-		"CAP Offensive": {"level": 100, "evs": {"df": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Shield Dust", "item": "Dragonium Z", "moves": ["Draco Meteor", "Volt Switch", "Fire Blast", "Hydro Pump"]},
-	},
-	"Fidgit": {
-		"CAP Persistent": {"level": 100, "evs": {"df": 36, "hp": 252, "sd": 220}, "nature": "Timid", "ability": "Persistent", "item": "Black Sludge", "moves": ["Trick Room", "Stealth Rock", "Earth Power", "U-turn"]},
-	},
 	"Jumbao": {
 		"CAP Wall": {"level": 100, "evs": {"HP": 252, "df": 160, "sd": 96}, "nature": "Calm", "ability": "Trace", "item": "Leftovers", "moves": ["Moonblast", "Shore Up", "Hidden Power Ground", "Wish"]},
 		"CAP Offensive": {"level": 100, "evs": {"HP": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Drought", "item": "Grassium Z", "moves": ["Moonblast", "Solar Beam", "Flame Burst", "Shore Up"]},
@@ -3509,18 +3695,8 @@ var SETDEX_SM = {
 		"CAP Utility": {"level": 100, "evs": {"at": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Limber", "item": "Leftovers", "moves": ["Will-O-Wisp", "Knock Off", "Shadow Strike", "U-turn"]},
 		"CAP Mini Metagross": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Iron Fist", "item": "Choice Band", "moves": ["Meteor Mash", "Ice Punch", "Shadow Strike", "U-turn"]},
 	},
-	"Krilowatt": {
-		"CAP Special Attacker": {"level": 100, "evs": {"sp": 252, "sa": 252, "hp": 4}, "nature": "Timid", "ability": "Magic Guard", "item": "Life Orb", "moves": ["Volt Switch", "Thunderbolt", "Ice Beam", "Earth Power"]},
-	},
-	"Malaconda": {
-		"CAP Wall": {"level": 100, "evs": {"hp": 252, "at": 4, "df": 252}, "nature": "Impish", "ability": "Drought", "item": "Leftovers", "moves": ["Knock Off", "Pursuit", "Glare", "Synthesis"]},
-	},
 	"Mollux": {
 		"CAP Specially Defensive": {"level": 100, "evs": {"hp": 252, "df": 4, "sd": 252}, "nature": "Calm", "ability": "Dry Skin", "item": "Black Sludge", "moves": ["Lava Plume", "Sludge Bomb", "Recover", "Rapid Spin"]},
-	},
-	"Naviathan": {
-		"CAP Dragon Dance": {"level": 100, "evs": {"hp": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Guts", "item": "Flame Orb", "moves": ["Dragon Dance", "Waterfall", "Facade", "Icicle Crash"]},
-		"CAP Calm Mind": {"level": 100, "evs": {"hp": 252, "df": 252, "sa": 4}, "nature": "Bold", "ability": "Heatproof", "item": "Leftovers", "moves": ["Calm Mind", "Scald", "Recover", "Hidden Power Ground"]},
 	},
 	"Necturna": {
 		"CAP Physical Sweeper": {"level": 100, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Forewarn", "item": "Ghostium Z", "moves": ["Shell Smash", "Phantom Force", "Substitute", "Power Whip"]},
@@ -3531,37 +3707,18 @@ var SETDEX_SM = {
 		"CAP Z Trapper": {"level": 100, "evs": {"hp": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Comatose", "item": "Dragonium Z", "moves": ["Outrage", "Spirit Shackle", "Ice Punch", "Heal Block"]},
 		"CAP Specially Defensive": {"level": 100, "evs": {"hp": 252, "sd": 252, "sp": 4}, "nature": "Careful", "ability": "Comatose", "item": "Leftovers", "moves": ["Spirit Shackle", "Toxic", "Protect", "Heal Block"]},
 	},
-	"Plasmanta": {
-		"CAP Special Attacker": {"level": 100, "evs": {"hp": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Storm Drain", "item": "Life Orb", "moves": ["Sludge Wave", "Thunderbolt", "Dazzling Gleam", "Hidden Power Ice"]},
-	},
 	"Pyroak": {
 		"CAP Physically Defensive": {"level": 100, "evs": {"hp": 248, "sd": 8, "df": 252}, "nature": "Bold", "ability": "Battle Armor", "item": "Leftovers", "moves": ["Synthesis", "Lava Plume", "Earth Power", "Stealth Rock"]},
 		"CAP cbrevan": {"level": 100, "evs": {"at": 252, "hp": 248, "sd": 8}, "nature": "Adamant", "ability": "Rock Head", "item": "Life Orb", "moves": ["Sword Dance", "Flare Blitz", "Wood Hammer", "Earthquake"]},
 	},
-	"Revenankh": {
-		"CAP Bulk Up": {"level": 100, "evs": {"df": 172, "hp": 252, "sd": 84}, "nature": "Careful", "ability": "Triage", "item": "Leftovers", "moves": ["Bulk Up", "Drain Punch", "Shadow Sneak", "Moonlight"]},
-		"CAP Dual Status": {"level": 100, "evs": {"df": 172, "hp": 252, "sd": 84}, "nature": "Careful", "ability": "Triage", "item": "Leftovers", "moves": ["Glare", "Drain Punch", "Toxic", "Moonlight"]},
-	},
 	"Stratagem": {
 		"CAP Technician": {"level": 100, "evs": {"sd": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Technician", "item": "Life Orb", "moves": ["Ancient Power", "Earth Power", "Hidden Power Ice", "Energy Ball"]},
 		"CAP Levitate Attacker": {"level": 100, "evs": {"sd": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Levitate", "item": "Fairium Z", "moves": ["Paleo Wave", "Dazzling Gleam", " Fire Blast", "Stealth Rock"]},
-	},
-	"Syclant": {
-		"CAP Revenge Killer": {"level": 100, "evs": {"sa": 252, "at": 4, "sp": 252}, "nature": "Hasty", "ability": "Mountaineer", "item": "Focus Sash", "moves": ["Ice Beam", "Earthquake", "U-turn", "Spikes"]},
-		"CAP Tail Glow": {"level": 100, "evs": {"hp": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Mountaineer", "item": "Icium Z", "moves": ["Tail Glow", "Ice Beam", "U-turn", "Earth Power"]},
 	},
 	"Tomohawk": {
 		"CAP Physically Defensive": {"level": 100, "evs": {"hp": 252, "df": 252, "sd": 4}, "nature": "Bold", "ability": "Prankster", "item": "Coba Berry", "moves": ["Haze", "Air Slash", "Rapid Spin", "Roost"]},
 		"CAP Offensive": {"level": 100, "evs": {"df": 4, "sa": 252, "sp": 252}, "nature": "Modest", "ability": "Prankster", "item": "Flyinium Z", "moves": ["Hurricane", "Focus Blast", "Nature Power", "Roost"]},
 		"CAP Stallbreaker": {"level": 100, "evs": {"df": 4, "sa": 252, "sp": 252}, "nature": "Modest", "ability": "Prankster", "item": "Life Orb", "moves": ["Taunt", "Hurricane", "Focus Blast", "Roost"]},
 		"CAP Rain Support": {"level": 100, "evs": {"hp": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Prankster", "item": "Damp Rock", "moves": ["Rain Dance", "Hurricane", "Focus Blast", "Healing Wish"]},
-	},
-	"Volkraken": {
-		"CAP Choice Scarf": {"level": 100, "evs": {"sp": 252, "sa": 252, "hp": 4}, "nature": "Timid", "ability": "Analytic", "item": "Choice Scarf", "moves": ["Fire Blast", "Surf", "Hydro Pump", "U-turn"]},
-		"CAP Choice Specs": {"level": 100, "evs": {"sp": 252, "sa": 252, "hp": 4}, "nature": "Modest", "ability": "Analytic", "item": "Choice Specs", "moves": ["Fire Blast", "Hydro Pump", "Hidden Power Grass", "U-turn"]},
-	},
-	"Voodoom": {
-		"CAP Mixed Attacker": {"level": 100, "evs": {"sp": 252, "sa": 252, "at": 4}, "nature": "Hasty", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Dark Pulse", "Close Combat", "Psychic", "Vacuum Wave"]},
-		"CAP Special Attacker": {"level": 100, "evs": {"hp": 4, "sa": 252, "sp": 252}, "nature": "Timid", "ability": "Lightning Rod", "item": "Life Orb", "moves": ["Focus Blast", "Dark Pulse", "Psychic", "Vacuum Wave"]},
 	},
 };

--- a/js/data/setdex_xy.js
+++ b/js/data/setdex_xy.js
@@ -3535,7 +3535,7 @@ var SETDEX_XY = {
 	"Wobbuffet": {
 		"PU Bulky Death Fodder": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Bold", "ability": "Telepathy", "item": "Leftovers", "moves": ["Encore", "Destiny Bond", "Counter", "Mirror Coat"]},
 		"Uber Utility Trapper": {"level": 100, "evs": {"sd": 252, "df": 176, "hp": 80}, "nature": "Calm", "ability": "Shadow Tag", "item": "Custap Berry", "moves": ["Encore", "Mirror Coat", "Counter", "Destiny Bond"]},
-		"Battle Spot Singles \(>_<)7": {"level": 50, "evs": {"sd": 252, "df": 252, "sp": 4}, "nature": "Bold", "ability": "Shadow Tag", "item": "Sitrus Berry", "moves": ["Encore", "Counter", "Mirror Coat", "Destiny Bond"]},
+		"Battle Spot Singles (>_<)7": {"level": 50, "evs": {"sd": 252, "df": 252, "sp": 4}, "nature": "Bold", "ability": "Shadow Tag", "item": "Sitrus Berry", "moves": ["Encore", "Counter", "Mirror Coat", "Destiny Bond"]},
 	},
 	"Woobat": {
 		"LC Baton Pass Recipient": {"level": 5, "evs": {"sd": 252, "df": 172, "hp": 76}, "nature": "Bold", "ability": "Unaware", "item": "Eviolite", "moves": ["Stored Power", "Calm Mind", "Roost", "Heat Wave"]},

--- a/js/data/setdex_xy.js
+++ b/js/data/setdex_xy.js
@@ -22,11 +22,11 @@ var SETDEX_XY = {
 		"RU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Super Luck", "item": "Life Orb", "moves": ["Knock Off", "Sucker Punch", "Superpower", "Play Rough"]},
 		"RU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Super Luck", "item": "Life Orb", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
 		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
-		"UU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Superpower"]},
+		"UU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Superpower"]},
 	},
 	"Absol-Mega": {
 		"UU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Swords Dance", "Knock Off", "Sucker Punch", "Superpower"]},
-		"UU All-out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Superpower"]},
+		"UU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Justified", "item": "Absolite", "moves": ["Knock Off", "Sucker Punch", "Pursuit", "Superpower"]},
 	},
 	"Accelgor": {
 		"RU Spikes Lead": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Unburden", "item": "Focus Sash", "moves": ["Spikes", "Final Gambit", "Encore", "Bug Buzz"]},
@@ -786,7 +786,7 @@ var SETDEX_XY = {
 		"LC Choice Scarf": {"level": 5, "evs": {"df": 36, "at": 236, "hp": 20, "sp": 212}, "nature": "Jolly", "ability": "Hustle", "item": "Choice Scarf", "moves": ["Outrage", "Crunch", "Superpower", "Zen Headbutt"]},
 	},
 	"Delcatty": {
-		"PU Delcatty Got Your Tongue?": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Bold", "ability": "Wonder Skin", "item": "Leftovers", "moves": ["Substitute", "Calm Mind", "Hyper Voice", "Baton Pass"]},
+		"PU Delcatty Got Your Tongue?": {"level": 100, "evs": {"hp": 252, "sp": 252, "sa": 4}, "nature": "Timid", "ability": "Wonder Skin", "item": "Leftovers", "moves": ["Substitute", "Calm Mind", "Hyper Voice", "Shadow Ball"]},
 	},
 	"Delibird": {
 		"PU Spikes Lead": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Vital Spirit", "item": "Focus Sash", "moves": ["Spikes", "Rapid Spin", "Icy Wind", "Destiny Bond"]},
@@ -802,7 +802,7 @@ var SETDEX_XY = {
 		"Uber All-out Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Rash", "ability": "Pressure", "item": "Life Orb", "moves": ["Psycho Boost", "Superpower", "Ice Beam", "Extreme Speed"]},
 		"Uber Suicide Lead": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Pressure", "item": "Focus Sash", "moves": ["Stealth Rock", "Psycho Boost", "Knock Off", "Extreme Speed"]},
 		"Doubles Fast Mixed Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Pressure", "item": "Focus Sash", "moves": ["Psycho Boost", "Superpower", "Extreme Speed", "Detect"]},
-		"AG All-out Attacker": {"level": 100, "evs": {"at": 20, "sp": 236, "sa": 252}, "nature": "Mild", "ability": "Pressure", "item": "Focus Sash", "moves": ["Psycho Boost", "Superpower", "Extreme Speed", "Ice Beam"]},
+		"AG All-Out Attacker": {"level": 100, "evs": {"at": 20, "sp": 236, "sa": 252}, "nature": "Mild", "ability": "Pressure", "item": "Focus Sash", "moves": ["Psycho Boost", "Superpower", "Extreme Speed", "Ice Beam"]},
 		"AG Suicide Lead": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Naive", "ability": "Pressure", "item": "Focus Sash", "moves": ["Psycho Boost", "Stealth Rock", "Taunt", "Knock Off"]},
 	},
 	"Deoxys-Defense": {
@@ -1276,7 +1276,7 @@ var SETDEX_XY = {
 		"PU Tank": {"level": 100, "evs": {"df": 4, "at": 252, "hp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Leftovers", "moves": ["Stealth Rock", "Stone Edge", "Superpower", "Toxic"]},
 	},
 	"Girafarig": {
-		"PU Baton Pass": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sap Sipper", "item": "Life Orb", "moves": ["Nasty Plot", "Baton Pass", "Psychic", "Hyper Voice"]},
+		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Sap Sipper", "item": "Life Orb", "moves": ["Nasty Plot", "Hyper Voice", "Psyshock", "Shadow Ball"]},
 	},
 	"Giratina": {
 		"Uber The Great Wall (Physically Defensive)": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Pressure", "item": "Leftovers", "moves": ["Will-O-Wisp", "Roar", "Rest", "Sleep Talk"]},
@@ -1324,9 +1324,9 @@ var SETDEX_XY = {
 		"PU Rain Dance": {"level": 100, "evs": {"df": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Swift Swim", "item": "Life Orb", "moves": ["Rain Dance", "Hydro Pump", "Ice Beam", "Psyshock"]},
 	},
 	"Golem": {
-		"PU Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Weakness Policy", "moves": ["Stealth Rock", "Earthquake", "Stone Edge", "Sucker Punch"]},
 		"PU Specially Defensive": {"level": 100, "evs": {"sd": 224, "at": 32, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Leftovers", "moves": ["Stealth Rock", "Earthquake", "Stone Edge", "Toxic"]},
 		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Choice Band", "moves": ["Earthquake", "Stone Edge", "Sucker Punch", "Fire Punch"]},
+		"PU Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Weakness Policy", "moves": ["Stealth Rock", "Earthquake", "Stone Edge", "Sucker Punch"]},
 		"PU Sun Lead": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Heat Rock", "moves": ["Sunny Day", "Stealth Rock", "Explosion", "Earthquake"]},
 		"NU All-Out Attacker": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Choice Band", "moves": ["Earthquake", "Stone Edge", "Explosion", "Sucker Punch"]},
 		"NU Custap Berry": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Sturdy", "item": "Custap Berry", "moves": ["Stealth Rock", "Earthquake", "Rock Blast", "Explosion"]},
@@ -1604,7 +1604,7 @@ var SETDEX_XY = {
 		"PU NastyPass": {"level": 100, "evs": {"sd": 4, "df": 252, "hp": 252}, "nature": "Calm", "ability": "Insomnia", "item": "Leftovers", "moves": ["Nasty Plot", "Baton Pass", "Substitute", "Psychic"]},
 	},
 	"Illumise": {
-		"PU Substitute + Baton Pass": {"level": 100, "evs": {"sd": 8, "df": 252, "hp": 248}, "nature": "Bold", "ability": "Prankster", "item": "Leftovers", "moves": ["Substitute", "Baton Pass", "Encore", "Bug Buzz"]},
+		"PU Choice Specs": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Modest", "ability": "Tinted Lens", "item": "Choice Specs", "moves": ["Bug Buzz", "Thunderbolt", "Giga Drain", "U-turn"]},
 	},
 	"Infernape": {
 		"UU Nasty Plot": {"level": 100, "evs": {"at": 136, "sp": 252, "sa": 120}, "nature": "Naive", "ability": "Blaze", "item": "Life Orb", "moves": ["Nasty Plot", "Fire Blast", "Close Combat", "Grass Knot"]},
@@ -1806,6 +1806,7 @@ var SETDEX_XY = {
 		"OU Offensive": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Earth Plate", "moves": ["Earthquake", "Stone Edge", "Swords Dance", "Stealth Rock"]},
 		"Uber Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "Stone Edge", "U-turn", "Explosion"]},
 		"Doubles Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "Rock Slide", "U-turn", "Superpower"]},
+		"Doubles Assault Vest Pivot": {"level": 100, "evs": {"sd": 36, "at": 124, "hp": 168, "sp": 180}, "nature": "Adamant", "ability": "Intimidate", "item": "Assault Vest", "moves": ["Earthquake", "Rock Slide", "Superpower", "U-turn"]},
 		"Doubles Life Orb Attacker": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Intimidate", "item": "Life Orb", "moves": ["Earthquake", "Stone Edge", "Superpower", "Protect"]},
 		"Battle Spot Singles Choice Scarf": {"level": 50, "evs": {"at": 252, "hp": 4, "sp": 252}, "nature": "Adamant", "ability": "Intimidate", "item": "Choice Scarf", "moves": ["Earthquake", "U-turn", "Knock Off", "Rock Slide"]},
 		"Battle Spot Singles Defensive": {"level": 50, "evs": {"df": 252, "hp": 236, "sp": 20}, "nature": "Impish", "ability": "Intimidate", "item": "Rocky Helmet", "moves": ["Earthquake", "U-turn", "Stealth Rock", "Rock Tomb"]},
@@ -1867,7 +1868,7 @@ var SETDEX_XY = {
 	},
 	"Leafeon": {
 		"PU Swords Dance": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Chlorophyll", "item": "Yache Berry", "moves": ["Swords Dance", "Leaf Blade", "Knock Off", "Return"]},
-		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Chlorophyll", "item": "Choice Scarf", "moves": ["Leaf Blade", "Knock Off", "Double-Edge", "Bullet Seed"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Chlorophyll", "item": "Choice Scarf", "moves": ["Leaf Blade", "Knock Off", "Double-Edge", "X-Scissor"]},
 		"PU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Adamant", "ability": "Leaf Guard", "item": "Choice Band", "moves": ["Bullet Seed", "Leaf Blade", "Knock Off", "Double-Edge"]},
 		"NU Offensive Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Chlorophyll", "item": "Starf Berry", "moves": ["Swords Dance", "Leaf Blade", "Knock Off", "Natural Gift"]},
 	},
@@ -2207,7 +2208,7 @@ var SETDEX_XY = {
 		"LC Choice Scarf": {"level": 5, "evs": {"sd": 36, "df": 36, "at": 196, "sp": 236}, "nature": "Jolly", "ability": "Skill Link", "item": "Choice Scarf", "moves": ["Tail Slap", "Knock Off", "U-turn", "Wake-Up Slap"]},
 	},
 	"Minun": {
-		"PU Cheerleader": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Minus", "item": "Leftovers", "moves": ["Encore", "Nuzzle", "Baton Pass", "Substitute"]},
+		"PU Cheerleader": {"level": 100, "evs": {"df": 8, "hp": 248, "sp": 252}, "nature": "Timid", "ability": "Minus", "item": "Leftovers", "moves": ["Encore", "Substitute", "Toxic", "Protect"]},
 	},
 	"Misdreavus": {
 		"PU Defensive": {"level": 100, "evs": {"df": 240, "hp": 252, "sp": 16}, "nature": "Timid", "ability": "Levitate", "item": "Eviolite", "moves": ["Will-O-Wisp", "Taunt", "Foul Play", "Pain Split"]},
@@ -2321,7 +2322,6 @@ var SETDEX_XY = {
 	},
 	"Onix": {
 		"LC Sturdy + Berry Juice": {"level": 5, "evs": {"at": 236, "hp": 76, "sp": 196}, "nature": "Jolly", "ability": "Sturdy", "item": "Berry Juice", "moves": ["Earthquake", "Rock Blast", "Stealth Rock", "Taunt"]},
-		"PU Sun Support": {"level": 100, "evs": {"at": 4, "hp": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Heat Rock", "moves": ["Stealth Rock", "Sunny Day", "Explosion", "Taunt"]},
 	},
 	"Oshawott": {
 		"LC Croagunk Lure": {"level": 5, "evs": {"sp": 236, "sa": 252}, "nature": "Rash", "ability": "Torrent", "item": "Life Orb", "moves": ["Hydro Pump", "Ice Beam", "Air Slash", "Aqua Jet"]},
@@ -2418,7 +2418,7 @@ var SETDEX_XY = {
 		"LC Stealth Rock + Defog": {"level": 5, "evs": {"sd": 148, "df": 252, "hp": 92}, "nature": "Bold", "ability": "Torrent", "item": "Eviolite", "moves": ["Stealth Rock", "Defog", "Scald", "Ice Beam"]},
 	},
 	"Plusle": {
-		"PU 'Support'": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Plus", "item": "Focus Sash", "moves": ["Nasty Plot", "Baton Pass", "Thunderbolt", "Hidden Power Ice"]},
+		"PU 'Offensive'": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Plus", "item": "Life Orb", "moves": ["Substitute", "Nasty Plot", "Thunderbolt", "Hidden Power Ice"]},
 	},
 	"Politoed": {
 		"PU Tank": {"level": 100, "evs": {"df": 8, "hp": 248, "sa": 252}, "nature": "Modest", "ability": "Water Absorb", "item": "Leftovers", "moves": ["Scald", "Ice Beam", "Hidden Power Electric", "Encore"]},
@@ -2732,7 +2732,7 @@ var SETDEX_XY = {
 		"RU Choice Band": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sturdy", "item": "Choice Band", "moves": ["Close Combat", "Knock Off", "Poison Jab", "Zen Headbutt"]},
 	},
 	"Sawsbuck": {
-		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sap Sipper", "item": "Choice Scarf", "moves": ["Double-Edge", "Horn Leech", "Baton Pass", "Toxic"]},
+		"PU Choice Scarf": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sap Sipper", "item": "Choice Scarf", "moves": ["Double-Edge", "Horn Leech", "Jump Kick", "Toxic"]},
 		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sap Sipper", "item": "Life Orb", "moves": ["Swords Dance", "Horn Leech", "Double-Edge", "Jump Kick"]},
 		"NU Swords Dance Sweeper": {"level": 100, "evs": {"df": 4, "at": 252, "sp": 252}, "nature": "Jolly", "ability": "Sap Sipper", "item": "Life Orb", "moves": ["Swords Dance", "Horn Leech", "Double-Edge", "Jump Kick"]},
 	},
@@ -2849,7 +2849,7 @@ var SETDEX_XY = {
 		"Uber SubSeed": {"level": 100, "evs": {"hp": 44, "sp": 252, "sa": 212}, "nature": "Timid", "ability": "Serene Grace", "item": "Leftovers", "moves": ["Substitute", "Leech Seed", "Air Slash", "Seed Flare"]},
 	},
 	"Shedinja": {
-		"PU Offensive Pivot": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "ivs": {"sd": 0, "df": 0}, "nature": "Lonely", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Baton Pass", "Protect", "Shadow Sneak", "Will-O-Wisp"]},
+		"PU Swords Dance": {"level": 100, "evs": {"sd": 4, "at": 252, "sp": 252}, "ivs": {"sd": 0, "df": 0}, "nature": "Lonely", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Swords Dance", "X-Scissor", "Shadow Sneak", "Will-O-Wisp"]},
 		"NU Swords Dance": {"level": 100, "evs": {"at": 252, "sp": 252}, "ivs": {"sd": 0, "df": 0}, "nature": "Lonely", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Swords Dance", "Will-O-Wisp", "X-Scissor", "Shadow Sneak"]},
 		"UU Swords Dance / Pivot": {"level": 100, "evs": {"at": 252, "sp": 252}, "ivs": {"sd": 0, "df": 0}, "nature": "Lonely", "ability": "Wonder Guard", "item": "Focus Sash", "moves": ["Swords Dance", "X-Scissor", "Shadow Sneak", "Protect"]},
 	},
@@ -2905,7 +2905,7 @@ var SETDEX_XY = {
 	},
 	"Simisear": {
 		"PU Nasty Plot": {"level": 100, "evs": {"sd": 4, "sp": 252, "sa": 252}, "nature": "Timid", "ability": "Blaze", "item": "Life Orb", "moves": ["Nasty Plot", "Fire Blast", "Grass Knot", "Focus Blast"]},
-		"PU All-Out-Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Blaze", "item": "Life Orb", "moves": ["Fire Blast", "Grass Knot", "Low Kick", "Knock Off"]},
+		"PU All-Out-Attacker": {"level": 100, "evs": {"at": 4, "sp": 252, "sa": 252}, "nature": "Hasty", "ability": "Blaze", "item": "Life Orb", "moves": ["Fire Blast", "Grass Knot", "Focus Blast", "Knock Off"]},
 	},
 	"Skarmory": {
 		"OU Specially Defensive": {"level": 100, "evs": {"sd": 252, "df": 4, "hp": 252}, "nature": "Careful", "ability": "Sturdy", "item": "Leftovers", "moves": ["Iron Head", "Spikes", "Roost", "Whirlwind"]},
@@ -3535,7 +3535,7 @@ var SETDEX_XY = {
 	"Wobbuffet": {
 		"PU Bulky Death Fodder": {"level": 100, "evs": {"sd": 252, "df": 252, "hp": 4}, "nature": "Bold", "ability": "Telepathy", "item": "Leftovers", "moves": ["Encore", "Destiny Bond", "Counter", "Mirror Coat"]},
 		"Uber Utility Trapper": {"level": 100, "evs": {"sd": 252, "df": 176, "hp": 80}, "nature": "Calm", "ability": "Shadow Tag", "item": "Custap Berry", "moves": ["Encore", "Mirror Coat", "Counter", "Destiny Bond"]},
-		"Battle Spot Singles (>_<)7": {"level": 50, "evs": {"sd": 252, "df": 252, "sp": 4}, "nature": "Bold", "ability": "Shadow Tag", "item": "Sitrus Berry", "moves": ["Encore", "Counter", "Mirror Coat", "Destiny Bond"]},
+		"Battle Spot Singles \(>_<)7": {"level": 50, "evs": {"sd": 252, "df": 252, "sp": 4}, "nature": "Bold", "ability": "Shadow Tag", "item": "Sitrus Berry", "moves": ["Encore", "Counter", "Mirror Coat", "Destiny Bond"]},
 	},
 	"Woobat": {
 		"LC Baton Pass Recipient": {"level": 5, "evs": {"sd": 252, "df": 172, "hp": 76}, "nature": "Bold", "ability": "Unaware", "item": "Eviolite", "moves": ["Stored Power", "Calm Mind", "Roost", "Heat Wave"]},


### PR DESCRIPTION
Some CAP analyses are now on the main Smogon dex, so those CAPs now have their sets ripped and are mixed in with the rest of the Pokemon. The CAPs still at the bottom of the list don't have analyses yet and can still be manually updated.