### PR TITLE
Issue #254: Allow ability / item modifiers to affect moves used 2+ times

### DIFF
--- a/js/damage.js
+++ b/js/damage.js
@@ -745,7 +745,7 @@ function getDamageResult(attacker, defender, move, field) {
 		var usedWhiteHerb = false;
 		var dropCount = attacker.boosts[attackStat];
 		for (var times = 0; times < move.usedTimes; times++) {
-			var newAttack = getModifiedStat(attacker.rawStats[attackStat], dropCount);
+			var newAttack = getModifiedStat(attack, dropCount);
 			var damageMultiplier = 0;
 			damage = damage.map(function (affectedAmount) {
 				if (times) {


### PR DESCRIPTION
Simple fix for this issue: https://github.com/Zarel/honko-damagecalc/issues/254

Previously, on second hits and beyond, the calculator would apply the drop modifier to the base stats, which causes it to ignore items and abilities that are affecting the attack stat such as Choice Specs. Anything that was not included in the finalMod calculations was ignored.

I replaced the raw attack with the modified attack to fix this issue.