### PR TITLE
Make Metronome item more accurate

### DIFF
--- a/honkalculate.template.html
+++ b/honkalculate.template.html
@@ -435,20 +435,21 @@
                             <option value="4">4 hits</option>
                             <option value="5">5 hits</option>
                         </select>
-							  <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
-							  <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
+                        <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
+                        <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                            <option value="0">Never</option>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
                     </div>
                     <div class="move2">
                         <select class="move-selector small-select"></select>
@@ -468,20 +469,21 @@
                             <option value="4">4 hits</option>
                             <option value="5">5 hits</option>
                         </select>
-							  <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
-							  <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
+                        <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
+                        <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                            <option value="0">Never</option>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
                     </div>
                     <div class="move3">
                         <select class="move-selector small-select"></select>
@@ -501,20 +503,21 @@
                             <option value="4">4 hits</option>
                             <option value="5">5 hits</option>
                         </select>
-							  <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
-							  <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
+                        <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
+                        <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                            <option value="0">Never</option>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
                     </div>
                     <div class="move4">
                         <select class="move-selector small-select"></select>
@@ -541,13 +544,14 @@
                     			<option value="4">4 times</option>
                     			<option value="5">5 times</option>
                 		  </select>
-							  <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
-                    			<option value="1">Once</option>
-                    			<option value="2">Twice</option>
-                    			<option value="3">3 times</option>
-                    			<option value="4">4 times</option>
-                    			<option value="5">5 times</option>
-                		  </select>
+                        <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                            <option value="0">Never</option>
+                            <option value="1">Once</option>
+                            <option value="2">Twice</option>
+                            <option value="3">3 times</option>
+                            <option value="4">4 times</option>
+                            <option value="5">5 times</option>
+                        </select>
                     </div>
                 </div>
             </div>

--- a/index.template.html
+++ b/index.template.html
@@ -493,7 +493,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -526,7 +527,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -559,7 +561,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -592,7 +595,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -1235,7 +1239,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -1268,7 +1273,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -1301,7 +1307,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>
@@ -1334,7 +1341,8 @@
                     <option value="4">4 times</option>
                     <option value="5">5 times</option>
                 </select>
-                <select class="metronome calc-trigger hide" title="How many times was this move used while holding Metronome?">
+                <select class="metronome calc-trigger hide" title="How many times was this move successfully and consecutively used while holding Metronome before this turn?">
+                    <option value="0">Never</option>
                     <option value="1">Once</option>
                     <option value="2">Twice</option>
                     <option value="3">3 times</option>

--- a/js/damage.js
+++ b/js/damage.js
@@ -725,6 +725,15 @@ function getDamageResult(attacker, defender, move, field) {
 		finalMods.push(0xC00);
 		description.defenderAbility = defender.ability;
 	}
+	if (attacker.hasItem("Metronome") && move.metronomeCount >= 1) {
+		var metronomeCount = Math.floor(move.metronomeCount);
+		if (metronomeCount <= 4) {
+			finalMods.push(0x1000 + metronomeCount * 0x333);
+		} else {
+			finalMods.push(0x2000);
+		}
+		description.attackerItem = attacker.item;
+	}
 	if (attacker.hasItem("Expert Belt") && typeEffectiveness > 1 && !move.isZ) {
 		finalMods.push(0x1333);
 		description.attackerItem = attacker.item;
@@ -795,21 +804,7 @@ function getDamageResult(attacker, defender, move, field) {
 			}
 		}
 	}
-	if (attacker.hasItem("Metronome") && move.metronomeCount > 1) {
-		var boostTurns;
-		if (move.dropsStats) {
-			boostTurns = move.usedTimes;
-		} else {
-			boostTurns = move.metronomeCount;
-		}
-		for (var metronome = 0; metronome < boostTurns; metronome++) {
-			var totalMetronomeBoost = 1 + metronome / 10;
-			damage = damage.map(function (damageRoll) {
-				return pokeRound(damageRoll * totalMetronomeBoost);
-			});
-		}
-		description.attackerItem = "Metronome";
-	}
+
 	description.attackBoost = attacker.boosts[attackStat];
 	return {"damage": damage, "description": buildDescription(description)};
 }

--- a/js/shared_controls.js
+++ b/js/shared_controls.js
@@ -307,7 +307,6 @@ $(".move-selector").change(function () {
 	moveGroupObj.children(".move-type").val(move.type);
 	moveGroupObj.children(".move-cat").val(move.category);
 	moveGroupObj.children(".move-crit").prop("checked", move.alwaysCrit === true);
-	moveGroupObj.children(".metronome").prop("disabled", !!move.dropsStats);
 	if (move.isMultiHit) {
 		moveGroupObj.children(".stat-drops").hide();
 		moveGroupObj.children(".move-hits").show();


### PR DESCRIPTION
This updates how the Metronome damage boost is applied according to this:
https://www.smogon.com/bw/articles/bw_complete_damage_formula

I removed the feature that attempts to calculate the damage over an estimate of turns as
1) it did not work correctly before
2) it is too complex too implement
3) I believe seeing the damage for a given turn is much more useful (you might be using the move on a different Pokémon after a few turns, stat boosts/drops may have happened inbetween turns, etc.)

I also made this independent of stat-dropping moves.