### PR TITLE
Add support for Shell Bell

### DIFF
--- a/calc/src/data/items.ts
+++ b/calc/src/data/items.ts
@@ -78,6 +78,7 @@ const ADV = GSC.concat([
   'Razz Berry',
   'Salac Berry',
   'Sea Incense',
+  'Shell Bell',
   'Silk Scarf',
   'Sitrus Berry',
   'Soul Dew',

--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -112,11 +112,11 @@ export function getRecovery(
 
   if (recovery[1] === 0) return { recovery, text };
 
-  recovery[0] = Math.min(recovery[0], attacker.maxHP());
-  recovery[1] = Math.min(recovery[1], attacker.maxHP());
-
   const minHealthRecovered = toDisplay(notation, recovery[0], attacker.maxHP());
   const maxHealthRecovered = toDisplay(notation, recovery[1], attacker.maxHP());
+
+  recovery[0] = Math.floor(recovery[0]);
+  recovery[1] = Math.floor(recovery[1]);
 
   text = `${minHealthRecovered} - ${maxHealthRecovered}${notation} recovered`;
   return { recovery, text };

--- a/calc/src/result.ts
+++ b/calc/src/result.ts
@@ -53,7 +53,7 @@ export class Result {
   }
 
   recovery(notation = '%') {
-    return getRecovery(this.attacker, this.defender, this.move, this.damage, notation);
+    return getRecovery(this.gen, this.attacker, this.defender, this.move, this.damage, notation);
   }
 
   recoil(notation = '%') {

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -192,8 +192,8 @@ describe('calc', () => {
         '224 Atk Choice Band Hoopa-Unbound Drain Punch vs. 0 HP / 0- Def Abomasnow: 398-470 (123.9 - 146.4%) -- guaranteed OHKO'
       );
       const recovery = result.recovery();
-      expect(recovery.recovery).toBeRange(199, 235);
-      expect(recovery.text).toBe('64.4 - 76% recovered');
+      expect(recovery.recovery).toBeRange(160, 160);
+      expect(recovery.text).toBe('51.9 - 51.9% recovered');
     });
 
     test('none', () => {


### PR DESCRIPTION
This mostly seems to work, but it causes the UI to deform in edge cases. Not sure about whether we care or whether there's a good solution:

<img width="533" alt="Screen Shot 2019-08-12 at 19 15 18" src="https://user-images.githubusercontent.com/117249/62884097-f736f080-bd35-11e9-8a95-89e87e19420e.png">

This also fixes recovery behavior to cap properly - recovery should be capped by the defender's HP stat (test values changed to reflect this).