### PR TITLE
Correct Gen 3 damage calculation

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -9,7 +9,7 @@ export interface MoveData {
   readonly type: Type;
   readonly category?: Category;
   readonly hasSecondaryEffect?: boolean;
-  readonly isSpread?: boolean;
+  readonly isSpread?: boolean | 'allAdjacent';
   readonly makesContact?: boolean;
   readonly hasRecoil?: Recoil;
   readonly alwaysCrit?: boolean;
@@ -166,13 +166,13 @@ const RBY: { [name: string]: MoveData } = {
     bp: 100,
     type: 'Ground',
     category: 'Physical',
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   Explosion: {
     bp: 170,
     type: 'Normal',
     category: 'Physical',
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   'Fire Blast': {
     bp: 120,
@@ -369,7 +369,7 @@ const RBY: { [name: string]: MoveData } = {
     bp: 130,
     type: 'Normal',
     category: 'Physical',
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   Sing: {
     bp: 0,
@@ -1488,7 +1488,7 @@ const DPP: { [name: string]: MoveData } = extend(true, {}, ADV, {
     type: 'Electric',
     category: 'Special',
     hasSecondaryEffect: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   Dive: { bp: 80 },
   'Double Hit': {
@@ -1673,7 +1673,7 @@ const DPP: { [name: string]: MoveData } = extend(true, {}, ADV, {
     type: 'Fire',
     category: 'Special',
     hasSecondaryEffect: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   'Leaf Blade': { bp: 90 },
   'Leaf Storm': {
@@ -1890,6 +1890,7 @@ const DPP: { [name: string]: MoveData } = extend(true, {}, ADV, {
     makesContact: true,
     hasPriority: true,
   },
+  Surf: { isSpread: 'allAdjacent' },
   Switcheroo: {
     bp: 0,
     type: 'Dark',
@@ -1998,7 +1999,7 @@ const BW: { [name: string]: MoveData } = extend(true, {}, DPP, {
     type: 'Ground',
     category: 'Physical',
     hasSecondaryEffect: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   'Bullet Seed': { bp: 25 },
   'Chip Away': {
@@ -2338,7 +2339,7 @@ const BW: { [name: string]: MoveData } = extend(true, {}, DPP, {
     type: 'Fire',
     category: 'Special',
     hasSecondaryEffect: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
     isBullet: true,
   },
   'Secret Sword': {
@@ -2366,7 +2367,7 @@ const BW: { [name: string]: MoveData } = extend(true, {}, DPP, {
     type: 'Poison',
     category: 'Special',
     hasSecondaryEffect: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   'Smack Down': {
     bp: 50,
@@ -2414,6 +2415,7 @@ const BW: { [name: string]: MoveData } = extend(true, {}, DPP, {
     bp: 70,
     type: 'Psychic',
     category: 'Special',
+    isSpread: 'allAdjacent',
   },
   Tackle: { bp: 50 },
   'Tail Slap': {
@@ -2497,7 +2499,7 @@ const XY: { [name: string]: MoveData } = extend(true, {}, BW, {
     type: 'Normal',
     category: 'Special',
     isSound: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   Chatter: { bp: 65 },
   Crabhammer: { bp: 100 },
@@ -2673,12 +2675,13 @@ const XY: { [name: string]: MoveData } = extend(true, {}, BW, {
     category: 'Special',
     givesHealth: true,
     percentHealed: 0.5,
+    isSpread: 'allAdjacent',
   },
   'Petal Blizzard': {
     bp: 90,
     type: 'Grass',
     category: 'Physical',
-    isSpread: true,
+    isSpread: 'allAdjacent',
   },
   'Phantom Force': {
     bp: 90,
@@ -2857,7 +2860,7 @@ const SM: { [name: string]: MoveData } = extend(true, {}, XY, {
     type: 'Dark',
     category: 'Physical',
     makesContact: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
     zp: 120,
   },
   'Bubble Beam': { zp: 120 },
@@ -3213,7 +3216,7 @@ const SM: { [name: string]: MoveData } = extend(true, {}, XY, {
     bp: 150,
     type: 'Fire',
     category: 'Special',
-    isSpread: true,
+    isSpread: 'allAdjacent',
     hasRecoil: true,
     zp: 200,
   },
@@ -3461,7 +3464,7 @@ const SM: { [name: string]: MoveData } = extend(true, {}, XY, {
     type: 'Water',
     category: 'Special',
     isSound: true,
-    isSpread: true,
+    isSpread: 'allAdjacent',
     zp: 175,
   },
   'Spectral Thief': {

--- a/calc/src/field.ts
+++ b/calc/src/field.ts
@@ -23,17 +23,17 @@ export class Field {
       weather?: Weather;
       terrain?: Terrain;
       isGravity?: boolean;
-      attackerSide: Partial<Side>;
-      defenderSide: Partial<Side>;
-    } = { attackerSide: {}, defenderSide: {} }
+      attackerSide?: Partial<Side>;
+      defenderSide?: Partial<Side>;
+    } = {}
   ) {
     this.gameType = field.gameType || 'Singles';
     this.terrain = field.terrain;
     this.weather = field.weather;
     this.isGravity = !!field.isGravity;
 
-    this.attackerSide = new Side(field.attackerSide);
-    this.defenderSide = new Side(field.defenderSide);
+    this.attackerSide = new Side(field.attackerSide || {});
+    this.defenderSide = new Side(field.defenderSide || {});
   }
 
   hasWeather(...weathers: Weather[]) {

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -249,7 +249,7 @@ export function calculateADV(attacker: Pokemon, defender: Pokemon, move: Move, f
     }
   }
 
-  if (field.gameType !== 'Singles' && move.isSpread) {
+  if (field.gameType !== 'Singles' && move.isSpread && move.isSpread !== 'allAdjacent') {
     baseDamage = Math.floor(baseDamage / 2);
   }
 

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -250,8 +250,7 @@ export function calculateADV(attacker: Pokemon, defender: Pokemon, move: Move, f
   }
 
   if (field.gameType !== 'Singles' && move.isSpread) {
-    // some sources say 3/4, some say 2/3, some say 1/2...using 3/4 for now since that's what DPP+ use
-    baseDamage = Math.floor((baseDamage * 3) / 4);
+    baseDamage = Math.floor(baseDamage / 2);
   }
 
   if (
@@ -274,7 +273,7 @@ export function calculateADV(attacker: Pokemon, defender: Pokemon, move: Move, f
     description.attackerAbility = 'Flash Fire';
   }
 
-  baseDamage = Math.max(1, baseDamage) + 2;
+  baseDamage = (move.category === 'Physical' ? Math.max(1, baseDamage) : baseDamage) + 2;
 
   if (isCritical) {
     baseDamage *= 2;

--- a/calc/src/move.ts
+++ b/calc/src/move.ts
@@ -20,7 +20,7 @@ export class Move {
   type: Type;
   category: Category;
   hasSecondaryEffect: boolean;
-  isSpread: boolean;
+  isSpread: boolean | 'allAdjacent';
   makesContact: boolean;
   hasRecoil?: Recoil;
   isCrit: boolean;
@@ -93,7 +93,7 @@ export class Move {
     this.type = data.type;
     this.category = data.category || 'Status';
     this.hasSecondaryEffect = !!data.hasSecondaryEffect;
-    this.isSpread = !!data.isSpread;
+    this.isSpread = data.isSpread === 'allAdjacent' ? data.isSpread : !!data.isSpread;
     this.makesContact = !!data.makesContact;
     this.hasRecoil = data.hasRecoil;
     this.isCrit = !!options.isCrit || !!data.alwaysCrit;

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -272,6 +272,36 @@ describe('calc', () => {
       );
     });
   });
+  describe('gen 3 spread', () => {
+    test('allAdjacent', () => {
+      const gengar = new Pokemon(3, 'Gengar', { nature: 'Mild', evs: { atk: 100 } });
+      const blissey = new Pokemon(3, 'Chansey', {
+        item: 'Leftovers',
+        nature: 'Bold',
+        evs: { hp: 252, def: 252 },
+      });
+      const field = new Field({ gameType: 'Doubles' });
+      const result = calculate(3, gengar, blissey, new Move(3, 'Explosion'), field);
+      expect(result.damage).toBeRange(578, 681);
+      expect(result.desc()).toBe(
+        '100 Atk Gengar Explosion vs. 252 HP / 252+ Def Chansey: 578-681 (82.1 - 96.7%) -- guaranteed 2HKO after Leftovers recovery'
+      );
+    });
+    test('allAdjacentFoes', () => {
+      const gengar = new Pokemon(3, 'Gengar', { nature: 'Modest', evs: { spa: 252 } });
+      const blissey = new Pokemon(3, 'Chansey', {
+        item: 'Leftovers',
+        nature: 'Bold',
+        evs: { hp: 252, def: 252 },
+      });
+      const field = new Field({ gameType: 'Doubles' });
+      const result = calculate(3, gengar, blissey, new Move(3, 'Blizzard'), field);
+      expect(result.damage).toBeRange(69, 82);
+      expect(result.desc()).toBe(
+        '252+ SpA Gengar Blizzard vs. 252 HP / 0 SpD Chansey: 69-82 (9.8 - 11.6%)'
+      );
+    });
+  });
   describe('water absorb', () => {
     test('gen 3', () => {
       const cacturne = new Pokemon(3, 'Cacturne', {


### PR DESCRIPTION
 - Doubles spread damage is 50%, not 75%
 - Only Physical attacks are guaranteed a minimum of 1 before the +2

Reference: https://web.archive.org/web/20170622160244/http://upcarchive.playker.info/0/upokecenter/content/pokemon-ruby-version-sapphire-version-and-emerald-version-timing-notes.html