### PR TITLE
Fix forme selection for alternate forme sets

### DIFF
--- a/js/damage.js
+++ b/js/damage.js
@@ -80,11 +80,11 @@ function getDamageResult(attacker, defender, move, field) {
 	var defenderIgnoresAbility = ["Full Metal Body", "Prism Armor", "Shadow Shield"].indexOf(defAbility) !== -1;
 	var attackerIgnoresAbility = ["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) !== -1;
 	if (attackerIgnoresAbility && !defenderIgnoresAbility) {
-			defAbility = "";
-			description.attackerAbility = attacker.ability;
-		}
+		defAbility = "";
+		description.attackerAbility = attacker.ability;
+	}
 	if (["Light That Burns the Sky", "Menacing Moonraze Maelstrom", "Moongeist Beam", "Photon Geyser", "Searing Sunraze Smash", "Sunsteel Strike"].indexOf(move.name) !== -1) {
-			defAbility = "";
+		defAbility = "";
 	}
 
 	var isCritical = (move.isZ && move.isCrit) || ((move.isCrit && ["Battle Armor", "Shell Armor"].indexOf(defAbility) === -1 || attacker.ability === "Merciless" && defender.status.indexOf("Poisoned") !== -1) && move.usedTimes === 1);

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -395,8 +395,20 @@ $(".set-selector").change(function () {
 		}
 		var formeObj = $(this).siblings().find(".forme").parent();
 		itemObj.prop("disabled", false);
+		var baseForme;
+		if (pokemon.isAlternateForme) {
+			// try to find the base forme name by chopping off everything after the last dash
+			var baseFormeName = pokemonName.substring(0, pokemonName.lastIndexOf('-'));
+			// special case: -Mega-X and -Mega-Y
+			if (baseFormeName.substring(baseFormeName.lastIndexOf('-')) === '-Mega') {
+				baseFormeName = baseFormeName.substring(0, baseFormeName.lastIndexOf('-'));
+			}
+			baseForme = pokedex[baseFormeName];
+		}
 		if (pokemon.formes) {
 			showFormes(formeObj, setName, pokemonName, pokemon);
+		} else if (baseForme && baseForme.formes) {
+			showFormes(formeObj, setName, pokemonName, baseForme);
 		} else {
 			formeObj.hide();
 		}
@@ -422,7 +434,8 @@ function showFormes(formeObj, setName, pokemonName, pokemon) {
 	            (pokemonName === "Groudon" && set.item.indexOf("Red Orb") !== -1) ||
 	            (pokemonName === "Kyogre" && set.item.indexOf("Blue Orb") !== -1) ||
 	            (pokemonName === "Meloetta" && set.moves.indexOf("Relic Song") !== -1) ||
-	            (pokemonName === "Rayquaza" && set.moves.indexOf("Dragon Ascent") !== -1)) {
+				(pokemonName === "Rayquaza" && set.moves.indexOf("Dragon Ascent") !== -1) ||
+				(pokemonName === "Greninja-Ash" && set.ability === "Battle Bond")) {
 				defaultForme = 1;
 			} else if (set.item.indexOf('ite Y') !== -1) {
 				defaultForme = 2;
@@ -854,13 +867,13 @@ function getSetOptions(sets) {
 	return setOptions;
 }
 
-function getSelectOptions(arr, sort) {
+function getSelectOptions(arr, sort, defaultOption) {
 	if (sort) {
 		arr.sort();
 	}
 	var r = '';
 	for (var i = 0; i < arr.length; i++) {
-		r += '<option value="' + arr[i] + '">' + arr[i] + '</option>';
+		r += '<option value="' + arr[i] + '" ' + (defaultOption === i ? 'selected' : '') + '>' + arr[i] + '</option>';
 	}
 	return r;
 }


### PR DESCRIPTION
When the set had the base forme, it was possible to switch to the other formes with a dropdown.
This did not work for the non-base formes (e.g. megas) because these don't have the formes property. Maybe the should be made to inherit their base forme's data?
Anyway, I fixed this for now by chopping off the last part of the name behind the dash, which works for all formes I think.
`getSelectOptions` was being called with three arguments despite only having two, but I suppose it didn't get noticed because the forme selection was broken anyway.

Also fixed the indentation eslint errors.